### PR TITLE
Replace unstable let chain in cycle detection

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -341,9 +341,11 @@ fn find_cycle(targets: &HashMap<PathBuf, BuildEdge>) -> Option<Vec<PathBuf>> {
         states: &mut HashMap<PathBuf, VisitState>,
     ) -> Option<Vec<PathBuf>> {
         for dep in deps {
-            if targets.contains_key(dep)
-                && let Some(cycle) = visit(targets, dep, stack, states)
-            {
+            if !targets.contains_key(dep) {
+                continue;
+            }
+
+            if let Some(cycle) = visit(targets, dep, stack, states) {
                 return Some(cycle);
             }
         }


### PR DESCRIPTION
## Summary
- rewrite dependency visitation to avoid unstable `let` chain

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893db17e0b08322bba652cebcb267fa

## Summary by Sourcery

Enhancements:
- Refactor cycle detection to remove unstable let chain and clarify control flow in visit logic