### PR TITLE
Invoke ninja subprocess

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1155,6 +1155,12 @@ The command construction will follow this pattern:
    streamed to the user's console, potentially with additional formatting or
    status updates from Netsuke itself.
 
+In the initial implementation a small helper wraps `Command::new` to forward
+the `-j` and `-C` flags and any explicit build targets. Standard output and
+error are piped and written back to Netsuke's own streams so users see Ninja's
+messages in order. A non-zero exit status or failure to spawn the process is
+reported as an `io::Error` for the CLI to surface.
+
 ### 6.2 The Criticality of Shell Escaping
 
 A primary security responsibility for Netsuke is the prevention of command

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,8 +61,8 @@ compilation pipeline from parsing to execution.
   - [x] Write logic to generate Ninja rule statements from ir::Action structs
     and build statements from ir::BuildEdge structs. *(done)*
 
-  - [ ] Implement the process management logic in `main.rs` to invoke the ninja
-    executable as a subprocess using `std::process::Command`.
+  - [x] Implement the process management logic in `main.rs` to invoke the ninja
+    executable as a subprocess using `std::process::Command`. *(done)*
 
 - **Success Criterion:**
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -322,10 +322,10 @@ fn find_cycle(targets: &HashMap<PathBuf, BuildEdge>) -> Option<Vec<PathBuf>> {
 
         stack.push(node.clone());
 
-        if let Some(edge) = targets.get(node)
-            && let Some(cycle) = visit_dependencies(targets, &edge.inputs, stack, states)
-        {
-            return Some(cycle);
+        if let Some(edge) = targets.get(node) {
+            if let Some(cycle) = visit_dependencies(targets, &edge.inputs, stack, states) {
+                return Some(cycle);
+            }
         }
 
         stack.pop();
@@ -340,10 +340,10 @@ fn find_cycle(targets: &HashMap<PathBuf, BuildEdge>) -> Option<Vec<PathBuf>> {
         states: &mut HashMap<PathBuf, VisitState>,
     ) -> Option<Vec<PathBuf>> {
         for dep in deps {
-            if targets.contains_key(dep)
-                && let Some(cycle) = visit(targets, dep, stack, states)
-            {
-                return Some(cycle);
+            if targets.contains_key(dep) {
+                if let Some(cycle) = visit(targets, dep, stack, states) {
+                    return Some(cycle);
+                }
             }
         }
         None
@@ -353,10 +353,10 @@ fn find_cycle(targets: &HashMap<PathBuf, BuildEdge>) -> Option<Vec<PathBuf>> {
     let mut stack = Vec::new();
 
     for node in targets.keys() {
-        if !states.contains_key(node)
-            && let Some(cycle) = visit(targets, node, &mut stack, &mut states)
-        {
-            return Some(cycle);
+        if !states.contains_key(node) {
+            if let Some(cycle) = visit(targets, node, &mut stack, &mut states) {
+                return Some(cycle);
+            }
         }
     }
     None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,17 @@
-use netsuke::{cli::Cli, runner};
+//! Application entry point.
+//!
+//! Parses command-line arguments and delegates execution to [`runner::run`].
 
-fn main() {
+use netsuke::{cli::Cli, runner};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
     let cli = Cli::parse_with_default();
-    runner::run(cli);
+    match runner::run(&cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,23 +1,65 @@
 //! CLI execution and command dispatch logic.
 //!
 //! This module keeps [`main`] minimal by providing a single entry point that
-//! handles command execution. It currently prints which command was invoked.
+//! handles command execution. It now delegates build requests to the Ninja
+//! subprocess, streaming its output back to the user.
 
 use crate::cli::{Cli, Commands};
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
 
 /// Execute the parsed [`Cli`] commands.
-pub fn run(cli: Cli) {
-    match cli.command.unwrap_or(Commands::Build {
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the Ninja process fails to spawn or exits with a
+/// non-zero status code.
+pub fn run(cli: &Cli) -> io::Result<()> {
+    let command = cli.command.clone().unwrap_or(Commands::Build {
         targets: Vec::new(),
-    }) {
-        Commands::Build { targets } => {
-            println!("Building targets: {targets:?}");
-        }
+    });
+    match command {
+        Commands::Build { targets } => run_ninja(Path::new("ninja"), cli, &targets),
         Commands::Clean => {
             println!("Clean requested");
+            Ok(())
         }
         Commands::Graph => {
             println!("Graph requested");
+            Ok(())
         }
+    }
+}
+
+/// Invoke the Ninja executable with the provided CLI settings.
+///
+/// The function forwards the job count and working directory to Ninja and
+/// streams its standard output and error back to the user.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the Ninja process fails to spawn or reports a
+/// non-zero exit status.
+pub fn run_ninja(program: &Path, cli: &Cli, targets: &[String]) -> io::Result<()> {
+    let mut cmd = Command::new(program);
+    if let Some(dir) = &cli.directory {
+        cmd.current_dir(dir).arg("-C").arg(dir);
+    }
+    if let Some(jobs) = cli.jobs {
+        cmd.arg("-j").arg(jobs.to_string());
+    }
+    cmd.args(targets);
+
+    let output = cmd.output()?;
+    io::stdout().write_all(&output.stdout)?;
+    io::stderr().write_all(&output.stderr)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "ninja exited with {}",
+            output.status
+        )))
     }
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -8,9 +8,23 @@ pub struct CliWorld {
     pub manifest_error: Option<String>,
     pub build_graph: Option<netsuke::ir::BuildGraph>,
     pub ninja: Option<String>,
+    pub run_status: Option<bool>,
+    pub run_error: Option<String>,
+    pub temp: Option<tempfile::TempDir>,
+    pub original_path: Option<std::ffi::OsString>,
 }
 
 mod steps;
+
+impl Drop for CliWorld {
+    fn drop(&mut self) {
+        if let Some(path) = self.original_path.take() {
+            unsafe {
+                std::env::set_var("PATH", path);
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {

--- a/tests/features/ninja_process.feature
+++ b/tests/features/ninja_process.feature
@@ -1,0 +1,19 @@
+Feature: Ninja process execution
+
+  Scenario: Ninja succeeds
+    Given a fake ninja executable that exits with 0
+    And the CLI is parsed with ""
+    When the ninja process is run
+    Then the command should succeed
+
+  Scenario: Ninja fails
+    Given a fake ninja executable that exits with 1
+    And the CLI is parsed with ""
+    When the ninja process is run
+    Then the command should fail
+
+  Scenario: Ninja missing
+    Given no ninja executable is available
+    And the CLI is parsed with ""
+    When the ninja process is run
+    Then the command should fail

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,0 +1,64 @@
+//! Unit tests for Ninja process invocation.
+
+use netsuke::cli::{Cli, Commands};
+use netsuke::runner;
+use rstest::rstest;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn test_cli() -> Cli {
+    Cli {
+        file: PathBuf::from("Netsukefile"),
+        directory: None,
+        jobs: None,
+        command: Some(Commands::Build {
+            targets: Vec::new(),
+        }),
+    }
+}
+
+struct FakeNinja {
+    _dir: TempDir,
+    path: PathBuf,
+}
+
+impl FakeNinja {
+    fn new(exit_code: i32) -> Self {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("ninja");
+        let mut file = File::create(&path).expect("script");
+        writeln!(file, "#!/bin/sh\nexit {exit_code}").expect("write script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&path).expect("meta").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&path, perms).expect("perms");
+        }
+        Self { _dir: dir, path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[rstest]
+#[case(0, true)]
+#[case(1, false)]
+fn run_ninja_status(#[case] code: i32, #[case] succeeds: bool) {
+    let fake = FakeNinja::new(code);
+    let cli = test_cli();
+    let result = runner::run_ninja(fake.path(), &cli, &[]);
+    assert_eq!(result.is_ok(), succeeds);
+}
+
+#[rstest]
+fn run_ninja_not_found() {
+    let cli = test_cli();
+    let err =
+        runner::run_ninja(Path::new("does-not-exist"), &cli, &[]).expect_err("process should fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -2,3 +2,4 @@ mod cli_steps;
 mod ir_steps;
 mod manifest_steps;
 mod ninja_steps;
+mod process_steps;

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -1,0 +1,72 @@
+//! Step definitions for Ninja process execution.
+
+use crate::CliWorld;
+use cucumber::{given, then, when};
+use netsuke::runner;
+use std::fs::{self, File};
+use std::io::Write;
+
+#[given(expr = "a fake ninja executable that exits with {int}")]
+fn fake_ninja(world: &mut CliWorld, code: i32) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("ninja");
+    let mut file = File::create(&path).expect("script");
+    writeln!(file, "#!/bin/sh\nexit {code}").expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&path).expect("meta").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("perms");
+    }
+    if world.original_path.is_none() {
+        world.original_path = Some(std::env::var_os("PATH").unwrap_or_default());
+    }
+    let dir_path = dir.path().display().to_string();
+    let new_path = if let Some(old) = world.original_path.as_ref() {
+        format!("{dir_path}:{}", old.to_string_lossy())
+    } else {
+        dir_path
+    };
+    unsafe {
+        std::env::set_var("PATH", new_path);
+    }
+    world.temp = Some(dir);
+}
+
+#[given("no ninja executable is available")]
+fn no_ninja(world: &mut CliWorld) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    if world.original_path.is_none() {
+        world.original_path = Some(std::env::var_os("PATH").unwrap_or_default());
+    }
+    unsafe {
+        std::env::set_var("PATH", dir.path());
+    }
+    world.temp = Some(dir);
+}
+
+#[when("the ninja process is run")]
+fn run(world: &mut CliWorld) {
+    let cli = world.cli.as_ref().expect("cli");
+    match runner::run(cli) {
+        Ok(()) => {
+            world.run_status = Some(true);
+            world.run_error = None;
+        }
+        Err(e) => {
+            world.run_status = Some(false);
+            world.run_error = Some(e.to_string());
+        }
+    }
+}
+
+#[then("the command should succeed")]
+fn command_should_succeed(world: &mut CliWorld) {
+    assert_eq!(world.run_status, Some(true));
+}
+
+#[then("the command should fail")]
+fn command_should_fail(world: &mut CliWorld) {
+    assert_eq!(world.run_status, Some(false));
+}


### PR DESCRIPTION
## Summary
- invoke the ninja binary as a subprocess and stream its output
- document Ninja process management and mark the roadmap task complete
- exercise the subprocess logic with unit and behavioural tests

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments. Expected 0 arguments but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_688dddde83308322b0c26df2217a0278