### PR TITLE
Implement IR generation and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,12 @@ jobs:
       - name: Run coverage
         run: cargo tarpaulin --out lcov
       - name: Upload coverage data to CodeScene
-        if: ${{ secrets.CS_ACCESS_TOKEN }}
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN != '' }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.1.0
         with:
           format: lcov
-          access-token: ${{ secrets.CS_ACCESS_TOKEN }}
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN != '' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.1.0
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +244,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cucumber"
@@ -296,6 +324,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -425,6 +463,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -677,6 +725,8 @@ dependencies = [
  "semver",
  "serde",
  "serde_yml",
+ "sha2",
+ "thiserror",
  "tokio",
 ]
 
@@ -987,6 +1037,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1206,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
 semver = { version = "1", features = ["serde"] }
 anyhow = "1"
+thiserror = "1"
+sha2 = "0.10"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1056,6 +1056,12 @@ action identifier and carries the `phony` and `always` flags verbatim from the
 manifest. No Ninja specific placeholders are stored in the IR to keep the
 representation portable.
 
+- Actions are deduplicated using a SHA-256 hash of their recipe and metadata.
+  Identical commands therefore share the same identifier which keeps the IR
+  deterministic for snapshot tests.
+- Multiple rule references in a single target are not yet supported. The IR
+  generator reports `IrGenError::MultipleRules` when encountered.
+
 ## Section 6: Process Management and Secure Execution
 
 The final stage of a Netsuke build involves executing commands. While Netsuke

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1061,6 +1061,8 @@ representation portable.
   deterministic for snapshot tests.
 - Multiple rule references in a single target are not yet supported. The IR
   generator reports `IrGenError::MultipleRules` when encountered.
+- Duplicate output files are rejected. Attempting to define the same output
+  path twice results in `IrGenError::DuplicateOutput`.
 
 ## Section 6: Process Management and Secure Execution
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,14 +40,15 @@ compilation pipeline from parsing to execution.
   - [x] Define the IR data structures (BuildGraph, Action, BuildEdge) in
     `src/ir.rs`, keeping it backend-agnostic as per the design. *(done)*
 
-  - [ ] Implement the ir::from_manifest transformation logic to convert the
-    AST into the BuildGraph IR.
+  - [x] Implement the ir::from_manifest transformation logic to convert the
+    AST into the BuildGraph IR. *(done)*
 
-  - [ ] During transformation, consolidate and deduplicate rules into ir::Action
-    structs based on a hash of their properties.
+  - [x] During transformation, consolidate and deduplicate rules into ir::Action
+    structs based on a hash of their properties. *(done)*
 
-  - [ ] Implement validation to ensure that every rule, command, or script
+  - [x] Implement validation to ensure that every rule, command, or script
     referenced by a target is valid and that they are mutually exclusive.
+    *(done)*
 
   - [ ] Implement a cycle detection algorithm (e.g., depth-first search) to fail
     compilation if a circular dependency is found in the target graph.

--- a/tests/data/duplicate_outputs.yml
+++ b/tests/data/duplicate_outputs.yml
@@ -1,0 +1,12 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+  - name: hello.o
+    sources: world.c
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"

--- a/tests/data/duplicate_rules.yml
+++ b/tests/data/duplicate_rules.yml
@@ -1,0 +1,21 @@
+netsuke_version: "1.0.0"
+rules:
+  - name: compile1
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+  - name: compile2
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule: compile1
+  - name: world.o
+    sources: world.c
+    recipe:
+      kind: rule
+      rule: compile2

--- a/tests/data/missing_rule.yml
+++ b/tests/data/missing_rule.yml
@@ -1,0 +1,7 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule: missing

--- a/tests/data/multiple_rules_per_target.yml
+++ b/tests/data/multiple_rules_per_target.yml
@@ -1,0 +1,18 @@
+netsuke_version: "1.0.0"
+rules:
+  - name: compile1
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+  - name: compile2
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule:
+        - compile1
+        - compile2

--- a/tests/features/ir.feature
+++ b/tests/features/ir.feature
@@ -20,3 +20,7 @@ Feature: BuildGraph
   Scenario: Rule not found during IR generation
     When the manifest file "tests/data/missing_rule.yml" is compiled to IR
     Then parsing the manifest fails
+
+  Scenario: Duplicate target outputs
+    When the manifest file "tests/data/duplicate_outputs.yml" is compiled to IR
+    Then parsing the manifest fails

--- a/tests/features/ir.feature
+++ b/tests/features/ir.feature
@@ -19,8 +19,12 @@ Feature: BuildGraph
 
   Scenario: Rule not found during IR generation
     When the manifest file "tests/data/missing_rule.yml" is compiled to IR
-    Then parsing the manifest fails
+    Then IR generation fails
+
+  Scenario: Multiple rules specified for target
+    When the manifest file "tests/data/multiple_rules_per_target.yml" is compiled to IR
+    Then IR generation fails
 
   Scenario: Duplicate target outputs
     When the manifest file "tests/data/duplicate_outputs.yml" is compiled to IR
-    Then parsing the manifest fails
+    Then IR generation fails

--- a/tests/features/ir.feature
+++ b/tests/features/ir.feature
@@ -6,3 +6,17 @@ Feature: BuildGraph
     And the graph has 0 targets
     And the graph has 0 default targets
 
+
+  Scenario: BuildGraph from manifest
+    When the manifest file "tests/data/rules.yml" is compiled to IR
+    Then the graph has 1 actions
+    And the graph has 1 targets
+
+  Scenario: Duplicate rules are deduplicated
+    When the manifest file "tests/data/duplicate_rules.yml" is compiled to IR
+    Then the graph has 1 actions
+    And the graph has 2 targets
+
+  Scenario: Rule not found during IR generation
+    When the manifest file "tests/data/missing_rule.yml" is compiled to IR
+    Then parsing the manifest fails

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -1,0 +1,30 @@
+//! Tests for generating `BuildGraph` from a manifest.
+
+use netsuke::{
+    ir::{BuildGraph, IrGenError},
+    manifest,
+};
+use rstest::rstest;
+
+#[rstest]
+fn minimal_manifest_to_ir() {
+    let manifest = manifest::from_path("tests/data/minimal.yml").expect("load");
+    let graph = BuildGraph::from_manifest(&manifest).expect("ir");
+    assert_eq!(graph.actions.len(), 1);
+    assert_eq!(graph.targets.len(), 1);
+}
+
+#[rstest]
+fn duplicate_rules_are_deduped() {
+    let manifest = manifest::from_path("tests/data/duplicate_rules.yml").expect("load");
+    let graph = BuildGraph::from_manifest(&manifest).expect("ir");
+    assert_eq!(graph.actions.len(), 1);
+    assert_eq!(graph.targets.len(), 2);
+}
+
+#[test]
+fn missing_rule_fails() {
+    let manifest = manifest::from_path("tests/data/missing_rule.yml").expect("load");
+    let err = BuildGraph::from_manifest(&manifest).expect_err("error");
+    matches!(err, IrGenError::RuleNotFound { .. });
+}

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -22,16 +22,23 @@ fn duplicate_rules_are_deduped() {
     assert_eq!(graph.targets.len(), 2);
 }
 
-#[test]
+#[rstest]
 fn missing_rule_fails() {
     let manifest = manifest::from_path("tests/data/missing_rule.yml").expect("load");
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
-    matches!(err, IrGenError::RuleNotFound { .. });
+    assert!(matches!(err, IrGenError::RuleNotFound { .. }));
 }
 
-#[test]
+#[rstest]
 fn duplicate_outputs_fail() {
     let manifest = manifest::from_path("tests/data/duplicate_outputs.yml").expect("load");
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
-    matches!(err, IrGenError::DuplicateOutput { .. });
+    assert!(matches!(err, IrGenError::DuplicateOutput { .. }));
+}
+
+#[rstest]
+fn multiple_rules_per_target_fails() {
+    let manifest = manifest::from_path("tests/data/multiple_rules_per_target.yml").expect("load");
+    let err = BuildGraph::from_manifest(&manifest).expect_err("error");
+    assert!(matches!(err, IrGenError::MultipleRules { .. }));
 }

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -28,3 +28,10 @@ fn missing_rule_fails() {
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
     matches!(err, IrGenError::RuleNotFound { .. });
 }
+
+#[test]
+fn duplicate_outputs_fail() {
+    let manifest = manifest::from_path("tests/data/duplicate_outputs.yml").expect("load");
+    let err = BuildGraph::from_manifest(&manifest).expect_err("error");
+    matches!(err, IrGenError::DuplicateOutput { .. });
+}

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -26,3 +26,23 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
     let g = world.build_graph.as_ref().expect("graph");
     assert_eq!(g.default_targets.len(), count);
 }
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber requires owned String arguments"
+)]
+#[when(expr = "the manifest file {string} is compiled to IR")]
+fn compile_manifest(world: &mut CliWorld, path: String) {
+    match netsuke::manifest::from_path(&path)
+        .and_then(|m| BuildGraph::from_manifest(&m).map_err(anyhow::Error::from))
+    {
+        Ok(graph) => {
+            world.build_graph = Some(graph);
+            world.manifest_error = None;
+        }
+        Err(e) => {
+            world.build_graph = None;
+            world.manifest_error = Some(e.to_string());
+        }
+    }
+}

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -46,3 +46,11 @@ fn compile_manifest(world: &mut CliWorld, path: String) {
         }
     }
 }
+
+#[then("IR generation fails")]
+fn ir_generation_fails(world: &mut CliWorld) {
+    assert!(
+        world.manifest_error.is_some(),
+        "expected IR generation error"
+    );
+}


### PR DESCRIPTION
## Summary
- implement `BuildGraph::from_manifest` with action deduplication
- add `IrGenError` for validation failures
- document hashing strategy and multiple rule limitation
- mark IR generation tasks as done in roadmap
- test IR generation with `rstest` and `cucumber`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68852d434cc88322b61cbab22ab5ca68

## Summary by Sourcery

Generate and validate the intermediate build graph (IR) from Netsuke manifests: deduplicate actions by hashing, enforce single-rule targets, surface errors for missing or multiple rules, and update tests and documentation accordingly

New Features:
- Add BuildGraph::from_manifest to convert parsed manifests into IR with action deduplication and validation for missing or multiple rule references
- Introduce IrGenError enum to report validation failures during IR generation
- Implement SHA-256 based hashing of Action metadata for deterministic deduplication

Build:
- Add thiserror and sha2 dependencies for error handling and hashing

Documentation:
- Mark IR generation and deduplication tasks as completed in the roadmap
- Document action hashing strategy and limitation on multiple rule references in the design documentation

Tests:
- Add rstest unit tests verifying IR generation for minimal manifests, deduplication, and missing-rule errors
- Add Cucumber steps and feature scenarios for compiling manifests to IR and handling error cases