### PR TITLE
Add example manifests

### DIFF
--- a/examples/book.yml
+++ b/examples/book.yml
@@ -5,16 +5,13 @@ vars:
 
 rules:
   - name: build
-    command: "pandoc {ins} -o {outs}"
+    command: "mkdir -p $(dirname {outs}) && pandoc {ins} -o {outs}"
     description: Compile document
 
 targets:
   - name: "{{ outdir }}/manuscript.pdf"
     rule: build
-    sources:
-      - chapters/intro.md
-      - chapters/body.md
-      - chapters/outro.md
+    sources: "{{ glob('chapters/*.md') }}"
 
 defaults:
   - "{{ outdir }}/manuscript.pdf"

--- a/examples/book.yml
+++ b/examples/book.yml
@@ -1,0 +1,20 @@
+netsuke_version: "1.0"
+
+vars:
+  outdir: build/book
+
+rules:
+  - name: build
+    command: "pandoc {ins} -o {outs}"
+    description: Compile document
+
+targets:
+  - name: "{{ outdir }}/manuscript.pdf"
+    rule: build
+    sources:
+      - chapters/intro.md
+      - chapters/body.md
+      - chapters/outro.md
+
+defaults:
+  - "{{ outdir }}/manuscript.pdf"

--- a/examples/c_app.yml
+++ b/examples/c_app.yml
@@ -3,29 +3,30 @@ netsuke_version: "1.0"
 vars:
   cc: gcc
   cflags: -Wall
+  objdir: build/obj
 
 rules:
   - name: compile
-    command: "{{ cc }} {{ cflags }} -c {ins} -o {outs}"
+    command: "mkdir -p $(dirname {outs}) && {{ cc }} {{ cflags }} -c {ins} -o {outs}"
     description: Compile C source
   - name: link
-    command: "{{ cc }} {ins} -o {outs}"
+    command: "{{ cc }} {{ cflags }} {ins} -o {outs}"
     description: Link objects
 
 # Target list generated from source files
 
-targets:
-{% for src in glob('src/*.c') %}
-  - name: "{{ src | replace('.c', '.o') }}"
+targets: |
+  {% for src in glob('src/*.c') %}
+  - name: "{{ objdir }}/{{ src | basename | replace('.c', '.o') }}"
     rule: compile
     sources: "{{ src }}"
-{% endfor %}
+  {% endfor %}
   - name: app
     rule: link
     sources:
-{% for src in glob('src/*.c') %}
-      - "{{ src | replace('.c', '.o') }}"
-{% endfor %}
+  {% for src in glob('src/*.c') %}
+      - "{{ objdir }}/{{ src | basename | replace('.c', '.o') }}"
+  {% endfor %}
 
 defaults:
   - app

--- a/examples/c_app.yml
+++ b/examples/c_app.yml
@@ -1,0 +1,31 @@
+netsuke_version: "1.0"
+
+vars:
+  cc: gcc
+  cflags: -Wall
+
+rules:
+  - name: compile
+    command: "{{ cc }} {{ cflags }} -c {ins} -o {outs}"
+    description: Compile C source
+  - name: link
+    command: "{{ cc }} {ins} -o {outs}"
+    description: Link objects
+
+# Target list generated from source files
+
+targets:
+{% for src in glob('src/*.c') %}
+  - name: "{{ src | replace('.c', '.o') }}"
+    rule: compile
+    sources: "{{ src }}"
+{% endfor %}
+  - name: app
+    rule: link
+    sources:
+{% for src in glob('src/*.c') %}
+      - "{{ src | replace('.c', '.o') }}"
+{% endfor %}
+
+defaults:
+  - app

--- a/examples/photo_album.yml
+++ b/examples/photo_album.yml
@@ -2,15 +2,15 @@ netsuke_version: "1.0"
 
 vars:
   style: "{{ env('DT_STYLE') | default('natural') }}"
-  outdir: build/jpg
+  outdir: "build/jpg/{{ style }}"
 
 rules:
   - name: develop
-    command: "darktable-cli {ins} {outs} --style {{ style }}"
+    command: "mkdir -p $(dirname {outs}) && darktable-cli {ins} {outs} --style {{ style }}"
     description: Develop RAW image
 
   - name: thumb
-    command: "convert {ins} -resize 200x200 {outs}"
+    command: "mkdir -p $(dirname {outs}) && convert {ins} -resize 200x200^ -gravity center -extent 200x200 {outs}"
     description: Create thumbnail
 
 targets:

--- a/examples/photo_album.yml
+++ b/examples/photo_album.yml
@@ -1,0 +1,29 @@
+netsuke_version: "1.0"
+
+vars:
+  style: "{{ env('DT_STYLE') | default('natural') }}"
+  outdir: build/jpg
+
+rules:
+  - name: develop
+    command: "darktable-cli {ins} {outs} --style {{ style }}"
+    description: Develop RAW image
+
+  - name: thumb
+    command: "convert {ins} -resize 200x200 {outs}"
+    description: Create thumbnail
+
+targets:
+{% for raw in glob('photos/*.nef') %}
+  - name: "{{ outdir }}/{{ raw | basename | replace('.nef', '.jpg') }}"
+    rule: develop
+    sources: "{{ raw }}"
+  - name: "{{ outdir }}/thumbs/{{ raw | basename | replace('.nef', '.jpg') }}"
+    rule: thumb
+    sources: "{{ outdir }}/{{ raw | basename | replace('.nef', '.jpg') }}"
+{% endfor %}
+
+defaults:
+{% for raw in glob('photos/*.nef') %}
+  - "{{ outdir }}/thumbs/{{ raw | basename | replace('.nef', '.jpg') }}"
+{% endfor %}

--- a/examples/python_package.yml
+++ b/examples/python_package.yml
@@ -1,0 +1,25 @@
+netsuke_version: "1.0"
+
+vars:
+  python: python3
+
+rules:
+  - name: install
+    command: "{{ python }} -m pip install -e ."
+    description: Install package
+  - name: test
+    command: "{{ python }} -m pytest {ins}"
+    description: Run tests
+
+targets:
+  - name: venv
+    rule: install
+    sources: requirements.txt
+  - name: test-results
+    rule: test
+    sources: tests
+    deps:
+      - venv
+
+defaults:
+  - test-results

--- a/examples/python_package.yml
+++ b/examples/python_package.yml
@@ -2,24 +2,32 @@ netsuke_version: "1.0"
 
 vars:
   python: python3
+  venv: .venv
 
 rules:
+  - name: setup
+    command: "{{ python }} -m venv {{ venv }}"
+    description: Create virtual environment
   - name: install
-    command: "{{ python }} -m pip install -e ."
+    command: "{{ venv }}/bin/pip install -e . -r requirements.txt"
     description: Install package
   - name: test
-    command: "{{ python }} -m pytest {ins}"
+    command: "{{ venv }}/bin/python -m pytest {{ ins | join(' ') }}"
     description: Run tests
 
 targets:
   - name: venv
+    rule: setup
+  - name: deps
     rule: install
     sources: requirements.txt
+    deps:
+      - venv
   - name: test-results
     rule: test
     sources: tests
     deps:
-      - venv
+      - deps
 
 defaults:
   - test-results

--- a/examples/svg_to_png.yml
+++ b/examples/svg_to_png.yml
@@ -1,0 +1,21 @@
+netsuke_version: "1.0"
+
+vars:
+  outdir: build/png
+
+rules:
+  - name: rasterise
+    command: "inkscape {ins} --export-type=png --export-filename={outs}"
+    description: Convert SVG to PNG
+
+targets:
+{% for svg in glob('assets/svg/*.svg') %}
+  - name: "{{ outdir }}/{{ svg | replace('.svg', '.png') }}"
+    rule: rasterise
+    sources: "{{ svg }}"
+{% endfor %}
+
+defaults:
+{% for svg in glob('assets/svg/*.svg') %}
+  - "{{ outdir }}/{{ svg | replace('.svg', '.png') }}"
+{% endfor %}

--- a/examples/svg_to_png.yml
+++ b/examples/svg_to_png.yml
@@ -5,17 +5,17 @@ vars:
 
 rules:
   - name: rasterise
-    command: "inkscape {ins} --export-type=png --export-filename={outs}"
+    command: "mkdir -p $(dirname {outs}) && inkscape {ins} --export-type=png --export-filename={outs}"
     description: Convert SVG to PNG
 
 targets:
 {% for svg in glob('assets/svg/*.svg') %}
-  - name: "{{ outdir }}/{{ svg | replace('.svg', '.png') }}"
+  - name: "{{ outdir }}/{{ svg | basename | replace('.svg', '.png') }}"
     rule: rasterise
     sources: "{{ svg }}"
 {% endfor %}
 
 defaults:
 {% for svg in glob('assets/svg/*.svg') %}
-  - "{{ outdir }}/{{ svg | replace('.svg', '.png') }}"
+  - "{{ outdir }}/{{ svg | basename | replace('.svg', '.png') }}"
 {% endfor %}


### PR DESCRIPTION
## Summary
- provide five example Netsukefile templates
  - C compilation
  - SVG rasterising
  - photo workflow
  - book building
  - Python package

## Testing
- `cargo fmt --all`
- `mdformat-all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: lint_groups_priority, print-stdout)*
- `cargo test --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_687239b30c848322b1d0cb24c9549f52

## Summary by Sourcery

New Features:
- Provide example Netsukefile templates for C compilation, SVG rasterising, photo workflow, book building, and Python packaging