### PR TITLE
Implement steps parsing with phony default

### DIFF
--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -1166,7 +1166,7 @@ aligned with what is needed.
 
 [^31]: Cucumber in cucumber – Rust – [Docs.rs](http://Docs.rs) — accessed on 14
        July 2025 —
-    <https://docs.rs/cucumber/latest/cucumber/struct.Cucumber.html>
+       <https://docs.rs/cucumber/latest/cucumber/struct.Cucumber.html>
 
 [^32]: CLI (command-line interface) - Cucumber Rust Book, accessed on
     14 July 2025, <https://cucumber-rs.github.io/cucumber/main/cli.html>

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -403,7 +403,7 @@ deserialization and easy debugging.
 
 Rust
 
-````rust
+```rust
 // In src/ast.rs
 
 use serde::Deserialize;
@@ -551,7 +551,7 @@ targets:
   - name: my_app
     sources: "{{ glob('src/*.c') }}"
     rule: compile
-````
+```
 
 The value of `sources`, `{{ glob('src/*.c') }}`, is not a valid YAML string
 from the perspective of a strict parser. Attempting to deserialize this
@@ -590,10 +590,11 @@ provides a default `Empty` variant, so optional lists are trivial to represent.
 The manifest version is parsed using the `semver` crate to validate that it
 follows semantic versioning rules. Global and target variable maps now share
 the `HashMap<String, String>` type for consistency. This keeps YAML manifests
-concise while ensuring forward compatibility.
-Targets also accept optional `phony` and `always` booleans. They default to
-`false`, making it explicit when a step should run regardless of file
-timestamps.
+concise while ensuring forward compatibility. Targets also accept optional
+`phony` and `always` booleans. They default to `false`, making it explicit when
+a step should run regardless of file timestamps. Targets listed in the `steps`
+section are deserialised using a custom helper so they are always treated as
+`phony` tasks. This ensures preparation actions never generate build artefacts.
 
 ### 3.5 Testing
 
@@ -1003,14 +1004,14 @@ structures to the Ninja file syntax.
 
    Code snippet
 
-   ````ninja
+   ```ninja
    # Generated from an ir::Action
    rule cc command = gcc -c -o $out $in description = CC $out depfile = $out.d
    deps = gcc
 
    ```ninja
 
-   ````
+   ```
 
 3. **Write Build Edges:** Iterate through the `graph.targets` map. For each
    `ir::BuildEdge`, write a corresponding Ninja `build` statement. This

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,8 +29,8 @@ compilation pipeline from parsing to execution.
 
   - [x] Support `phony` and `always` boolean flags on targets. *(done)*
 
-  - [ ] Parse the actions steps list, treating each entry as a target with
-    phony: true.
+  - [x] Parse the actions steps list, treating each entry as a target with
+    phony: true. *(done)*
 
   - [ ] Implement the YAML parsing logic to deserialize a static Netsukefile
     into the NetsukeManifest AST.

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -244,3 +244,60 @@ fn phony_and_always_flags() {
     assert!(!target.phony);
     assert!(!target.always);
 }
+
+#[test]
+fn steps_are_marked_phony() {
+    let yaml = r#"
+        netsuke_version: "1.0.0"
+        steps:
+          - name: setup
+            recipe:
+              kind: command
+              command: "echo hi"
+        targets:
+          - name: done
+            recipe:
+              kind: command
+              command: "true"
+    "#;
+    let manifest = serde_yml::from_str::<NetsukeManifest>(yaml).expect("parse");
+    let step = manifest.steps.first().expect("step");
+    assert!(step.phony);
+    assert!(!step.always);
+}
+
+#[test]
+fn steps_override_phony_false() {
+    let yaml = r#"
+        netsuke_version: "1.0.0"
+        steps:
+          - name: setup
+            recipe:
+              kind: command
+              command: "echo hi"
+            phony: false
+        targets:
+          - name: done
+            recipe:
+              kind: command
+              command: "true"
+    "#;
+    let manifest = serde_yml::from_str::<NetsukeManifest>(yaml).expect("parse");
+    let step = manifest.steps.first().expect("step");
+    assert!(step.phony, "steps must be treated as phony");
+}
+
+#[test]
+fn steps_missing_fields_fail() {
+    let yaml = r#"
+        netsuke_version: "1.0.0"
+        steps:
+          - name: setup
+        targets:
+          - name: done
+            recipe:
+              kind: command
+              command: "true"
+    "#;
+    assert!(serde_yml::from_str::<NetsukeManifest>(yaml).is_err());
+}

--- a/tests/data/step_invalid.yml
+++ b/tests/data/step_invalid.yml
@@ -1,0 +1,10 @@
+netsuke_version: "1.0.0"
+steps:
+  - name: setup
+    phony: false
+targets:
+  - name: done
+    recipe:
+      kind: command
+      command: "true"
+

--- a/tests/data/steps.yml
+++ b/tests/data/steps.yml
@@ -1,0 +1,13 @@
+netsuke_version: "1.0.0"
+steps:
+  - name: setup
+    recipe:
+      kind: command
+      command: "echo hi"
+    phony: false
+targets:
+  - name: done
+    recipe:
+      kind: command
+      command: "true"
+

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -9,3 +9,11 @@ Feature: Manifest parsing
     When the manifest file "tests/data/phony.yml" is parsed
     Then the first target is phony
     And the first target is always rebuilt
+
+  Scenario: Steps are always treated as phony
+    When the manifest file "tests/data/steps.yml" is parsed
+    Then the first step is phony
+
+  Scenario: Invalid step fails to parse
+    When the manifest file "tests/data/step_invalid.yml" is parsed
+    Then parsing the manifest fails

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -68,3 +68,15 @@ fn first_target_always(world: &mut CliWorld) {
     let first = manifest.targets.first().expect("targets");
     assert!(first.always);
 }
+
+#[then("the first step is phony")]
+fn first_step_phony(world: &mut CliWorld) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    let first = manifest.steps.first().expect("steps");
+    assert!(first.phony);
+}
+
+#[then("parsing the manifest fails")]
+fn manifest_parse_error(world: &mut CliWorld) {
+    assert!(world.manifest_error.is_some(), "expected parse error");
+}


### PR DESCRIPTION
## Summary
- ensure steps list entries are marked phony on load
- update design notes about step deserialisation
- mark roadmap item for steps parsing as done
- cover steps parsing with unit and behavioural tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6881498e6da08322a1cf81533393c641