### PR TITLE
Encode script newlines in Ninja manifest

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1348,13 +1348,11 @@ entire CLI specification.
 Rust
 
 ```rust
-use clap::{Args, Parser, Subcommand};
-use std::path::PathBuf;
+use clap::{Args, Parser, Subcommand}; use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-struct Cli {
-    /// Path to the Netsuke manifest file to use.
+struct Cli { /// Path to the Netsuke manifest file to use.
     #[arg(short, long, value_name = "FILE", default_value = "Netsukefile")]
     file: PathBuf,
 
@@ -1371,38 +1369,29 @@ struct Cli {
     verbose: bool,
 
     #[command(subcommand)]
-    command: Option<Commands>,
-}
+    command: Option<Commands>, }
 
 #[derive(Subcommand)]
-enum Commands {
-    /// Build specified targets (or default targets if none are given).
-    /// This is the default subcommand.
-    Build(BuildArgs),
+enum Commands { /// Build specified targets (or default targets if none are
+given). /// This is the default subcommand. Build(BuildArgs),
 
-    /// Remove build artefacts and intermediate files.
-    Clean,
+    /// Remove build artefacts and intermediate files. Clean,
 
     /// Display the build dependency graph in DOT format for visualisation.
     Graph,
 
-    /// Write the Ninja manifest to `FILE` without invoking Ninja.
-    Manifest {
-        /// Output path for the generated Ninja file.
+    /// Write the Ninja manifest to `FILE` without invoking Ninja. Manifest {
+    /// Output path for the generated Ninja file.
         #[arg(value_name = "FILE")]
-        file: PathBuf,
-    },
-}
+        file: PathBuf, }, }
 
 #[derive(Args)]
-struct BuildArgs {
-    /// Write the generated Ninja manifest to this path and retain it.
+struct BuildArgs { /// Write the generated Ninja manifest to this path and
+retain it.
     #[arg(long, value_name = "FILE")]
     emit: Option<PathBuf>,
 
-    /// A list of specific targets to build.
-    targets: Vec<String>,
-}
+    /// A list of specific targets to build. targets: Vec<String>, }
 ```
 
 *Note: The* `Build` *command is wrapped in an* `Option<Commands>` *and will be

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -86,16 +86,18 @@ fn path_key(paths: &[PathBuf]) -> String {
 
 /// Escape a script for embedding within a single-quoted `printf %b` argument.
 ///
-/// Backslashes, single quotes, and backticks are escaped so the outer shell
-/// preserves them, while newlines become `\n` to keep the rule on one line.
-/// Percent and dollar signs are passed through unchanged because the script is
-/// an argument rather than a format string, allowing the inner shell to
-/// perform variable expansion.
+/// Backslashes, dollar signs, double quotes, backticks, and single quotes are
+/// escaped so the outer shell preserves them, while newlines become `\n` to
+/// keep the rule on one line. Percent signs are passed through unchanged because
+/// the script is an argument rather than a format string, allowing the inner
+/// shell to perform variable expansion.
 fn escape_script(script: &str) -> String {
     script
         .replace('\\', "\\\\")
-        .replace('\'', "'\"'\"'")
+        .replace('$', "\\$")
+        .replace('"', "\\\"")
         .replace('`', "\\`")
+        .replace('\'', "'\"'\"'")
         .replace('\n', "\\n")
 }
 

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -86,17 +86,16 @@ fn path_key(paths: &[PathBuf]) -> String {
 
 /// Escape a script for embedding within a single-quoted `printf %b` argument.
 ///
-/// Backslashes and single quotes are escaped so the outer shell preserves
-/// them, while newlines become `\n` to keep the rule on one line. Percent
-/// signs, dollar signs, and backticks are passed through unchanged because the
-/// script is an argument rather than a format string, allowing the inner shell
-/// to perform variable expansion and command substitution.
+/// Backslashes, single quotes, and backticks are escaped so the outer shell
+/// preserves them, while newlines become `\n` to keep the rule on one line.
+/// Percent and dollar signs are passed through unchanged because the script is
+/// an argument rather than a format string, allowing the inner shell to
+/// perform variable expansion.
 fn escape_script(script: &str) -> String {
     script
         .replace('\\', "\\\\")
         .replace('\'', "'\"'\"'")
-        // Backticks remain unescaped to allow command substitution when the
-        // script executes.
+        .replace('`', "\\`")
         .replace('\n', "\\n")
 }
 

--- a/tests/ninja_gen_tests.rs
+++ b/tests/ninja_gen_tests.rs
@@ -4,6 +4,7 @@
 //! with multiple inputs and outputs, complex dependency relationships, and
 //! edge cases like empty build graphs.
 
+use insta::{Settings, assert_snapshot};
 use netsuke::ast::Recipe;
 use netsuke::ir::{Action, BuildEdge, BuildGraph};
 use netsuke::ninja_gen::generate;
@@ -147,6 +148,14 @@ fn generate_multiline_script_valid() {
     graph.default_targets.push(PathBuf::from("out"));
 
     let ninja = generate(&graph);
+    let mut settings = Settings::new();
+    settings.set_snapshot_path(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/snapshots/ninja",
+    ));
+    settings.bind(|| {
+        assert_snapshot!("multiline_script_ninja", &ninja);
+    });
     let lines: Vec<&str> = ninja.lines().collect();
     let command_line = lines.get(1).expect("command line");
     assert!(

--- a/tests/snapshots/ninja/ninja_gen_tests__multiline_script_ninja.snap
+++ b/tests/snapshots/ninja/ninja_gen_tests__multiline_script_ninja.snap
@@ -1,0 +1,11 @@
+---
+source: tests/ninja_gen_tests.rs
+assertion_line: 157
+expression: "&ninja"
+---
+rule script
+  command = /bin/sh -e -c "printf %b \"echo one\necho two\" | /bin/sh -e"
+
+build out: script
+
+default out

--- a/tests/snapshots/ninja/ninja_gen_tests__multiline_script_ninja.snap
+++ b/tests/snapshots/ninja/ninja_gen_tests__multiline_script_ninja.snap
@@ -1,10 +1,10 @@
 ---
 source: tests/ninja_gen_tests.rs
-assertion_line: 157
+assertion_line: 176
 expression: "&ninja"
 ---
 rule script
-  command = /bin/sh -e -c "printf %b \"echo one\necho two\" | /bin/sh -e"
+  command = /bin/sh -e -c "printf %b 'echo one\necho two' | /bin/sh -e"
 
 build out: script
 


### PR DESCRIPTION
## Summary
- Encode newlines in `Recipe::Script` so Ninja rules stay single-line and reconstruct scripts via `printf %b`
- Add regression test for multi-line scripts to ensure generated Ninja manifests parse

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894b1d8f5708322ad367964b1bd502e

## Summary by Sourcery

Encode multiline scripts in Ninja manifests by escaping newlines and reconstructing them via `printf %b` to maintain single-line rules, and add a regression test to verify that generated manifests parse correctly.

Enhancements:
- Escape backslashes, dollar signs, quotes, and newlines in `Recipe::Script` and wrap commands with `printf %b` piped into `/bin/sh -e` to keep Ninja rules single-line

Tests:
- Add regression test that generates a multiline script, checks for `\n` encoding, and runs Ninja with `-n` to ensure the manifest is valid