### PR TITLE
Improve IR errors and hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "anyhow",
  "clap",
  "cucumber",
+ "itoa",
  "rstest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ semver = { version = "1", features = ["serde"] }
 anyhow = "1"
 thiserror = "1"
 sha2 = "0.10"
+itoa = "1"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -71,6 +71,8 @@ impl ActionHasher {
         match rule {
             StringOrList::String(r) => Self::update_with_len(hasher, r.as_bytes()),
             StringOrList::List(list) => {
+                // Preserve the original sequence so that different orders
+                // generate distinct hashes.
                 for r in list {
                     Self::update_with_len(hasher, r.as_bytes());
                 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -23,6 +23,7 @@
 //! assert!(!hash.is_empty());
 //! ```
 
+use itoa::Buffer;
 use sha2::{Digest, Sha256};
 
 use crate::ast::{Recipe, StringOrList};
@@ -89,8 +90,11 @@ impl ActionHasher {
     }
 
     fn update_with_len(hasher: &mut Sha256, bytes: &[u8]) {
-        let len = bytes.len();
-        hasher.update(format!("{len}:").as_bytes());
+        // Write the length prefix into a stack buffer to avoid heap allocation.
+        let mut buf = Buffer::new();
+        let len_str = buf.format(bytes.len());
+        hasher.update(len_str.as_bytes());
+        hasher.update(b":");
         hasher.update(bytes);
     }
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -94,38 +94,3 @@ impl ActionHasher {
         hasher.update(bytes);
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ast::{Recipe, StringOrList};
-    use crate::ir::Action;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case(
-        Action {
-            recipe: Recipe::Command { command: "echo".into() },
-            description: Some("desc".into()),
-            depfile: Some("$out.d".into()),
-            deps_format: Some("gcc".into()),
-            pool: None,
-            restat: false,
-        },
-        "a0f6e2cd3b9b3cee0bf94a7d53bce56cf4178dfe907bb1cb7c832f47846baf38"
-    )]
-    #[case(
-        Action {
-            recipe: Recipe::Rule { rule: StringOrList::List(vec!["a".into(), "b".into()]) },
-            description: None,
-            depfile: None,
-            deps_format: None,
-            pool: None,
-            restat: true,
-        },
-        "cf8e97357820acf6f66037dcf977ee36c88c2811d60342db30c99507d24a0d60"
-    )]
-    fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
-        assert_eq!(ActionHasher::hash(&action), expected);
-    }
-}

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,0 +1,131 @@
+//! Action hashing utilities.
+//!
+//! This module provides the [`ActionHasher`] type used to compute a stable
+//! SHA-256 digest for [`Action`] definitions. The hash is used to deduplicate
+//! identical actions when generating the build graph.
+//!
+//! # Examples
+//!
+//! ```
+//! use netsuke::hasher::ActionHasher;
+//! use netsuke::ir::Action;
+//! use netsuke::ast::{Recipe, StringOrList};
+//!
+//! let action = Action {
+//!     recipe: Recipe::Command { command: "echo".into() },
+//!     description: None,
+//!     depfile: None,
+//!     deps_format: None,
+//!     pool: None,
+//!     restat: false,
+//! };
+//! let hash = ActionHasher::hash(&action);
+//! assert!(!hash.is_empty());
+//! ```
+
+use sha2::{Digest, Sha256};
+
+use crate::ast::{Recipe, StringOrList};
+use crate::ir::Action;
+
+/// Computes stable digests for [`Action`] definitions.
+pub struct ActionHasher;
+
+impl ActionHasher {
+    /// Calculate the hash of an [`Action`].
+    #[must_use]
+    pub fn hash(action: &Action) -> String {
+        let mut hasher = Sha256::new();
+        Self::hash_recipe(&mut hasher, &action.recipe);
+        Self::hash_optional_fields(&mut hasher, action);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn hash_recipe(hasher: &mut Sha256, recipe: &Recipe) {
+        match recipe {
+            Recipe::Command { command } => {
+                hasher.update(b"cmd");
+                Self::update_with_len(hasher, command.as_bytes());
+            }
+            Recipe::Script { script } => {
+                hasher.update(b"scr");
+                Self::update_with_len(hasher, script.as_bytes());
+            }
+            Recipe::Rule { rule } => {
+                hasher.update(b"rule");
+                Self::hash_rule_reference(hasher, rule);
+            }
+        }
+    }
+
+    fn hash_optional_fields(hasher: &mut Sha256, action: &Action) {
+        Self::hash_optional_string(hasher, action.description.as_ref());
+        Self::hash_optional_string(hasher, action.depfile.as_ref());
+        Self::hash_optional_string(hasher, action.deps_format.as_ref());
+        Self::hash_optional_string(hasher, action.pool.as_ref());
+        hasher.update(if action.restat { b"1" } else { b"0" });
+    }
+
+    fn hash_rule_reference(hasher: &mut Sha256, rule: &StringOrList) {
+        match rule {
+            StringOrList::String(r) => Self::update_with_len(hasher, r.as_bytes()),
+            StringOrList::List(list) => {
+                for r in list {
+                    Self::update_with_len(hasher, r.as_bytes());
+                }
+            }
+            StringOrList::Empty => {}
+        }
+    }
+
+    fn hash_optional_string(hasher: &mut Sha256, value: Option<&String>) {
+        match value {
+            Some(v) => {
+                hasher.update(b"1");
+                Self::update_with_len(hasher, v.as_bytes());
+            }
+            None => hasher.update(b"0"),
+        }
+    }
+
+    fn update_with_len(hasher: &mut Sha256, bytes: &[u8]) {
+        let len = bytes.len();
+        hasher.update(format!("{len}:").as_bytes());
+        hasher.update(bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Recipe, StringOrList};
+    use crate::ir::Action;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        Action {
+            recipe: Recipe::Command { command: "echo".into() },
+            description: Some("desc".into()),
+            depfile: Some("$out.d".into()),
+            deps_format: Some("gcc".into()),
+            pool: None,
+            restat: false,
+        },
+        "a0f6e2cd3b9b3cee0bf94a7d53bce56cf4178dfe907bb1cb7c832f47846baf38"
+    )]
+    #[case(
+        Action {
+            recipe: Recipe::Rule { rule: StringOrList::List(vec!["a".into(), "b".into()]) },
+            description: None,
+            depfile: None,
+            deps_format: None,
+            pool: None,
+            restat: true,
+        },
+        "cf8e97357820acf6f66037dcf977ee36c88c2811d60342db30c99507d24a0d60"
+    )]
+    fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
+        assert_eq!(ActionHasher::hash(&action), expected);
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -69,8 +69,9 @@ pub struct BuildEdge {
 }
 
 use crate::ast::{NetsukeManifest, Recipe, StringOrList};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use crate::hasher::ActionHasher;
 
 /// Errors produced during IR generation.
 #[derive(Debug, Error)]
@@ -81,11 +82,14 @@ pub enum IrGenError {
         rule_name: String,
     },
 
-    #[error("multiple rules per target are not supported for '{target_name}'")]
-    MultipleRules { target_name: String },
+    #[error("multiple rules for target '{target_name}': {rules:?}")]
+    MultipleRules {
+        target_name: String,
+        rules: Vec<String>,
+    },
 
-    #[error("target output '{output}' defined multiple times")]
-    DuplicateOutput { output: String },
+    #[error("duplicate target outputs: {outputs:?}")]
+    DuplicateOutput { outputs: Vec<String> },
 }
 
 impl BuildGraph {
@@ -127,16 +131,20 @@ impl BuildGraph {
             let outputs = to_paths(&target.name);
             let action_id = match &target.recipe {
                 Recipe::Rule { rule } => {
-                    let name = extract_single(rule).ok_or_else(|| IrGenError::MultipleRules {
-                        target_name: get_target_display_name(&outputs),
-                    })?;
-                    rule_map
-                        .get(name)
-                        .cloned()
-                        .ok_or_else(|| IrGenError::RuleNotFound {
+                    if let Some(name) = extract_single(rule) {
+                        rule_map
+                            .get(name)
+                            .cloned()
+                            .ok_or_else(|| IrGenError::RuleNotFound {
+                                target_name: get_target_display_name(&outputs),
+                                rule_name: name.to_string(),
+                            })?
+                    } else {
+                        return Err(IrGenError::MultipleRules {
                             target_name: get_target_display_name(&outputs),
-                            rule_name: name.to_string(),
-                        })?
+                            rules: to_strings(rule),
+                        });
+                    }
                 }
                 Recipe::Command { .. } | Recipe::Script { .. } => {
                     register_action(actions, target.recipe.clone(), None)
@@ -153,12 +161,18 @@ impl BuildGraph {
                 always: target.always,
             };
 
-            for out in outputs {
-                if targets.contains_key(&out) {
-                    return Err(IrGenError::DuplicateOutput {
-                        output: out.display().to_string(),
-                    });
+            let mut duplicates = Vec::new();
+            for out in &outputs {
+                if targets.contains_key(out) {
+                    duplicates.push(out.display().to_string());
                 }
+            }
+            if !duplicates.is_empty() {
+                return Err(IrGenError::DuplicateOutput {
+                    outputs: duplicates,
+                });
+            }
+            for out in outputs {
                 targets.insert(out, edge.clone());
             }
         }
@@ -185,74 +199,9 @@ fn register_action(
         pool: None,
         restat: false,
     };
-    let hash = hash_action(&action);
+    let hash = ActionHasher::hash(&action);
     actions.entry(hash.clone()).or_insert(action);
     hash
-}
-
-/// Computes a hash for an [`Action`].
-///
-/// Note: The hash depends on the order and formatting of the fields as they
-/// are serialized. If stability across code or format changes is required,
-/// consider using a canonical serialization format via `serde`.
-fn hash_action(action: &Action) -> String {
-    let mut hasher = Sha256::new();
-    hash_recipe(&mut hasher, &action.recipe);
-    hash_optional_fields(&mut hasher, action);
-    format!("{:x}", hasher.finalize())
-}
-
-fn hash_recipe(hasher: &mut Sha256, recipe: &Recipe) {
-    match recipe {
-        Recipe::Command { command } => {
-            hasher.update(b"cmd");
-            update_with_len(hasher, command.as_bytes());
-        }
-        Recipe::Script { script } => {
-            hasher.update(b"scr");
-            update_with_len(hasher, script.as_bytes());
-        }
-        Recipe::Rule { rule } => {
-            hasher.update(b"rule");
-            hash_rule_reference(hasher, rule);
-        }
-    }
-}
-
-fn hash_optional_fields(hasher: &mut Sha256, action: &Action) {
-    hash_optional_string(hasher, action.description.as_ref());
-    hash_optional_string(hasher, action.depfile.as_ref());
-    hash_optional_string(hasher, action.deps_format.as_ref());
-    hash_optional_string(hasher, action.pool.as_ref());
-    hasher.update(if action.restat { b"1" } else { b"0" });
-}
-
-fn hash_rule_reference(hasher: &mut Sha256, rule: &StringOrList) {
-    match rule {
-        StringOrList::String(r) => update_with_len(hasher, r.as_bytes()),
-        StringOrList::List(list) => {
-            for r in list {
-                update_with_len(hasher, r.as_bytes());
-            }
-        }
-        StringOrList::Empty => {}
-    }
-}
-
-fn hash_optional_string(hasher: &mut Sha256, value: Option<&String>) {
-    match value {
-        Some(v) => {
-            hasher.update(b"1");
-            update_with_len(hasher, v.as_bytes());
-        }
-        None => hasher.update(b"0"),
-    }
-}
-
-fn update_with_len(hasher: &mut Sha256, bytes: &[u8]) {
-    let len = bytes.len();
-    hasher.update(format!("{len}:").as_bytes());
-    hasher.update(bytes);
 }
 
 fn to_paths(sol: &StringOrList) -> Vec<PathBuf> {
@@ -260,6 +209,14 @@ fn to_paths(sol: &StringOrList) -> Vec<PathBuf> {
         StringOrList::Empty => Vec::new(),
         StringOrList::String(s) => vec![PathBuf::from(s)],
         StringOrList::List(v) => v.iter().map(PathBuf::from).collect(),
+    }
+}
+
+fn to_strings(sol: &StringOrList) -> Vec<String> {
+    match sol {
+        StringOrList::Empty => Vec::new(),
+        StringOrList::String(s) => vec![s.clone()],
+        StringOrList::List(v) => v.clone(),
     }
 }
 
@@ -276,37 +233,4 @@ fn get_target_display_name(paths: &[PathBuf]) -> String {
         .first()
         .map(|p| p.display().to_string())
         .unwrap_or_default()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case(
-        Action {
-            recipe: Recipe::Command { command: "echo".into() },
-            description: Some("desc".into()),
-            depfile: Some("$out.d".into()),
-            deps_format: Some("gcc".into()),
-            pool: None,
-            restat: false,
-        },
-        "a0f6e2cd3b9b3cee0bf94a7d53bce56cf4178dfe907bb1cb7c832f47846baf38"
-    )]
-    #[case(
-        Action {
-            recipe: Recipe::Rule { rule: StringOrList::List(vec!["a".into(), "b".into()]) },
-            description: None,
-            depfile: None,
-            deps_format: None,
-            pool: None,
-            restat: true,
-        },
-        "cf8e97357820acf6f66037dcf977ee36c88c2811d60342db30c99507d24a0d60"
-    )]
-    fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
-        assert_eq!(hash_action(&action), expected);
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod ast;
 pub mod cli;
+pub mod hasher;
 pub mod ir;
 pub mod manifest;
 pub mod runner;

--- a/tests/data/duplicate_outputs_multi.yml
+++ b/tests/data/duplicate_outputs_multi.yml
@@ -1,0 +1,16 @@
+netsuke_version: "1.0.0"
+targets:
+  - name:
+      - foo.o
+      - bar.o
+    sources: foo.c
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"
+  - name:
+      - bar.o
+      - foo.o
+    sources: bar.c
+    recipe:
+      kind: command
+      command: "cc -c $in -o $out"

--- a/tests/data/empty_rule.yml
+++ b/tests/data/empty_rule.yml
@@ -1,0 +1,7 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule: []

--- a/tests/data/rule_not_found.yml
+++ b/tests/data/rule_not_found.yml
@@ -1,0 +1,7 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello.o
+    sources: hello.c
+    recipe:
+      kind: rule
+      rule: missing_rule

--- a/tests/hasher_tests.rs
+++ b/tests/hasher_tests.rs
@@ -61,6 +61,18 @@ use rstest::rstest;
     },
     "28adc0857704aa0c54c3bc624cb2dc70c101c3936987b20ae520a20319f591c2"
 )]
+// Order of rule names influences the digest.
+#[case(
+    Action {
+        recipe: Recipe::Rule { rule: StringOrList::List(vec!["b".into(), "a".into()]) },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: true,
+    },
+    "b93ff0102089f1f1a3fe9eec082b59d5aab58271a40724ccdfdaade6a68fe340"
+)]
 fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
     assert_eq!(ActionHasher::hash(&action), expected);
 }

--- a/tests/hasher_tests.rs
+++ b/tests/hasher_tests.rs
@@ -1,0 +1,33 @@
+//! Tests for action hashing utilities.
+
+use netsuke::ast::{Recipe, StringOrList};
+use netsuke::hasher::ActionHasher;
+use netsuke::ir::Action;
+use rstest::rstest;
+
+#[rstest]
+#[case(
+    Action {
+        recipe: Recipe::Command { command: "echo".into() },
+        description: Some("desc".into()),
+        depfile: Some("$out.d".into()),
+        deps_format: Some("gcc".into()),
+        pool: None,
+        restat: false,
+    },
+    "a0f6e2cd3b9b3cee0bf94a7d53bce56cf4178dfe907bb1cb7c832f47846baf38"
+)]
+#[case(
+    Action {
+        recipe: Recipe::Rule { rule: StringOrList::List(vec!["a".into(), "b".into()]) },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: true,
+    },
+    "cf8e97357820acf6f66037dcf977ee36c88c2811d60342db30c99507d24a0d60"
+)]
+fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
+    assert_eq!(ActionHasher::hash(&action), expected);
+}

--- a/tests/hasher_tests.rs
+++ b/tests/hasher_tests.rs
@@ -28,6 +28,39 @@ use rstest::rstest;
     },
     "cf8e97357820acf6f66037dcf977ee36c88c2811d60342db30c99507d24a0d60"
 )]
+#[case(
+    Action {
+        recipe: Recipe::Command { command: String::new() },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: false,
+    },
+    "69f72afccc2aa5a709af1139a9c7ef5f4f72e57cf5376e6c043e575f68f2ef8d"
+)]
+#[case(
+    Action {
+        recipe: Recipe::Rule { rule: StringOrList::List(vec![]) },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: false,
+    },
+    "c28b5c0b7f20bf1093cbab990976b904268f173413f54b7007166b2c02f498f3"
+)]
+#[case(
+    Action {
+        recipe: Recipe::Command { command: "特殊字符!@#$%^&*()".into() },
+        description: Some("desc\nwith\nnewlines".into()),
+        depfile: Some(String::new()),
+        deps_format: None,
+        pool: None,
+        restat: false,
+    },
+    "28adc0857704aa0c54c3bc624cb2dc70c101c3936987b20ae520a20319f591c2"
+)]
 fn hash_action_is_stable(#[case] action: Action, #[case] expected: &str) {
     assert_eq!(ActionHasher::hash(&action), expected);
 }

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -37,6 +37,7 @@ enum ExpectedError {
         rules: Vec<String>,
     },
     EmptyRule(String),
+    RuleNotFound(String),
 }
 
 #[rstest]
@@ -59,6 +60,10 @@ enum ExpectedError {
     "tests/data/empty_rule.yml",
     ExpectedError::EmptyRule("hello.o".into())
 )]
+#[case(
+    "tests/data/rule_not_found.yml",
+    ExpectedError::RuleNotFound("missing_rule".into())
+)]
 fn manifest_error_cases(#[case] manifest_path: &str, #[case] expected: ExpectedError) {
     let manifest = manifest::from_path(manifest_path).expect("load");
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
@@ -78,6 +83,9 @@ fn manifest_error_cases(#[case] manifest_path: &str, #[case] expected: ExpectedE
         }
         (IrGenError::EmptyRule { target_name }, ExpectedError::EmptyRule(exp_target)) => {
             assert_eq!(target_name, exp_target);
+        }
+        (IrGenError::RuleNotFound { rule_name, .. }, ExpectedError::RuleNotFound(exp_rule)) => {
+            assert_eq!(rule_name, exp_rule);
         }
         (other, exp) => panic!("expected {exp:?} but got {other:?}"),
     }

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -33,12 +33,35 @@ fn missing_rule_fails() {
 fn duplicate_outputs_fail() {
     let manifest = manifest::from_path("tests/data/duplicate_outputs.yml").expect("load");
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
-    assert!(matches!(err, IrGenError::DuplicateOutput { .. }));
+    match err {
+        IrGenError::DuplicateOutput { outputs } => {
+            assert_eq!(outputs, vec![String::from("hello.o")]);
+        }
+        _ => panic!("wrong error"),
+    }
 }
 
 #[rstest]
 fn multiple_rules_per_target_fails() {
     let manifest = manifest::from_path("tests/data/multiple_rules_per_target.yml").expect("load");
     let err = BuildGraph::from_manifest(&manifest).expect_err("error");
-    assert!(matches!(err, IrGenError::MultipleRules { .. }));
+    match err {
+        IrGenError::MultipleRules { target_name, rules } => {
+            assert_eq!(target_name, "hello.o");
+            assert_eq!(rules, vec![String::from("compile1"), String::from("compile2")]);
+        }
+        _ => panic!("wrong error"),
+    }
+}
+
+#[rstest]
+fn duplicate_outputs_multi_listed() {
+    let manifest = manifest::from_path("tests/data/duplicate_outputs_multi.yml").expect("load");
+    let err = BuildGraph::from_manifest(&manifest).expect_err("error");
+    match err {
+        IrGenError::DuplicateOutput { outputs } => {
+            assert_eq!(outputs, vec![String::from("bar.o"), String::from("foo.o")]);
+        }
+        _ => panic!("wrong error"),
+    }
 }

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -29,9 +29,13 @@ fn missing_rule_fails() {
     assert!(matches!(err, IrGenError::RuleNotFound { .. }));
 }
 
+#[derive(Debug)]
 enum ExpectedError {
     DuplicateOutput(Vec<String>),
-    MultipleRules { target: String, rules: Vec<String> },
+    MultipleRules {
+        target_name: String,
+        rules: Vec<String>,
+    },
     EmptyRule(String),
 }
 
@@ -47,7 +51,7 @@ enum ExpectedError {
 #[case(
     "tests/data/multiple_rules_per_target.yml",
     ExpectedError::MultipleRules {
-        target: "hello.o".into(),
+        target_name: "hello.o".into(),
         rules: vec!["compile1".into(), "compile2".into()],
     }
 )]
@@ -65,16 +69,16 @@ fn manifest_error_cases(#[case] manifest_path: &str, #[case] expected: ExpectedE
         (
             IrGenError::MultipleRules { target_name, rules },
             ExpectedError::MultipleRules {
-                target,
+                target_name: exp_target,
                 rules: exp_rules,
             },
         ) => {
-            assert_eq!(target_name, target);
+            assert_eq!(target_name, exp_target);
             assert_eq!(rules, exp_rules);
         }
         (IrGenError::EmptyRule { target_name }, ExpectedError::EmptyRule(exp_target)) => {
             assert_eq!(target_name, exp_target);
         }
-        (other, _) => panic!("wrong error: {other:?}"),
+        (other, exp) => panic!("expected {exp:?} but got {other:?}"),
     }
 }

--- a/tests/ir_from_manifest_tests.rs
+++ b/tests/ir_from_manifest_tests.rs
@@ -48,7 +48,10 @@ fn multiple_rules_per_target_fails() {
     match err {
         IrGenError::MultipleRules { target_name, rules } => {
             assert_eq!(target_name, "hello.o");
-            assert_eq!(rules, vec![String::from("compile1"), String::from("compile2")]);
+            assert_eq!(
+                rules,
+                vec![String::from("compile1"), String::from("compile2")]
+            );
         }
         _ => panic!("wrong error"),
     }
@@ -61,6 +64,18 @@ fn duplicate_outputs_multi_listed() {
     match err {
         IrGenError::DuplicateOutput { outputs } => {
             assert_eq!(outputs, vec![String::from("bar.o"), String::from("foo.o")]);
+        }
+        _ => panic!("wrong error"),
+    }
+}
+
+#[rstest]
+fn empty_rule_fails() {
+    let manifest = manifest::from_path("tests/data/empty_rule.yml").expect("load");
+    let err = BuildGraph::from_manifest(&manifest).expect_err("error");
+    match err {
+        IrGenError::EmptyRule { target_name } => {
+            assert_eq!(target_name, "hello.o");
         }
         _ => panic!("wrong error"),
     }


### PR DESCRIPTION
## Summary
- add an ActionHasher utility module and unit tests
- capture all duplicate outputs and rules when constructing the IR
- update tests for new IrGenError variants

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688669648cc48322a62a9cc0ca1eb07c

## Summary by Sourcery

Introduce ActionHasher module for stable action hashing, enhance IR error variants to report multiple duplicate outputs, missing and empty rules, refactor IR generation to use the new hasher and improved error handling, and update tests and dependencies accordingly.

New Features:
- Add ActionHasher module to compute stable SHA-256 hashes for Action definitions

Enhancements:
- Capture all duplicate target outputs and report them in DuplicateOutput errors
- Include all provided rules in MultipleRules errors and add new EmptyRule variant for targets without rules
- Refactor IR generation to use ActionHasher for hashing and to detect empty rule lists

Build:
- Add itoa dependency for efficient number-to-string conversion in hashing

Tests:
- Consolidate IR error tests into parameterized cases and add scenarios for empty rules and multi-output duplicates
- Introduce hasher_tests for verifying stable action hashes