### PR TITLE
Emit Ninja manifest for Netsukefile test assertions

### DIFF
--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -51,18 +51,28 @@ jobs:
               command: "touch unused.txt"
           MANIFEST
       - name: Build dependent and inline targets
-        run: ./target/debug/netsuke --verbose build dependent.txt inline-command.txt inline-script.txt
+        run: ./target/debug/netsuke --verbose build --emit build.ninja dependent.txt inline-command.txt inline-script.txt
       - name: Assert dependent artefacts exist
+        env:
+          NINJA_MANIFEST: build.ninja
         run: |
           scripts/assert-file-exists.sh base.txt
           scripts/assert-file-exists.sh dependent.txt
       - name: Assert inline command artefact exists
+        env:
+          NINJA_MANIFEST: build.ninja
         run: scripts/assert-file-exists.sh inline-command.txt
       - name: Assert inline script artefact exists
+        env:
+          NINJA_MANIFEST: build.ninja
         run: scripts/assert-file-exists.sh inline-script.txt
       - name: Run action target
-        run: ./target/debug/netsuke --verbose build say-hello
+        run: ./target/debug/netsuke --verbose build --emit action.ninja say-hello
       - name: Assert action artefact exists
+        env:
+          NINJA_MANIFEST: action.ninja
         run: scripts/assert-file-exists.sh action-called.txt
       - name: Assert unused action artefact absent
-        run: test ! -f unused.txt
+        env:
+          NINJA_MANIFEST: action.ninja
+        run: scripts/assert-file-absent.sh unused.txt

--- a/scripts/assert-file-absent.sh
+++ b/scripts/assert-file-absent.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $(basename "$0") <file>" >&2
-  exit 64   # EX_USAGE
+  exit 2   # usage error
 fi
 
 file="$1"

--- a/scripts/assert-file-absent.sh
+++ b/scripts/assert-file-absent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensures the Netsuke build produced the expected artefact.
-# If the artefact is absent and `NINJA_MANIFEST` is set, the referenced
+# Ensures the Netsuke build did not produce an unexpected artefact.
+# If the artefact is present and `NINJA_MANIFEST` is set, the referenced
 # Ninja manifest is dumped to stderr for debugging.
 set -euo pipefail
 
@@ -11,8 +11,8 @@ fi
 
 file="$1"
 
-if [[ ! -f "$file" ]]; then
-  echo "Expected build artefact '$file' to exist." >&2
+if [[ -f "$file" ]]; then
+  echo "Unexpected build artefact '$file' present." >&2
   if [[ -n "${NINJA_MANIFEST:-}" && -f "$NINJA_MANIFEST" ]]; then
     echo "Ninja manifest '$NINJA_MANIFEST' for debugging:" >&2
     echo "-----BEGIN NINJA MANIFEST-----" >&2


### PR DESCRIPTION
## Summary
- persist Ninja manifests during Netsukefile workflow tests using `--emit`
- dump Ninja manifest when an artefact assertion fails
- extract unused artefact assertion into script

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68929bba61548322b4639fd00b23c911

## Summary by Sourcery

Enhance the Netsukefile test workflows to emit and persist Ninja manifests, improve assertion scripts to dump manifests on failure, and introduce a dedicated script for absent artefact checks.

Enhancements:
- Persist and emit Ninja manifests during Netsukefile test builds for improved debugging

CI:
- Update GitHub Actions test workflow to emit Ninja manifests for build steps and set NINJA_MANIFEST for assertion steps

Tests:
- Augment assert-file-exists.sh to dump the Ninja manifest on artefact check failures
- Add assert-file-absent.sh script for verifying unexpected artefacts and integrate it into the CI workflow