### PR TITLE
Add verbose logging via tracing

### DIFF
--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -37,6 +37,6 @@ jobs:
               command: "touch generated.txt"
           MANIFEST
       - name: Run Netsuke
-        run: ./target/debug/netsuke build generated.txt
+        run: ./target/debug/netsuke --verbose build generated.txt
       - name: Assert artefact exists
         run: scripts/assert-file-exists.sh generated.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,11 +763,14 @@ dependencies = [
  "rstest",
  "semver",
  "serde",
+ "serde_json",
  "serde_yml",
  "sha2",
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -786,6 +795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +824,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "peg"
@@ -1088,6 +1113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1132,12 @@ name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smart-default"
@@ -1221,6 +1261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1293,63 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1297,6 +1403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1463,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ thiserror = "1"
 sha2 = "0.10"
 itoa = "1"
 itertools = "0.12"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+serde_json = "1"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ You can also pass:
 - `--file` to use an alternate manifest
 - `--directory` to run in a different working dir
 - `-j N` to control parallelism (passed through to Ninja)
+- `-v`, `--verbose` to enable verbose logging
 
 ## 🚧 Status
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1373,6 +1373,10 @@ struct Cli { /// Path to the Netsuke manifest file to use.
     #[arg(short, long, value_name = "N")]
     jobs: Option<usize>,
 
+    /// Enable verbose logging output.
+    #[arg(short, long)]
+    verbose: bool,
+
     #[command(subcommand)]
     command: Option<Commands>, }
 
@@ -1517,6 +1521,7 @@ selected for this project and the rationale for their inclusion.
 | Templating | minijinja | High compatibility with Jinja2, minimal dependencies, and supports runtime template loading. |
 | Shell Quoting | shell-quote | A critical security component; provides robust, shell-specific escaping for command arguments. |
 | Error Handling | anyhow + thiserror | An idiomatic and powerful combination for creating rich, contextual, and user-friendly error reports. |
+| Logging | tracing | Structured, levelled diagnostic output for debugging and insight. |
 | Versioning | semver | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field. |
 
 ### 9.3 Future Enhancements

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -18,7 +18,7 @@
 //! ```
 
 use semver::Version;
-use serde::{Deserialize, de::Deserializer};
+use serde::{Deserialize, Serialize, de::Deserializer};
 
 fn deserialize_actions<'de, D>(deserializer: D) -> Result<Vec<Target>, D::Error>
 where
@@ -55,7 +55,7 @@ use std::collections::HashMap;
 /// assert_eq!(manifest.targets.len(), 1);
 /// # Ok(()) }
 /// ```
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NetsukeManifest {
     /// Semantic version of the manifest format.
@@ -88,7 +88,7 @@ pub struct NetsukeManifest {
 /// targets. It may define a command line, a script block, or delegate to another
 /// named rule. Dependencies may be specified as either a single string or a
 /// list of strings.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Rule {
     /// Unique identifier used by targets to reference this rule.
@@ -106,7 +106,7 @@ pub struct Rule {
 ///
 /// The variant is selected using the `kind` field in the manifest. Each variant
 /// corresponds to a different way of specifying how a command should run.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum Recipe {
     /// A single shell command.
@@ -125,7 +125,7 @@ pub enum Recipe {
 /// Targets describe the files produced by a rule and their dependencies.
 /// `phony` targets are always considered out of date, while `always` targets are
 /// regenerated even if their inputs are unchanged.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Target {
     /// Output file or files.
@@ -172,7 +172,7 @@ pub struct Target {
 ///   - hello
 ///   - world
 /// ```
-#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum StringOrList {
     /// No value provided.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,10 @@ pub struct Cli {
     #[arg(short, long, value_name = "N", value_parser = parse_jobs)]
     pub jobs: Option<usize>,
 
+    /// Enable verbose logging output.
+    #[arg(short, long)]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,11 @@ use std::process::ExitCode;
 
 fn main() -> ExitCode {
     let cli = Cli::parse_with_default();
+    if cli.verbose {
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .init();
+    }
     match runner::run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,13 @@
 
 use netsuke::{cli::Cli, runner};
 use std::process::ExitCode;
+use tracing::Level;
+use tracing_subscriber::fmt;
 
 fn main() -> ExitCode {
     let cli = Cli::parse_with_default();
     if cli.verbose {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .init();
+        fmt().with_max_level(Level::DEBUG).init();
     }
     match runner::run(&cli) {
         Ok(()) => ExitCode::SUCCESS,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -9,25 +9,29 @@ use rstest::rstest;
 use std::path::PathBuf;
 
 #[rstest]
-#[case(vec!["netsuke"], PathBuf::from("Netsukefile"), None, None, Commands::Build { targets: Vec::new() })]
+#[case(vec!["netsuke"], PathBuf::from("Netsukefile"), None, None, false, Commands::Build { targets: Vec::new() })]
 #[case(
     vec!["netsuke", "--file", "alt.yml", "-C", "work", "-j", "4", "build", "a", "b"],
     PathBuf::from("alt.yml"),
     Some(PathBuf::from("work")),
     Some(4),
+    false,
     Commands::Build { targets: vec!["a".into(), "b".into()] },
 )]
+#[case(vec!["netsuke", "--verbose"], PathBuf::from("Netsukefile"), None, None, true, Commands::Build { targets: Vec::new() })]
 fn parse_cli(
     #[case] argv: Vec<&str>,
     #[case] file: PathBuf,
     #[case] directory: Option<PathBuf>,
     #[case] jobs: Option<usize>,
+    #[case] verbose: bool,
     #[case] expected_cmd: Commands,
 ) {
     let cli = Cli::parse_from_with_default(argv.clone());
     assert_eq!(cli.file, file);
     assert_eq!(cli.directory, directory);
     assert_eq!(cli.jobs, jobs);
+    assert_eq!(cli.verbose, verbose);
     assert_eq!(cli.command.expect("command should be set"), expected_cmd);
 }
 

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -11,6 +11,7 @@ fn test_cli() -> Cli {
         file: PathBuf::from("Netsukefile"),
         directory: None,
         jobs: None,
+        verbose: false,
         command: Some(Commands::Build {
             targets: Vec::new(),
         }),
@@ -35,4 +36,37 @@ fn run_ninja_not_found() {
     let err =
         runner::run_ninja(Path::new("does-not-exist"), &cli, &[]).expect_err("process should fail");
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[rstest]
+fn run_writes_ninja_file() {
+    let (ninja_dir, ninja_path) = support::fake_ninja(0);
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths: Vec<_> = std::env::split_paths(&original_path).collect();
+    paths.insert(0, ninja_dir.path().to_path_buf());
+    let new_path = std::env::join_paths(paths).expect("join paths");
+    unsafe {
+        std::env::set_var("PATH", &new_path);
+    }
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let manifest_path = temp.path().join("Netsukefile");
+    std::fs::copy("tests/data/minimal.yml", &manifest_path).expect("copy manifest");
+    let cli = Cli {
+        file: manifest_path,
+        directory: Some(temp.path().to_path_buf()),
+        jobs: None,
+        verbose: false,
+        command: Some(Commands::Build {
+            targets: Vec::new(),
+        }),
+    };
+
+    runner::run(&cli).expect("run");
+    assert!(temp.path().join("build.ninja").exists());
+
+    unsafe {
+        std::env::set_var("PATH", original_path);
+    }
+    drop(ninja_path);
 }


### PR DESCRIPTION
## Summary
- add a `--verbose` flag to emit debugging logs
- log parsed Netsukefile AST, generated Ninja file path, and the Ninja invocation command
- document and test verbose mode

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package highlight.js)*

------
https://chatgpt.com/codex/tasks/task_e_6891a49306cc8322b00e5cbcf6eaa187

## Summary by Sourcery

Add a verbose mode controlled by a CLI flag to emit debug-level logs of the manifest AST, Ninja file generation, and Ninja invocation, and update code, tests, docs, and dependencies accordingly.

New Features:
- Introduce --verbose flag for CLI to enable debug logging via tracing
- Log parsed Netsuke manifest AST, generated Ninja file path, and the Ninja command invocation

Enhancements:
- Derive Serialize for AST structs and add serde_json pretty-print support

Build:
- Add tracing, tracing-subscriber, and serde_json dependencies to Cargo.toml

Documentation:
- Document the verbose flag in the CLI design docs and README

Tests:
- Extend CLI tests to verify verbose flag parsing and add an integration test for Ninja file creation