### PR TITLE
Handle ActionHasher::hash result in example

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -19,7 +19,7 @@
 //!     pool: None,
 //!     restat: false,
 //! };
-//! let hash = ActionHasher::hash(&action);
+//! let hash = ActionHasher::hash(&action).expect("hash action");
 //! assert!(!hash.is_empty());
 //! ```
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -19,7 +19,7 @@
 //!     pool: None,
 //!     restat: false,
 //! };
-//! let hash = ActionHasher::hash(&action).expect("hash action");
+//! let hash = ActionHasher::hash(&action).expect("failed to hash action");
 //! assert!(!hash.is_empty());
 //! ```
 


### PR DESCRIPTION
## Summary
- handle `ActionHasher::hash` result in documentation example

## Testing
- `make lint`
- `make test`
- `make fmt` *(fails: AGENTS.md:153 MD040/fenced-code-language)*

------
https://chatgpt.com/codex/tasks/task_e_6895d8a46d10832294bf1627b19d461a

## Summary by Sourcery

Documentation:
- Add `.expect("hash action")` to the ActionHasher::hash call in the example to unwrap the Result