### PR TITLE
Document phony and always targets

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,9 @@ compilation pipeline from parsing to execution.
   - [ ] Annotate the AST structs with `#[derive(Deserialize)]` and
     `#[serde(deny_unknown_fields)]` to enable parsing.
 
+  - [ ] Support `phony` and `always` boolean flags on targets and parse an
+    optional `actions` list that treats each entry as a `phony` target.
+
   - [ ] Implement the YAML parsing logic using `serde_yaml` to deserialize a
     static `Netsuke.yml` file into the `NetsukeManifest` AST.
 


### PR DESCRIPTION
## Summary
- describe optional `actions` block
- document `phony` and `always` flags in manifests
- reflect new behaviour in IR generation and Ninja synthesis
- update roadmap with a task for these flags

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_687296d1a28483229250d4c38fd7db10