### PR TITLE
Fix MockRepository example in docs

### DIFF
--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -265,6 +265,14 @@ struct MockRepository {
     data: HashMap<String, String>,
 }
 
+impl Default for MockRepository {
+    fn default() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+}
+
 impl Repository for MockRepository {
     fn add_item(&mut self, id: &str, name: &str) {
         self.data.insert(id.to_string(), name.to_string());

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -261,16 +261,9 @@ trait Repository {
     fn get_item_name(&self, id: &str) -> Option<String>;
 }
 
+#[derive(Default)]
 struct MockRepository {
     data: HashMap<String, String>,
-}
-
-impl Default for MockRepository {
-    fn default() -> Self {
-        Self {
-            data: HashMap::new(),
-        }
-    }
 }
 
 impl Repository for MockRepository {


### PR DESCRIPTION
## Summary
- implement `Default` for `MockRepository` in fixture example

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6876a6d095b48322923e3b3b55801602

## Summary by Sourcery

Documentation:
- Add Default implementation for MockRepository in the docs example to allow using `MockRepository::default()` in tests