### PR TITLE
Integrate manifest-to-Ninja pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "1"
 sha2 = "0.10"
 itoa = "1"
 itertools = "0.12"
+tempfile = "3"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -59,7 +60,6 @@ rstest = "0.18.0"
 cucumber = "0.20.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], default-features = false }
 insta = { version = "1", features = ["yaml"] }
-tempfile = "3"
 
 [[test]]
 name = "cucumber"

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -3,12 +3,15 @@
 use netsuke::cli::{Cli, Commands};
 use netsuke::runner;
 use rstest::rstest;
+use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
 
 /// Creates a default CLI configuration for testing Ninja invocation.
-fn test_cli() -> Cli {
+fn test_cli(file: PathBuf) -> Cli {
     Cli {
-        file: PathBuf::from("Netsukefile"),
+        file,
         directory: None,
         jobs: None,
         command: Some(Commands::Build {
@@ -24,15 +27,71 @@ mod support;
 #[case(1, false)]
 fn run_ninja_status(#[case] code: i32, #[case] succeeds: bool) {
     let (_dir, path) = support::fake_ninja(code);
-    let cli = test_cli();
+    let mut manifest = NamedTempFile::new().expect("manifest");
+    write_manifest(&mut manifest);
+    let cli = test_cli(manifest.path().to_path_buf());
     let result = runner::run_ninja(&path, &cli, &[]);
     assert_eq!(result.is_ok(), succeeds);
 }
 
 #[rstest]
 fn run_ninja_not_found() {
-    let cli = test_cli();
+    let mut manifest = NamedTempFile::new().expect("manifest");
+    write_manifest(&mut manifest);
+    let cli = test_cli(manifest.path().to_path_buf());
     let err =
         runner::run_ninja(Path::new("does-not-exist"), &cli, &[]).expect_err("process should fail");
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[rstest]
+fn run_pipeline_generates_ninja() {
+    use netsuke::ast::Recipe;
+    use netsuke::hasher::ActionHasher;
+    use netsuke::ir::Action;
+
+    let (_dir, path, capture) = support::fake_ninja_capture();
+    let mut manifest = NamedTempFile::new().expect("manifest");
+    write_manifest(&mut manifest);
+    let cli = Cli {
+        file: manifest.path().to_path_buf(),
+        directory: None,
+        jobs: None,
+        command: Some(Commands::Build {
+            targets: Vec::new(),
+        }),
+    };
+
+    runner::run_ninja(&path, &cli, &[]).expect("run ninja");
+
+    let generated = fs::read_to_string(&capture).expect("captured build");
+
+    let action = Action {
+        recipe: Recipe::Command {
+            command: "echo hi".into(),
+        },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: false,
+    };
+    let hash = ActionHasher::hash(&action);
+    let expected =
+        format!("rule {hash}\n  command = echo hi\n\nbuild out: {hash}\n\ndefault out\n");
+    assert_eq!(generated, expected);
+}
+
+fn write_manifest(file: &mut NamedTempFile) {
+    let manifest = concat!(
+        "netsuke_version: \"1.0.0\"\n",
+        "targets:\n",
+        "  - name: out\n",
+        "    recipe:\n",
+        "      kind: command\n",
+        "      command: echo hi\n",
+        "defaults:\n",
+        "  - out\n",
+    );
+    file.write_all(manifest.as_bytes()).expect("write manifest");
 }

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,4 +1,7 @@
 //! Unit tests for Ninja process invocation.
+//!
+//! These tests verify that the runner can translate a manifest into a Ninja
+//! build script and invoke the Ninja process with appropriate arguments.
 
 use netsuke::cli::{Cli, Commands};
 use netsuke::runner;

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -4,12 +4,11 @@ use netsuke::cli::{Cli, Commands};
 use netsuke::runner;
 use rstest::rstest;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 /// Creates a default CLI configuration for testing Ninja invocation.
-fn test_cli(file: PathBuf) -> Cli {
+fn cli_with_manifest(file: PathBuf) -> Cli {
     Cli {
         file,
         directory: None,
@@ -28,8 +27,8 @@ mod support;
 fn run_ninja_status(#[case] code: i32, #[case] succeeds: bool) {
     let (_dir, path) = support::fake_ninja(code);
     let mut manifest = NamedTempFile::new().expect("manifest");
-    write_manifest(&mut manifest);
-    let cli = test_cli(manifest.path().to_path_buf());
+    support::write_manifest(&mut manifest);
+    let cli = cli_with_manifest(manifest.path().to_path_buf());
     let result = runner::run_ninja(&path, &cli, &[]);
     assert_eq!(result.is_ok(), succeeds);
 }
@@ -37,8 +36,8 @@ fn run_ninja_status(#[case] code: i32, #[case] succeeds: bool) {
 #[rstest]
 fn run_ninja_not_found() {
     let mut manifest = NamedTempFile::new().expect("manifest");
-    write_manifest(&mut manifest);
-    let cli = test_cli(manifest.path().to_path_buf());
+    support::write_manifest(&mut manifest);
+    let cli = cli_with_manifest(manifest.path().to_path_buf());
     let err =
         runner::run_ninja(Path::new("does-not-exist"), &cli, &[]).expect_err("process should fail");
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
@@ -52,15 +51,8 @@ fn run_pipeline_generates_ninja() {
 
     let (_dir, path, capture) = support::fake_ninja_capture();
     let mut manifest = NamedTempFile::new().expect("manifest");
-    write_manifest(&mut manifest);
-    let cli = Cli {
-        file: manifest.path().to_path_buf(),
-        directory: None,
-        jobs: None,
-        command: Some(Commands::Build {
-            targets: Vec::new(),
-        }),
-    };
+    support::write_manifest(&mut manifest);
+    let cli = cli_with_manifest(manifest.path().to_path_buf());
 
     runner::run_ninja(&path, &cli, &[]).expect("run ninja");
 
@@ -80,18 +72,4 @@ fn run_pipeline_generates_ninja() {
     let expected =
         format!("rule {hash}\n  command = echo hi\n\nbuild out: {hash}\n\ndefault out\n");
     assert_eq!(generated, expected);
-}
-
-fn write_manifest(file: &mut NamedTempFile) {
-    let manifest = concat!(
-        "netsuke_version: \"1.0.0\"\n",
-        "targets:\n",
-        "  - name: out\n",
-        "    recipe:\n",
-        "      kind: command\n",
-        "      command: echo hi\n",
-        "defaults:\n",
-        "  - out\n",
-    );
-    file.write_all(manifest.as_bytes()).expect("write manifest");
 }

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -53,6 +53,8 @@ fn no_ninja(world: &mut CliWorld) {
 /// on the execution outcome.
 #[when("the ninja process is run")]
 fn run(world: &mut CliWorld) {
+    // Touch the capture variant so the support module's helpers remain used.
+    let _ = support::fake_ninja_capture as fn() -> (TempDir, PathBuf, PathBuf);
     let cli = world.cli.as_mut().expect("cli");
 
     // Ensure a manifest exists at the path expected by the CLI.

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,7 +3,7 @@
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::PathBuf;
-use tempfile::TempDir;
+use tempfile::{NamedTempFile, TempDir};
 
 fn write_script(dir: &TempDir, body: &str) -> PathBuf {
     let path = dir.path().join("ninja");
@@ -43,4 +43,23 @@ pub fn fake_ninja_capture() -> (TempDir, PathBuf, PathBuf) {
     );
     let path = write_script(&dir, &body);
     (dir, path, capture)
+}
+
+/// Write a minimal Netsukefile to the provided temporary file.
+#[allow(
+    dead_code,
+    reason = "helper is unused when the support crate builds independently"
+)]
+pub fn write_manifest(file: &mut NamedTempFile) {
+    let manifest = concat!(
+        "netsuke_version: \"1.0.0\"\n",
+        "targets:\n",
+        "  - name: out\n",
+        "    recipe:\n",
+        "      kind: command\n",
+        "      command: echo hi\n",
+        "defaults:\n",
+        "  - out\n",
+    );
+    file.write_all(manifest.as_bytes()).expect("write manifest");
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -5,14 +5,10 @@ use std::io::Write;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-/// Create a fake Ninja executable that exits with `exit_code`.
-///
-/// Returns the temporary directory and the path to the executable.
-pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
-    let dir = TempDir::new().expect("temp dir");
+fn write_script(dir: &TempDir, body: &str) -> PathBuf {
     let path = dir.path().join("ninja");
     let mut file = File::create(&path).expect("script");
-    writeln!(file, "#!/bin/sh\nexit {exit_code}").expect("write script");
+    file.write_all(body.as_bytes()).expect("write script");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -20,5 +16,31 @@ pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
         perms.set_mode(0o755);
         fs::set_permissions(&path, perms).expect("perms");
     }
+    path
+}
+
+/// Create a fake Ninja executable that exits with `exit_code`.
+///
+/// Returns the temporary directory and the path to the executable.
+pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("temp dir");
+    let body = format!("#!/bin/sh\nexit {exit_code}\n");
+    let path = write_script(&dir, &body);
     (dir, path)
+}
+
+/// Create a fake Ninja that copies the provided build file to a capture path.
+///
+/// Returns the temporary directory, path to the executable and the capture file
+/// location.
+#[allow(dead_code, reason = "not every test exercises the capture variant")]
+pub fn fake_ninja_capture() -> (TempDir, PathBuf, PathBuf) {
+    let dir = TempDir::new().expect("temp dir");
+    let capture = dir.path().join("captured.ninja");
+    let body = format!(
+        "#!/bin/sh\nwhile [ \"$1\" != \"\" ]; do\n  if [ \"$1\" = \"-f\" ]; then\n    shift\n    cat \"$1\" > \"{}\"\n  fi\n  shift\ndone\n",
+        capture.display()
+    );
+    let path = write_script(&dir, &body);
+    (dir, path, capture)
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -33,23 +33,29 @@ pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
 ///
 /// Returns the temporary directory, path to the executable and the capture file
 /// location.
-#[allow(dead_code, reason = "not every test exercises the capture variant")]
 pub fn fake_ninja_capture() -> (TempDir, PathBuf, PathBuf) {
     let dir = TempDir::new().expect("temp dir");
     let capture = dir.path().join("captured.ninja");
     let body = format!(
-        "#!/bin/sh\nwhile [ \"$1\" != \"\" ]; do\n  if [ \"$1\" = \"-f\" ]; then\n    shift\n    cat \"$1\" > \"{}\"\n  fi\n  shift\ndone\n",
-        capture.display()
+        concat!(
+            "#!/bin/sh\n",
+            "while [ $# -gt 0 ]; do\n",
+            "  if [ \"$1\" = \"-f\" ] && [ $# -gt 1 ]; then\n",
+            "    shift\n",
+            "    cat \"$1\" > \"{}\"\n",
+            "    shift\n",
+            "  else\n",
+            "    shift\n",
+            "  fi\n",
+            "done\n",
+        ),
+        capture.display(),
     );
     let path = write_script(&dir, &body);
     (dir, path, capture)
 }
 
 /// Write a minimal Netsukefile to the provided temporary file.
-#[allow(
-    dead_code,
-    reason = "helper is unused when the support crate builds independently"
-)]
 pub fn write_manifest(file: &mut NamedTempFile) {
     let manifest = concat!(
         "netsuke_version: \"1.0.0\"\n",


### PR DESCRIPTION
## Summary
- Parse Netsukefile, convert to IR, and generate a temporary Ninja script before invoking Ninja
- Capture generated build files with test helper and exercise full manifest→IR→Ninja CLI flow

## Testing
- `make fmt`
- `make lint`
- `make test` *(fails: 3 steps failed)*
- `cargo test --test runner_tests`


------
https://chatgpt.com/codex/tasks/task_e_6891a8f2ed1c8322830bd969f8bedf19

## Summary by Sourcery

Integrate a manifest-to-Ninja pipeline by updating the runner to parse a Netsukefile, convert it to IR, generate a temporary Ninja build script, and invoke Ninja with the generated file; extend tests to use temporary manifests and capture the generated build file; refactor test support and add the tempfile dependency.

New Features:
- Parse Netsukefile and generate a Ninja build script before invoking Ninja
- Add an end-to-end integration test to verify the manifest→IR→Ninja pipeline by capturing the generated build file

Enhancements:
- Update run_ninja to write the generated Ninja script to a temporary file and pass "-f" to Ninja
- Refactor test support to consolidate script writing and introduce fake_ninja_capture for build file capture

Build:
- Add tempfile crate for temporary file support

Tests:
- Adapt runner_tests to use temporary manifest files via a write_manifest helper and adjust test_cli signature