### PR TITLE
Clean workflow cache before build

### DIFF
--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -26,6 +26,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
+      - name: Clean build artefacts
+        run: make clean
       - name: Build Netsuke
         run: make build
       - name: Create Netsukefile


### PR DESCRIPTION
## Summary
- run `make clean` in Netsukefile test workflow to drop cached `target` artifacts

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68949b12c4308322b7eb5406362d4be0

## Summary by Sourcery

Enhancements:
- Add a step to clean build artifacts by running `make clean` before building in the netsukefile-test workflow