### PR TITLE
Refactor build CLI into dedicated args

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1348,9 +1348,7 @@ entire CLI specification.
 Rust
 
 ```rust
-use clap::{Parser, Subcommand};
-
-use std::path::PathBuf;
+use clap::{Args, Parser, Subcommand}; use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -1375,22 +1373,25 @@ struct Cli { /// Path to the Netsuke manifest file to use.
 
 #[derive(Subcommand)]
 enum Commands { /// Build specified targets (or default targets if none are
-given) [default]. Build { /// Write the generated Ninja manifest to this path
-and retain it.
-        #[arg(long, value_name = "FILE")]
-        emit: Option<PathBuf>,
+given) [default]. Build(BuildArgs),
 
-        /// A list of specific targets to build. targets: Vec<String>, },
-
-    /// Remove build artefacts and intermediate files. Clean {},
+    /// Remove build artefacts and intermediate files. Clean,
 
     /// Display the build dependency graph in DOT format for visualisation.
-    Graph {},
+    Graph,
 
     /// Write the Ninja manifest to `FILE` without invoking Ninja. Manifest {
     /// Output path for the generated Ninja file.
         #[arg(value_name = "FILE")]
         file: PathBuf, }, }
+
+#[derive(Args)]
+struct BuildArgs { /// Write the generated Ninja manifest to this path and
+retain it.
+    #[arg(long, value_name = "FILE")]
+    emit: Option<PathBuf>,
+
+    /// A list of specific targets to build. targets: Vec<String>, }
 ```
 
 *Note: The* `Build` *command is wrapped in an* `Option<Commands>` *and will be

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@
 //! This module defines the [`Cli`] structure and its subcommands.
 //! It mirrors the design described in `docs/netsuke-design.md`.
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 /// Maximum number of jobs accepted by the CLI.
@@ -71,27 +71,31 @@ impl Cli {
     #[must_use]
     fn with_default_command(mut self) -> Self {
         if self.command.is_none() {
-            self.command = Some(Commands::Build {
+            self.command = Some(Commands::Build(BuildArgs {
                 emit: None,
                 targets: Vec::new(),
-            });
+            }));
         }
         self
     }
+}
+
+/// Arguments accepted by the `build` command.
+#[derive(Debug, Args, PartialEq, Eq, Clone)]
+pub struct BuildArgs {
+    /// Write the generated Ninja manifest to this path and retain it.
+    #[arg(long, value_name = "FILE")]
+    pub emit: Option<PathBuf>,
+
+    /// A list of specific targets to build.
+    pub targets: Vec<String>,
 }
 
 /// Available top-level commands for Netsuke.
 #[derive(Debug, Subcommand, PartialEq, Eq, Clone)]
 pub enum Commands {
     /// Build specified targets (or default targets if none are given) [default].
-    Build {
-        /// Write the generated Ninja manifest to this path and retain it.
-        #[arg(long, value_name = "FILE")]
-        emit: Option<PathBuf>,
-
-        /// A list of specific targets to build.
-        targets: Vec<String>,
-    },
+    Build(BuildArgs),
 
     /// Remove build artifacts and intermediate files.
     Clean,

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -4,28 +4,28 @@
 //! using `rstest` for parameterised coverage of success and error scenarios.
 use clap::Parser;
 use clap::error::ErrorKind;
-use netsuke::cli::{Cli, Commands};
+use netsuke::cli::{BuildArgs, Cli, Commands};
 use rstest::rstest;
 use std::path::PathBuf;
 
 #[rstest]
-#[case(vec!["netsuke"], PathBuf::from("Netsukefile"), None, None, false, Commands::Build { emit: None, targets: Vec::new() })]
+#[case(vec!["netsuke"], PathBuf::from("Netsukefile"), None, None, false, Commands::Build(BuildArgs { emit: None, targets: Vec::new() }))]
 #[case(
     vec!["netsuke", "--file", "alt.yml", "-C", "work", "-j", "4", "build", "a", "b"],
     PathBuf::from("alt.yml"),
     Some(PathBuf::from("work")),
     Some(4),
     false,
-    Commands::Build { emit: None, targets: vec!["a".into(), "b".into()] },
+    Commands::Build(BuildArgs { emit: None, targets: vec!["a".into(), "b".into()] }),
 )]
-#[case(vec!["netsuke", "--verbose"], PathBuf::from("Netsukefile"), None, None, true, Commands::Build { emit: None, targets: Vec::new() })]
+#[case(vec!["netsuke", "--verbose"], PathBuf::from("Netsukefile"), None, None, true, Commands::Build(BuildArgs { emit: None, targets: Vec::new() }))]
 #[case(
     vec!["netsuke", "build", "--emit", "out.ninja", "a"],
     PathBuf::from("Netsukefile"),
     None,
     None,
     false,
-    Commands::Build { emit: Some(PathBuf::from("out.ninja")), targets: vec!["a".into()] },
+    Commands::Build(BuildArgs { emit: Some(PathBuf::from("out.ninja")), targets: vec!["a".into()] }),
 )]
 #[case(
     vec!["netsuke", "manifest", "out.ninja"],

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,4 +1,4 @@
-use netsuke::cli::{Cli, Commands};
+use netsuke::cli::{BuildArgs, Cli, Commands};
 use netsuke::runner::{BuildTargets, run, run_ninja};
 use rstest::rstest;
 use serial_test::serial;
@@ -16,10 +16,10 @@ fn run_exits_with_manifest_error_on_invalid_version() {
         directory: None,
         jobs: None,
         verbose: false,
-        command: Some(Commands::Build {
+        command: Some(Commands::Build(BuildArgs {
             emit: None,
             targets: vec![],
-        }),
+        })),
     };
 
     let result = run(&cli);
@@ -35,10 +35,10 @@ fn run_ninja_not_found() {
         directory: None,
         jobs: None,
         verbose: false,
-        command: Some(Commands::Build {
+        command: Some(Commands::Build(BuildArgs {
             emit: None,
             targets: vec![],
-        }),
+        })),
     };
     let targets = BuildTargets::new(vec![]);
     let err = run_ninja(
@@ -71,10 +71,10 @@ fn run_executes_ninja_without_persisting_file() {
         directory: Some(temp.path().to_path_buf()),
         jobs: None,
         verbose: false,
-        command: Some(Commands::Build {
+        command: Some(Commands::Build(BuildArgs {
             emit: None,
             targets: vec![],
-        }),
+        })),
     };
 
     let result = run(&cli);
@@ -111,10 +111,10 @@ fn run_build_with_emit_keeps_file() {
         directory: Some(temp.path().to_path_buf()),
         jobs: None,
         verbose: false,
-        command: Some(Commands::Build {
+        command: Some(Commands::Build(BuildArgs {
             emit: Some(emit_path.clone()),
             targets: vec![],
-        }),
+        })),
     };
 
     let result = run(&cli);

--- a/tests/steps/cli_steps.rs
+++ b/tests/steps/cli_steps.rs
@@ -6,7 +6,7 @@
 use crate::CliWorld;
 use clap::Parser;
 use cucumber::{given, then, when};
-use netsuke::cli::{Cli, Commands};
+use netsuke::cli::{BuildArgs, Cli, Commands};
 use std::path::PathBuf;
 
 fn apply_cli(world: &mut CliWorld, args: &str) {
@@ -16,10 +16,10 @@ fn apply_cli(world: &mut CliWorld, args: &str) {
     match Cli::try_parse_from(tokens) {
         Ok(mut cli) => {
             if cli.command.is_none() {
-                cli.command = Some(Commands::Build {
+                cli.command = Some(Commands::Build(BuildArgs {
                     emit: None,
                     targets: Vec::new(),
-                });
+                }));
             }
             world.cli = Some(cli);
             world.cli_error = None;
@@ -34,7 +34,7 @@ fn apply_cli(world: &mut CliWorld, args: &str) {
 fn extract_build(world: &CliWorld) -> Option<(&Vec<String>, &Option<PathBuf>)> {
     let cli = world.cli.as_ref()?;
     match cli.command.as_ref()? {
-        Commands::Build { targets, emit } => Some((targets, emit)),
+        Commands::Build(args) => Some((&args.targets, &args.emit)),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- model build subcommand with `BuildArgs` struct and explicit `--emit`
- adjust runner and tests for new `Commands::Build(BuildArgs)` pattern
- document revised CLI in design notes

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `./target/debug/netsuke --file tests/data/minimal.yml --verbose build --emit /tmp/out.ninja hello`


------
https://chatgpt.com/codex/tasks/task_e_68930362753c832284a53f268ffc83bd