### PR TITLE
Add Gherkin scenarios for manifest parsing

### DIFF
--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -5,24 +5,24 @@ Feature: Manifest Parsing
 
   Scenario: Parsing a minimal valid manifest
     Given the manifest file "tests/data/minimal.yml" is parsed
-    When the manifest version is checked
+    When the version is checked
     Then the manifest version is "1.0.0"
     And the first target name is "hello"
 
   Scenario: Parsing a manifest with phony and always flags
     Given the manifest file "tests/data/phony.yml" is parsed
-    When the target flags are checked
+    When the flags are checked
     Then the first target is phony
     And the first target is always rebuilt
 
   Scenario: A target in the 'actions' block is implicitly phony
     Given the manifest file "tests/data/actions.yml" is parsed
-    When the action flags are checked
+    When the flags are checked
     Then the first action is phony
 
   Scenario: Parsing a manifest with rules
     Given the manifest file "tests/data/rules.yml" is parsed
-    When the manifest contents are checked
+    When the rules are checked
     Then the first rule name is "compile"
     And the first target name is "hello.o"
 

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -48,7 +48,8 @@ fn parse_manifest(world: &mut CliWorld, path: String) {
 fn when_item_checked(world: &mut CliWorld, item: String) {
     match item.as_str() {
         "parsing result" => assert_parsed(world),
-        _ => assert_manifest(world),
+        "manifest" | "version" | "flags" | "rules" => assert_manifest(world),
+        unexpected => panic!("Unexpected item checked: '{unexpected}'"),
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `manifest.feature` with detailed scenarios
- update step definitions for new Given/When phrasing

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688be606cc948322965acca5c4b404b8

## Summary by Sourcery

Add comprehensive Gherkin scenarios for manifest parsing and refactor step definitions to support Given/When phrasing and shared assertion logic

Enhancements:
- Refactor manifest_steps.rs to extract a common parse_manifest_inner function and add assert_manifest/assert_parsed helpers
- Switch to cucumber’s given decorator and introduce new step definitions for parsing, version/flag/content checks, and parsing result validation

Tests:
- Extend manifest.feature with a feature narrative, updated scenario titles, and Given steps for valid manifest parsing (version, flags, rules)
- Add failure scenarios for unknown fields, invalid version strings, missing recipes, and invalid actions