### PR TITLE
Update command escaping docs

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -115,6 +115,8 @@ CLI ergonomics.
   - [ ] **Mandate** its use for all variable substitutions within the `command`
     strings during Ninja file synthesis to prevent command injection
     vulnerabilities. This is a critical security feature.
+  - [ ] Ensure the interpolated `command` value parses successfully with
+    `shlex`.
 
   - [ ] Implement custom Jinja filters for shell safety and path manipulation,
     such as `| shell_escape`, `| to_path`, and `| parent`.


### PR DESCRIPTION
## Summary
- document that `command` values must be `shlex` parsable
- clarify auto escaping in shell scripts
- describe `shell_escape` behaviour for lists and scalars
- mention future script language support
- update roadmap for `shlex` parsing

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6873ac416c248322bb3cd2d8832b65f1