### PR TITLE
Replace allow with expect in test support

### DIFF
--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -74,7 +74,7 @@ where
 /// specified as the first argument.
 ///
 /// Returns the temporary directory and the path to the executable.
-#[allow(dead_code, reason = "used only in directory tests")]
+#[expect(dead_code, reason = "used only in directory tests")]
 pub fn fake_ninja_pwd() -> (TempDir, PathBuf) {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join("ninja");


### PR DESCRIPTION
## Summary
- replace deprecated `#[allow]` with `#[expect]` for lint suppression in `fake_ninja_pwd`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68924a9b08e48322bf909b03ef0e9714

## Summary by Sourcery

Enhancements:
- Replace #[allow(dead_code)] with #[expect(dead_code)] in tests/support to use the updated lint suppression attribute