### PR TITLE
Simplify manifest syntax

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -254,12 +254,12 @@ Each entry in the `rules` list is a mapping that defines a reusable action.
   filter is applied. Future versions will allow configurable script languages
   with their own escaping rules. On Windows, scripts default to
   `powershell -Command` unless the manifest's `interpreter` field overrides the
-  setting. Exactly one of `command` or `script` must be provided. The manifest
-  parser enforces this rule to prevent invalid states.
+  setting. Exactly one of `command`, `script`, or `rule` must be provided. The
+  manifest parser enforces this rule to prevent invalid states.
 
   Internally, these options deserialize into a shared `Recipe` enum. The parser
-  selects the appropriate variant based on whether `command` or `script` is
-  present.
+  selects the appropriate variant based on whether `command`, `script`, or
+  `rule` is present.
 
 - `description`: An optional, user-friendly string that is printed to the
   console when the rule is executed. This maps to Ninja's `description` field

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -19,9 +19,7 @@ use std::{fs, path::Path};
 /// netsuke_version: 1.0.0
 /// targets:
 ///   - name: a
-///     recipe:
-///       kind: command
-///       command: echo hi
+///     command: echo hi
 /// "#;
 /// let manifest = from_str(yaml).expect("parse");
 /// assert_eq!(manifest.targets.len(), 1);

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -14,9 +14,7 @@ fn parse_minimal_manifest() {
     let yaml = r#"netsuke_version: "1.0.0"
 targets:
   - name: hello
-    recipe:
-      kind: command
-      command: "echo hi""#;
+    command: "echo hi""#;
 
     let manifest = manifest::from_str(yaml).expect("parse");
 
@@ -44,9 +42,7 @@ fn missing_required_fields() {
     let yaml = r#"
         targets:
           - name: hello
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
     "#;
     assert!(manifest::from_str(yaml).is_err());
 
@@ -58,9 +54,7 @@ fn missing_required_fields() {
     let yaml = r#"
         netsuke_version: "1.0.0"
         targets:
-          - recipe:
-              kind: command
-              command: "echo hi"
+          - command: "echo hi"
     "#;
     assert!(manifest::from_str(yaml).is_err());
 }
@@ -71,9 +65,7 @@ fn unknown_fields() {
         netsuke_version: "1.0.0"
         targets:
           - name: hello
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
         extra: 42
     "#;
     assert!(manifest::from_str(yaml).is_err());
@@ -82,9 +74,7 @@ fn unknown_fields() {
         netsuke_version: "1.0.0"
         targets:
           - name: hello
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
             unexpected: true
     "#;
     assert!(manifest::from_str(yaml).is_err());
@@ -103,7 +93,7 @@ fn empty_lists_and_maps() {
         netsuke_version: "1.0.0"
         targets:
           - name: hello
-            recipe: {}
+            command: {}
     "#;
     assert!(manifest::from_str(yaml).is_err());
 }
@@ -114,9 +104,7 @@ fn string_or_list_variants() {
         netsuke_version: "1.0.0"
         targets:
           - name: hello
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let first = manifest.targets.first().expect("target");
@@ -132,9 +120,7 @@ fn string_or_list_variants() {
           - name:
               - hello
               - world
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let first = manifest.targets.first().expect("target");
@@ -148,9 +134,7 @@ fn string_or_list_variants() {
         netsuke_version: "1.0.0"
         targets:
           - name: []
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let first = manifest.targets.first().expect("target");
@@ -167,16 +151,12 @@ fn optional_fields() {
         netsuke_version: "1.0.0"
         rules:
           - name: compile
-            recipe:
-              kind: command
-              command: cc
+            command: cc
             description: "Compile"
             deps: hello
         targets:
           - name: hello
-            recipe:
-              kind: rule
-              rule: compile
+            rule: compile
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let rule = manifest.rules.first().expect("rule");
@@ -190,14 +170,10 @@ fn optional_fields() {
         netsuke_version: "1.0.0"
         rules:
           - name: compile
-            recipe:
-              kind: command
-              command: cc
+            command: cc
         targets:
           - name: hello
-            recipe:
-              kind: rule
-              rule: compile
+            rule: compile
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let rule = manifest.rules.first().expect("rule");
@@ -211,9 +187,8 @@ fn optional_fields() {
     netsuke_version: "1.0.0"
     targets:
       - name: hello
-        recipe:
-          kind: not_a_kind
-          command: "echo hi"
+        kind: not_a_kind
+        command: "echo hi"
 "#
 )]
 #[case::actions_missing_recipe(
@@ -223,9 +198,7 @@ fn optional_fields() {
       - name: setup
     targets:
       - name: done
-        recipe:
-          kind: command
-          command: "true"
+        command: "true"
 "#
 )]
 fn parsing_failures(#[case] yaml: &str) {
@@ -238,9 +211,7 @@ fn phony_and_always_flags() {
         netsuke_version: "1.0.0"
         targets:
           - name: clean
-            recipe:
-              kind: command
-              command: rm -rf build
+            command: rm -rf build
             phony: true
             always: true
     "#;
@@ -253,9 +224,7 @@ fn phony_and_always_flags() {
         netsuke_version: "1.0.0"
         targets:
           - name: clean
-            recipe:
-              kind: command
-              command: rm -rf build
+            command: rm -rf build
     "#;
     let manifest = manifest::from_str(yaml).expect("parse");
     let target = manifest.targets.first().expect("target");
@@ -269,14 +238,10 @@ fn phony_and_always_flags() {
     netsuke_version: "1.0.0"
     actions:
       - name: setup
-        recipe:
-          kind: command
-          command: "echo hi"
+        command: "echo hi"
     targets:
       - name: done
-        recipe:
-          kind: command
-          command: "true"
+        command: "true"
 "#,
     true,
     false
@@ -286,15 +251,11 @@ fn phony_and_always_flags() {
     netsuke_version: "1.0.0"
     actions:
       - name: setup
-        recipe:
-          kind: command
-          command: "echo hi"
+        command: "echo hi"
         phony: false
     targets:
       - name: done
-        recipe:
-          kind: command
-          command: "true"
+        command: "true"
 "#,
     true,
     false
@@ -304,15 +265,11 @@ fn phony_and_always_flags() {
     netsuke_version: "1.0.0"
     actions:
       - name: setup
-        recipe:
-          kind: command
-          command: "echo hi"
+        command: "echo hi"
         always: true
     targets:
       - name: done
-        recipe:
-          kind: command
-          command: "true"
+        command: "true"
 "#,
     true,
     true
@@ -334,22 +291,14 @@ fn multiple_actions_are_marked_phony() {
         netsuke_version: "1.0.0"
         actions:
           - name: setup
-            recipe:
-              kind: command
-              command: "echo hi"
+            command: "echo hi"
           - name: build
-            recipe:
-              kind: command
-              command: "make build"
+            command: "make build"
           - name: test
-            recipe:
-              kind: command
-              command: "cargo test"
+            command: "cargo test"
         targets:
           - name: done
-            recipe:
-              kind: command
-              command: "true"
+            command: "true"
     "#;
     let manifest = parse_manifest(yaml).expect("parse");
     assert_eq!(manifest.actions.len(), 3);

--- a/tests/data/action_invalid.yml
+++ b/tests/data/action_invalid.yml
@@ -1,10 +1,8 @@
-# This fixture is intentionally invalid. It lacks keys like `recipe` and
-# `phony` so the loader should fail when parsing it.
+# This fixture is intentionally invalid. It lacks a `command` or `rule`
+# so the loader should fail when parsing it.
 netsuke_version: "1.0.0"
 actions:
   - name: setup
 targets:
   - name: done
-    recipe:
-      kind: command
-      command: "true"
+    command: "true"

--- a/tests/data/actions.yml
+++ b/tests/data/actions.yml
@@ -1,11 +1,7 @@
 netsuke_version: "1.0.0"
 actions:
   - name: setup
-    recipe:
-      kind: command
-      command: "echo hi"
+    command: "echo hi"
 targets:
   - name: done
-    recipe:
-      kind: command
-      command: "true"
+    command: "true"

--- a/tests/data/circular.yml
+++ b/tests/data/circular.yml
@@ -2,11 +2,7 @@ netsuke_version: "1.0.0"
 targets:
   - name: a
     sources: b
-    recipe:
-      kind: command
-      command: "touch a"
+    command: "touch a"
   - name: b
     sources: a
-    recipe:
-      kind: command
-      command: "touch b"
+    command: "touch b"

--- a/tests/data/duplicate_outputs.yml
+++ b/tests/data/duplicate_outputs.yml
@@ -2,11 +2,7 @@ netsuke_version: "1.0.0"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
   - name: hello.o
     sources: world.c
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"

--- a/tests/data/duplicate_outputs_multi.yml
+++ b/tests/data/duplicate_outputs_multi.yml
@@ -4,13 +4,9 @@ targets:
       - foo.o
       - bar.o
     sources: foo.c
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
   - name:
       - bar.o
       - foo.o
     sources: bar.c
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"

--- a/tests/data/duplicate_rules.yml
+++ b/tests/data/duplicate_rules.yml
@@ -1,21 +1,13 @@
 netsuke_version: "1.0.0"
 rules:
   - name: compile1
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
   - name: compile2
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule: compile1
+    rule: compile1
   - name: world.o
     sources: world.c
-    recipe:
-      kind: rule
-      rule: compile2
+    rule: compile2

--- a/tests/data/empty_rule.yml
+++ b/tests/data/empty_rule.yml
@@ -2,6 +2,4 @@ netsuke_version: "1.0.0"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule: []
+    rule: []

--- a/tests/data/invalid_version.yml
+++ b/tests/data/invalid_version.yml
@@ -1,6 +1,4 @@
 netsuke_version: "1"
 targets:
   - name: hi
-    recipe:
-      kind: command
-      command: "echo hi"
+    command: "echo hi"

--- a/tests/data/minimal.yml
+++ b/tests/data/minimal.yml
@@ -1,6 +1,4 @@
 netsuke_version: "1.0.0"
 targets:
   - name: hello
-    recipe:
-      kind: command
-      command: "echo hi"
+    command: "echo hi"

--- a/tests/data/missing_rule.yml
+++ b/tests/data/missing_rule.yml
@@ -2,6 +2,4 @@ netsuke_version: "1.0.0"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule: missing
+    rule: missing

--- a/tests/data/multiple_rules_per_target.yml
+++ b/tests/data/multiple_rules_per_target.yml
@@ -1,18 +1,12 @@
 netsuke_version: "1.0.0"
 rules:
   - name: compile1
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
   - name: compile2
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule:
-        - compile1
-        - compile2
+    rule:
+      - compile1
+      - compile2

--- a/tests/data/phony.yml
+++ b/tests/data/phony.yml
@@ -1,8 +1,6 @@
 netsuke_version: "1.0.0"
 targets:
   - name: clean
-    recipe:
-      kind: command
-      command: "rm -rf build"
+    command: "rm -rf build"
     phony: true
     always: true

--- a/tests/data/rule_not_found.yml
+++ b/tests/data/rule_not_found.yml
@@ -2,6 +2,4 @@ netsuke_version: "1.0.0"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule: missing_rule
+    rule: missing_rule

--- a/tests/data/rules.yml
+++ b/tests/data/rules.yml
@@ -1,13 +1,9 @@
 netsuke_version: "1.0.0"
 rules:
   - name: compile
-    recipe:
-      kind: command
-      command: "cc -c $in -o $out"
+    command: "cc -c $in -o $out"
 targets:
   - name: hello.o
     sources: hello.c
-    recipe:
-      kind: rule
-      rule: compile
+    rule: compile
 

--- a/tests/data/unknown_field.yml
+++ b/tests/data/unknown_field.yml
@@ -2,6 +2,4 @@ netsuke_version: "1.0.0"
 extra: field
 targets:
   - name: hi
-    recipe:
-      kind: command
-      command: "echo hi"
+    command: "echo hi"

--- a/tests/ninja_snapshot_tests.rs
+++ b/tests/ninja_snapshot_tests.rs
@@ -31,15 +31,11 @@ fn touch_manifest_ninja_validation() {
         netsuke_version: "1.0.0"
         rules:
           - name: touch
-            recipe:
-              kind: command
-              command: "python3 -c 'import os,sys; open(sys.argv[1],\"a\").close()' $out"
+            command: "python3 -c 'import os,sys; open(sys.argv[1],\"a\").close()' $out"
         targets:
           - name: out/a
             sources: in/a
-            recipe:
-              kind: rule
-              rule: touch
+            rule: touch
     "#;
 
     let manifest = manifest::from_str(manifest_yaml).expect("parse manifest");


### PR DESCRIPTION
## Summary
- allow top-level command/script/rule fields instead of nested recipe kind blocks
- update documentation and tests to match the streamlined manifest syntax

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make nixie` *(fails: failed copying files from cache to destination for package @mermaid-js/mermaid-cli)*


------
https://chatgpt.com/codex/tasks/task_e_6891af74508c8322a0aee165f115ab68

## Summary by Sourcery

Simplify manifest syntax by flattening recipe fields so that command, script, or rule keys appear directly at the top level of targets, rules, and actions, and by implementing custom untagged deserialization for the Recipe enum to enforce mutual exclusivity.

New Features:
- Allow top-level `command`, `script`, and `rule` fields instead of nested `recipe` blocks for targets, rules, and actions.

Enhancements:
- Remove serde `kind` tagging on the Recipe enum and add `#[serde(flatten)]` to embed its fields directly into Rule and Target structs.
- Implement custom untagged deserialization for Recipe to ensure exactly one of command, script, or rule is specified.

Documentation:
- Update documentation and examples to reflect the simplified, untagged manifest syntax.

Tests:
- Revise parsing tests and YAML fixtures to use the new top-level recipe fields across all test data.