### PR TITLE
Implement phony/always flags

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -591,6 +591,9 @@ The manifest version is parsed using the `semver` crate to validate that it
 follows semantic versioning rules. Global and target variable maps now share
 the `HashMap<String, String>` type for consistency. This keeps YAML manifests
 concise while ensuring forward compatibility.
+Targets also accept optional `phony` and `always` booleans. They default to
+`false`, making it explicit when a step should run regardless of file
+timestamps.
 
 ### 3.5 Testing
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@ compilation pipeline from parsing to execution.
   - [ ] Implement parsing for the netsuke_version field and validate it using
     the semver crate.
 
-  - [ ] Support `phony` and `always` boolean flags on targets.
+  - [x] Support `phony` and `always` boolean flags on targets. *(done)*
 
   - [ ] Parse the optional steps list, treating each entry as a target with
     phony: true by default.

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -213,3 +213,34 @@ fn invalid_enum_variants() {
     "#;
     assert!(serde_yml::from_str::<NetsukeManifest>(yaml).is_err());
 }
+
+#[test]
+fn phony_and_always_flags() {
+    let yaml = r#"
+        netsuke_version: "1.0.0"
+        targets:
+          - name: clean
+            recipe:
+              kind: command
+              command: rm -rf build
+            phony: true
+            always: true
+    "#;
+    let manifest = serde_yml::from_str::<NetsukeManifest>(yaml).expect("parse");
+    let target = manifest.targets.first().expect("target");
+    assert!(target.phony);
+    assert!(target.always);
+
+    let yaml = r#"
+        netsuke_version: "1.0.0"
+        targets:
+          - name: clean
+            recipe:
+              kind: command
+              command: rm -rf build
+    "#;
+    let manifest = serde_yml::from_str::<NetsukeManifest>(yaml).expect("parse");
+    let target = manifest.targets.first().expect("target");
+    assert!(!target.phony);
+    assert!(!target.always);
+}

--- a/tests/data/phony.yml
+++ b/tests/data/phony.yml
@@ -1,0 +1,8 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: clean
+    recipe:
+      kind: command
+      command: "rm -rf build"
+    phony: true
+    always: true

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -4,3 +4,8 @@ Feature: Manifest parsing
     When the manifest file "tests/data/minimal.yml" is parsed
     Then the manifest version is "1.0.0"
     And the first target name is "hello"
+
+  Scenario: Parse phony and always flags
+    When the manifest file "tests/data/phony.yml" is parsed
+    Then the first target is phony
+    And the first target is always rebuilt

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -54,3 +54,17 @@ fn first_target_name(world: &mut CliWorld, name: String) {
         other => panic!("Expected StringOrList::String, got: {other:?}"),
     }
 }
+
+#[then("the first target is phony")]
+fn first_target_phony(world: &mut CliWorld) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    let first = manifest.targets.first().expect("targets");
+    assert!(first.phony);
+}
+
+#[then("the first target is always rebuilt")]
+fn first_target_always(world: &mut CliWorld) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    let first = manifest.targets.first().expect("targets");
+    assert!(first.always);
+}


### PR DESCRIPTION
## Summary
- parse phony and always flags on targets
- document behaviour in the design doc
- mark roadmap item as done
- test phony and always parsing via unit and cucumber tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_6880cd8c0e4c8322b10f0b698345b930

## Summary by Sourcery

Enable `phony` and `always` flags on manifest targets, update documentation, and add corresponding tests

New Features:
- Support `phony` and `always` boolean flags on targets that default to false

Documentation:
- Document `phony` and `always` flags in the design doc and mark the roadmap item as done

Tests:
- Add unit tests, Cucumber steps, and feature scenario for parsing `phony` and `always` flags