### PR TITLE
Add examples section

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -262,11 +262,11 @@ Each entry in the `rules` list is a mapping that defines a reusable action.
   field (defaulting to `/bin/sh -e`). For `/bin/sh` scripts, each interpolation
   is automatically passed through the `shell_escape` filter unless a `| raw`
   filter is applied. Future versions will allow configurable script languages
-  with their own escaping rules.  
+  with their own escaping rules.
   On Windows, scripts default to `powershell -Command` unless the manifest's
-  `interpreter` field overrides the setting.
-  Exactly one of `command` or `script` must be provided. The manifest parser
-  enforces this rule to prevent invalid states.
+  `interpreter` field overrides the setting. Exactly one of `command` or
+  `script` must be provided. The manifest parser enforces this rule to prevent
+  invalid states.
 
   Internally, these options deserialize into a shared `Recipe` enum tagged with
   a `kind` field. Serde aliases ensure manifests that omit the tag continue to
@@ -1385,6 +1385,23 @@ possibilities for future enhancements beyond the initial scope.
   Netsuke could include an alternative generator that targets a distributed
   build system, allowing for massively parallel builds across a cluster of
   machines. The user's `Netsukefile` manifest would remain unchanged.
+
+## Section 10: Example Manifests
+
+The repository includes several complete Netsuke manifests in the `examples/
+` directory. They demonstrate how the YAML schema can be applied to real-world
+projects.
+
+- [`basic_c.yml`](../examples/basic_c.yml): a minimal C project compiling two
+  object files and linking them into a small application.
+- [`photo_edit.yml`](../examples/photo_edit.yml): converts RAW photographs and
+  generates a simple HTML gallery for previewing the results.
+- [`visual_design.yml`](../examples/visual_design.yml): rasterises a set of SVG
+  design assets into PNG images using Inkscape.
+- [`website.yml`](../examples/website.yml): builds a static web site from
+  Markdown pages with Pandoc and assembles an index page.
+- [`writing.yml`](../examples/writing.yml): produces a multi-chapter PDF book
+  by combining chapters rendered from Markdown via LaTeX.
 
 ### **Works cited**
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1388,9 +1388,9 @@ possibilities for future enhancements beyond the initial scope.
 
 ## Section 10: Example Manifests
 
-The repository includes several complete Netsuke manifests in the `examples/
-` directory. They demonstrate how the YAML schema can be applied to real-world
-projects.
+The repository includes several complete Netsuke manifests in the
+`examples/` directory. They demonstrate how the YAML schema can be applied
+to real-world projects.
 
 - [`basic_c.yml`](../examples/basic_c.yml): a minimal C project compiling two
   object files and linking them into a small application.


### PR DESCRIPTION
## Summary
- document example Netsuke manifests in the design doc

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_68744266c8e48322913a79e49aa54019

## Summary by Sourcery

Add an “Example Manifests” section to the Netsuke design doc showcasing sample YAML manifests and refine the formatting of the command/script requirement description

Enhancements:
- Merge the interpreter, command, and script requirement lines into a single succinct paragraph

Documentation:
- Introduce Section 10 “Example Manifests” in netsuke-design.md with descriptions of sample YAML manifests in the examples directory