### PR TITLE
Implement Netsukefile YAML parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
 name = "netsuke"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "cucumber",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ clap = { version = "4.5.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
 semver = { version = "1", features = ["serde"] }
+anyhow = "1"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -595,15 +595,19 @@ concise while ensuring forward compatibility. Targets also accept optional
 an action should run regardless of file timestamps. Targets listed in the
 `actions` section are deserialised using a custom helper so they are always
 treated as `phony` tasks. This ensures preparation actions never generate build
-artefacts.
+artefacts. Convenience functions in `src/manifest.rs` load a manifest from a
+string or a file path, returning `anyhow::Result` for straightforward error
+handling.
 
 ### 3.5 Testing
 
 Unit tests in `tests/ast_tests.rs` and behavioural scenarios in
 `tests/features/manifest.feature` exercise the deserialization logic. They
 assert that manifests fail to parse when unknown fields are present, and that a
-minimal manifest round-trips correctly. This suite guards against regressions
-as the schema evolves.
+minimal manifest round-trips correctly. A collection of sample manifests under
+`tests/data` cover both valid and invalid permutations of the schema. These
+fixtures are loaded by the tests to ensure real-world YAML files behave as
+expected. This suite guards against regressions as the schema evolves.
 
 ## Section 4: Dynamic Builds with the Jinja Templating Engine
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,16 +24,16 @@ compilation pipeline from parsing to execution.
     #[serde(deny_unknown_fields)]
     to enable serde_yml parsing. *(done)*
 
-  - [ ] Implement parsing for the netsuke_version field and validate it using
-    the semver crate.
+  - [x] Implement parsing for the netsuke_version field and validate it using
+    the semver crate. *(done)*
 
   - [x] Support `phony` and `always` boolean flags on targets. *(done)*
 
   - [x] Parse the actions list, treating each entry as a target with
     phony: true. *(done)*
 
-  - [ ] Implement the YAML parsing logic to deserialize a static Netsukefile
-    into the NetsukeManifest AST.
+  - [x] Implement the YAML parsing logic to deserialize a static Netsukefile
+    into the NetsukeManifest AST. *(done)*
 
 - [ ] **Intermediate Representation (IR) and Validation:**
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -645,7 +645,7 @@ mastering doctests:
 [^11]: Compile_fail doc test ignored in cfg(test) - help - The Rust Programming
    Language Forum, accessed on July 15, 2025,
    <https://users.rust-lang.org/t/compile-fail-doc-test-ignored-in-cfg-test/124927>
-    accessed on July 15, 2025,
+    accessed on July 15, 2025
    <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
    2025, <https://docs.rs/quote-doctest>
@@ -654,7 +654,7 @@ mastering doctests:
 [^14]: rust - How can I conditionally execute a module-level doctest based …,
    accessed on July 15, 2025,
    <https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>
-    Why have doctests?, accessed on July 15, 2025,
+    Why have doctests?, accessed on July 15, 2025
    <https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-docte>
 [^15]: How do you write your doc tests? : r/rust - Reddit, accessed on July 15,
    2025,

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -645,7 +645,7 @@ mastering doctests:
 [^11]: Compile_fail doc test ignored in cfg(test) - help - The Rust Programming
    Language Forum, accessed on July 15, 2025,
    <https://users.rust-lang.org/t/compile-fail-doc-test-ignored-in-cfg-test/124927>
-   accessed on July 15, 2025,
+    accessed on July 15, 2025,
    <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
    2025, <https://docs.rs/quote-doctest>
@@ -654,7 +654,7 @@ mastering doctests:
 [^14]: rust - How can I conditionally execute a module-level doctest based …,
    accessed on July 15, 2025,
    <https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>
-   Why have doctests?, accessed on July 15, 2025,
+    Why have doctests?, accessed on July 15, 2025,
    <https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-docte>
 [^15]: How do you write your doc tests? : r/rust - Reddit, accessed on July 15,
    2025,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@
 
 pub mod ast;
 pub mod cli;
+pub mod manifest;
 pub mod runner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Netsuke core library.
 //!
-//! Currently this library only exposes the command line interface
-//! definitions used by the binary and tests.
+//! This library provides the command line interface definitions and
+//! helper functions for parsing `Netsukefile` manifests.
 
 pub mod ast;
 pub mod cli;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -15,7 +15,14 @@ use std::{fs, path::Path};
 /// ```
 /// use netsuke::manifest::from_str;
 ///
-/// let yaml = "netsuke_version: 1.0.0\ntargets:\n  - name: a\n    recipe:\n      kind: command\n      command: echo hi";
+/// let yaml = r#"
+/// netsuke_version: 1.0.0
+/// targets:
+///   - name: a
+///     recipe:
+///       kind: command
+///       command: echo hi
+/// "#;
 /// let manifest = from_str(yaml).expect("parse");
 /// assert_eq!(manifest.targets.len(), 1);
 /// ```

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,49 @@
+//! Manifest loading helpers.
+//!
+//! This module provides convenience functions for parsing a static
+//! `Netsukefile` into the [`crate::ast::NetsukeManifest`] structure.
+//! They wrap `serde_yml` and add basic file handling.
+
+use crate::ast::NetsukeManifest;
+use anyhow::{Context, Result};
+use std::{fs, path::Path};
+
+/// Parse a YAML string into a [`NetsukeManifest`].
+///
+/// # Examples
+///
+/// ```
+/// use netsuke::manifest::from_str;
+///
+/// let yaml = "netsuke_version: 1.0.0\ntargets:\n  - name: a\n    recipe:\n      kind: command\n      command: echo hi";
+/// let manifest = from_str(yaml).expect("parse");
+/// assert_eq!(manifest.targets.len(), 1);
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if the YAML is malformed or fails validation.
+pub fn from_str(yaml: &str) -> Result<NetsukeManifest> {
+    serde_yml::from_str::<NetsukeManifest>(yaml).context("YAML parse error")
+}
+
+/// Load a [`NetsukeManifest`] from the given file path.
+///
+/// # Examples
+///
+/// ```no_run
+/// use netsuke::manifest::from_path;
+///
+/// let manifest = from_path("Netsukefile");
+/// assert!(manifest.is_ok());
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or the YAML fails to parse.
+pub fn from_path(path: impl AsRef<Path>) -> Result<NetsukeManifest> {
+    let path_ref = path.as_ref();
+    let data = fs::read_to_string(path_ref)
+        .with_context(|| format!("Failed to read {}", path_ref.display()))?;
+    from_str(&data)
+}

--- a/tests/data/invalid_version.yml
+++ b/tests/data/invalid_version.yml
@@ -1,0 +1,6 @@
+netsuke_version: "1"
+targets:
+  - name: hi
+    recipe:
+      kind: command
+      command: "echo hi"

--- a/tests/data/missing_recipe.yml
+++ b/tests/data/missing_recipe.yml
@@ -1,0 +1,3 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hi

--- a/tests/data/missing_recipe.yml
+++ b/tests/data/missing_recipe.yml
@@ -1,3 +1,4 @@
 netsuke_version: "1.0.0"
 targets:
   - name: hi
+

--- a/tests/data/rules.yml
+++ b/tests/data/rules.yml
@@ -1,0 +1,12 @@
+netsuke_version: "1.0.0"
+rules:
+  - name: compile
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule: compile

--- a/tests/data/rules.yml
+++ b/tests/data/rules.yml
@@ -10,3 +10,4 @@ targets:
     recipe:
       kind: rule
       rule: compile
+

--- a/tests/data/unknown_field.yml
+++ b/tests/data/unknown_field.yml
@@ -1,0 +1,7 @@
+netsuke_version: "1.0.0"
+extra: field
+targets:
+  - name: hi
+    recipe:
+      kind: command
+      command: "echo hi"

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -17,3 +17,20 @@ Feature: Manifest parsing
   Scenario: Invalid action fails to parse
     When the manifest file "tests/data/action_invalid.yml" is parsed
     Then parsing the manifest fails
+
+  Scenario: Manifest with rules parses correctly
+    When the manifest file "tests/data/rules.yml" is parsed
+    Then the first rule name is "compile"
+    And the first target name is "hello.o"
+
+  Scenario: Unknown field fails to parse
+    When the manifest file "tests/data/unknown_field.yml" is parsed
+    Then parsing the manifest fails
+
+  Scenario: Invalid version fails to parse
+    When the manifest file "tests/data/invalid_version.yml" is parsed
+    Then parsing the manifest fails
+
+  Scenario: Missing recipe fails to parse
+    When the manifest file "tests/data/missing_recipe.yml" is parsed
+    Then parsing the manifest fails


### PR DESCRIPTION
## Summary
- load Netsukefiles via new `manifest` module
- document manifest loader design
- mark roadmap tasks as done
- test manifest parsing via rstest and cucumber
- add manifest YAML fixtures and broaden tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound copying files)*

------
https://chatgpt.com/codex/tasks/task_e_68840c33dba0832286a182bfe899d6b9

## Summary by Sourcery

Introduce a new manifest module to parse Netsukefile YAML via from_str and from_path helper functions, replace raw serde_yaml usage throughout tests and Cucumber steps, and broaden test coverage with YAML fixtures and BDD scenarios while updating related documentation and dependencies.

New Features:
- Add manifest module with from_str and from_path functions for loading and validating Netsukefile YAML

Enhancements:
- Replace direct serde_yaml deserialization in unit tests and Cucumber steps with the manifest loader
- Add tests/data fixtures and expand rstest and Cucumber scenarios to cover valid and invalid manifest files
- Update Cargo.toml to include anyhow for error handling and expose the manifest module in lib.rs

Build:
- Add anyhow dependency to Cargo.toml for manifest module error handling

Documentation:
- Update netsuke-design.md to document loader helpers and fixtures, and mark YAML parser tasks done in roadmap.md
- Fix minor spacing in rust-doctest-dry-guide.md

Tests:
- Extend ast_tests.rs with file-based loading tests and error cases via manifest::from_path
- Add BDD step for verifying the first rule name and new scenarios in manifest.feature