### PR TITLE
Add example manifests

### DIFF
--- a/examples/basic_c.yml
+++ b/examples/basic_c.yml
@@ -1,0 +1,35 @@
+netsuke_version: "1.0"
+
+vars:
+  cc: "{{ env('CC') | default('gcc') }}"
+  cflags: "-Wall -O2"
+
+rules:
+  - name: compile
+    command: "{{ cc }} {{ cflags }} -c {ins} -o {outs}"
+    description: "Compiling {outs}"
+
+  - name: link
+    command: "{{ cc }} {ins} -o {outs}"
+
+targets:
+  - name: main.o
+    rule: compile
+    sources: src/main.c
+
+  - name: utils.o
+    rule: compile
+    sources: src/utils.c
+
+  - name: app
+    rule: link
+    sources:
+      - main.o
+      - utils.o
+
+actions:
+  - name: run
+    command: "./app"
+
+defaults:
+  - app

--- a/examples/photo_edit.yml
+++ b/examples/photo_edit.yml
@@ -1,0 +1,37 @@
+netsuke_version: "1.0"
+
+vars:
+  raw_dir: raw_photos
+  out_dir: processed
+
+macros:
+  - signature: "photo(path)"
+    body: |
+      - name: "{{ out_dir }}/{{ path | basename | replace('.CR2', '.jpg') }}"
+        rule: convert_raw
+        sources: "{{ path }}"
+
+rules:
+  - name: convert_raw
+    command: "darktable-cli {ins} {outs}"
+    description: "Converting RAW photo"
+
+  - name: make_gallery
+    command: "make-gallery {{ out_dir }} > {outs}"
+
+targets:
+  - foreach: "{{ glob(raw_dir ~ '/*.CR2') }}"
+    {{ photo(item) }}
+
+  - name: "{{ out_dir }}/gallery.html"
+    rule: make_gallery
+    sources: "{{ glob(out_dir ~ '/*.jpg') }}"
+    always: true
+
+actions:
+  - name: preview
+    script: |
+      feh {{ out_dir }} &
+
+defaults:
+  - "{{ out_dir }}/gallery.html"

--- a/examples/visual_design.yml
+++ b/examples/visual_design.yml
@@ -1,0 +1,27 @@
+netsuke_version: "1.0"
+
+vars:
+  src_dir: design/svg
+  out_dir: build/raster
+  inkscape: "{{ env('INKSCAPE_BIN') | default('inkscape') }}"
+
+rules:
+  - name: rasterise
+    command: "{{ inkscape }} {ins} --export-filename={outs}"
+    description: "Rasterising {ins}"
+
+  - name: clean
+    command: "rm -rf {{ out_dir }}"
+
+targets:
+  - foreach: "{{ glob(src_dir ~ '/*.svg') }}"
+    name: "{{ out_dir }}/{{ item | basename | replace('.svg', '.png') }}"
+    rule: rasterise
+    sources: "{{ item }}"
+
+actions:
+  - name: clean
+    rule: clean
+
+defaults:
+  - "{{ out_dir }}/hero.png"

--- a/examples/website.yml
+++ b/examples/website.yml
@@ -1,0 +1,32 @@
+netsuke_version: "1.0"
+
+vars:
+  pages_dir: pages
+  site_dir: site
+
+macros:
+  - signature: "page(path)"
+    body: |
+      - name: "{{ site_dir }}/{{ path | basename | replace('.md', '.html') }}"
+        rule: page
+        sources: "{{ path }}"
+
+rules:
+  - name: page
+    command: "pandoc {ins} -o {outs}"
+
+  - name: index
+    script: |
+      cat {{ site_dir }}/*.html > {{ site_dir }}/index.html
+
+targets:
+  - foreach: "{{ glob(pages_dir ~ '/*.md') }}"
+    {{ page(item) }}
+
+  - name: "{{ site_dir }}/index.html"
+    rule: index
+    deps: "{{ glob(site_dir ~ '/*.html') }}"
+    always: true
+
+defaults:
+  - "{{ site_dir }}/index.html"

--- a/examples/writing.yml
+++ b/examples/writing.yml
@@ -1,0 +1,31 @@
+netsuke_version: "1.0"
+
+vars:
+  chapters_dir: chapters
+  build_dir: build
+  pandoc_flags: "-N --pdf-engine=xelatex"
+
+rules:
+  - name: tex
+    command: "pandoc {{ pandoc_flags }} {ins} -o {outs}"
+
+  - name: combine
+    command: "latexmk -pdf -outdir={{ build_dir }} {ins}"
+
+macros:
+  - signature: "chapter(path)"
+    body: |
+      - name: "{{ build_dir }}/{{ path | basename | replace('.md', '.tex') }}"
+        rule: tex
+        sources: "{{ path }}"
+
+targets:
+  - foreach: "{{ glob(chapters_dir ~ '/*.md') }}"
+    {{ chapter(item) }}
+
+  - name: "{{ build_dir }}/book.pdf"
+    rule: combine
+    sources: "{{ glob(build_dir ~ '/*.tex') }}"
+
+defaults:
+  - "{{ build_dir }}/book.pdf"


### PR DESCRIPTION
## Summary
- create an `examples` directory containing sample Netsuke manifests
  - basic C project
  - photo editing workflow
  - SVG to PNG rasterisation
  - simple website build
  - book compilation pipeline

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68737b7fd48483228fc802558b970a30