### PR TITLE
Support Jinja control flow in manifests

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -161,9 +161,9 @@ level keys.
   future evolution of the schema while maintaining backward compatibility. This
   version string should be parsed and validated using the `semver` crate.[^4]
 
-- `vars`: A mapping of global key-value string pairs. These variables are
-  available for substitution in rule commands and target definitions and are
-  exposed to the Jinja templating context.
+- `vars`: A mapping of global key-value pairs. Values may be strings, numbers,
+  booleans, or sequences. These variables seed the Jinja templating context and
+  drive control flow within the manifest.
 
 - `macros`: An optional list of Jinja macro definitions. Each item provides a
   `signature` string using standard Jinja syntax and a `body` declared with the
@@ -414,7 +414,7 @@ pub struct NetsukeManifest {
     pub netsuke_version: Version,
 
     #[serde(default)]
-    pub vars: HashMap<String, String>,
+    pub vars: HashMap<String, serde_yml::Value>,
 
     #[serde(default)]
     pub rules: Vec<Rule>,
@@ -466,7 +466,7 @@ pub struct Target {
     pub order_only_deps: StringOrList,
 
     #[serde(default)]
-    pub vars: HashMap<String, String>,
+    pub vars: HashMap<String, serde_yml::Value>,
 
     /// Run this target when requested even if a file with the same name exists.
     #[serde(default)]
@@ -585,15 +585,14 @@ Unknown fields are rejected to surface user errors early. `StringOrList`
 provides a default `Empty` variant, so optional lists are trivial to represent.
 The manifest version is parsed using the `semver` crate to validate that it
 follows semantic versioning rules. Global and target variable maps now share
-the `HashMap<String, String>` type for consistency. This keeps YAML manifests
-concise while ensuring forward compatibility. Targets also accept optional
-`phony` and `always` booleans. They default to `false`, making it explicit when
-an action should run regardless of file timestamps. Targets listed in the
-`actions` section are deserialised using a custom helper so they are always
-treated as `phony` tasks. This ensures preparation actions never generate build
-artefacts. Convenience functions in `src/manifest.rs` load a manifest from a
-string or a file path, returning `anyhow::Result` for straightforward error
-handling.
+the `HashMap<String, serde_yml::Value>` type so booleans and sequences are
+preserved for Jinja control flow. Targets also accept optional `phony` and
+`always` booleans. They default to `false`, making it explicit when an action
+should run regardless of file timestamps. Targets listed in the `actions`
+section are deserialised using a custom helper so they are always treated as
+`phony` tasks. This ensures preparation actions never generate build artefacts.
+Convenience functions in `src/manifest.rs` load a manifest from a string or a
+file path, returning `anyhow::Result` for straightforward error handling.
 
 ### 3.5 Testing
 
@@ -665,6 +664,12 @@ placeholders elsewhere in the template, Netsuke first renders the manifest with
 lenient undefined behaviour. The resulting YAML is parsed to obtain the global
 variables, which are then injected into the environment before a second, strict
 render pass produces the final manifest for deserialisation.
+
+The parser copies `vars` values into the environment using
+`Value::from_serializable`. This preserves native YAML types so Jinja's
+`{% if %}` and `{% for %}` constructs can branch on booleans or iterate over
+sequences. Attempting to iterate over a non-sequence results in a render error
+surfaced during manifest loading.
 
 ### 4.3 User-Defined Macros
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,9 +88,9 @@ configurations with variables, control flow, and custom functions.
 
 - [ ] **Dynamic Features and Custom Functions:**
 
-  - [ ] Implement support for basic Jinja control structures (`{% if %}` and
-        `{% for %}`) 
-    
+  - [x] Implement support for basic Jinja control structures (`{% if %}` and
+        `{% for %}`)
+
   - [ ] Implement the foreach key for target generation.
 
   - [ ] Implement the essential custom Jinja function env(var_name) to read

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -61,7 +61,7 @@ pub struct NetsukeManifest {
 
     /// Global key/value pairs available to recipes.
     #[serde(default)]
-    pub vars: HashMap<String, String>,
+    pub vars: HashMap<String, serde_yml::Value>,
 
     /// Named rule templates that can be referenced by targets.
     #[serde(default)]
@@ -187,7 +187,7 @@ pub struct Target {
 
     /// Target-scoped variables available during command execution.
     #[serde(default)]
-    pub vars: HashMap<String, String>,
+    pub vars: HashMap<String, serde_yml::Value>,
 
     /// Declares that the target does not correspond to a real file.
     #[serde(default)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -7,7 +7,7 @@
 use crate::ast::NetsukeManifest;
 use anyhow::{Context, Result};
 use minijinja::{Environment, UndefinedBehavior, context, value::Value};
-use std::{collections::HashMap, fs, path::Path};
+use std::{fs, path::Path};
 
 /// Parse a manifest string using Jinja for templating.
 ///
@@ -48,22 +48,15 @@ pub fn from_str(yaml: &str) -> Result<NetsukeManifest> {
 
     let doc: serde_yml::Value =
         serde_yml::from_str(&rendered).context("first-pass YAML parse error")?;
-    let vars = doc
-        .get("vars")
-        .and_then(|v| v.as_mapping())
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| k.as_str().and_then(|key| v.as_str().map(|val| (key, val))))
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
-
-    // Populate the environment with the extracted variables for subsequent
-    // rendering. Undefined variables now trigger errors to surface template
-    // mistakes early.
-    for (key, value) in vars {
-        env.add_global(key, Value::from(value));
+    if let Some(vars) = doc.get("vars").and_then(|v| v.as_mapping()) {
+        // Copy each key-value pair into the environment, preserving native YAML
+        // types so control structures like `{% if %}` and `{% for %}` can operate
+        // on booleans and sequences.
+        for (k, v) in vars {
+            if let Some(key) = k.as_str() {
+                env.add_global(key, Value::from_serialize(v.clone()));
+            }
+        }
     }
 
     env.set_undefined_behavior(UndefinedBehavior::Strict);

--- a/tests/data/jinja_for.yml
+++ b/tests/data/jinja_for.yml
@@ -1,0 +1,10 @@
+netsuke_version: 1.0.0
+vars:
+  items:
+    - foo
+    - bar
+targets:
+{% for item in items %}
+  - name: "{{ item }}"
+    command: "echo {{ item }}"
+{% endfor %}

--- a/tests/data/jinja_for_invalid.yml
+++ b/tests/data/jinja_for_invalid.yml
@@ -1,0 +1,8 @@
+netsuke_version: 1.0.0
+vars:
+  items: 1
+targets:
+{% for item in items %}
+  - name: "{{ item }}"
+    command: "echo {{ item }}"
+{% endfor %}

--- a/tests/data/jinja_if.yml
+++ b/tests/data/jinja_if.yml
@@ -1,0 +1,6 @@
+netsuke_version: 1.0.0
+vars:
+  enable: true
+targets:
+  - name: hello
+    command: "{% if enable %}echo on{% else %}echo off{% endif %}"

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -55,3 +55,20 @@ Feature: Manifest Parsing
     Given the manifest file "tests/data/jinja_undefined.yml" is parsed
     When the parsing result is checked
     Then parsing the manifest fails
+
+  Scenario: Rendering Jinja conditionals in a manifest
+    Given the manifest file "tests/data/jinja_if.yml" is parsed
+    When the manifest is checked
+    Then the first target command is "echo on"
+
+  Scenario: Rendering Jinja loops in a manifest
+    Given the manifest file "tests/data/jinja_for.yml" is parsed
+    When the manifest is checked
+    Then the manifest has 2 targets
+    And the target 1 command is "echo foo"
+    And the target 2 command is "echo bar"
+
+  Scenario: Parsing fails when a Jinja loop iterates over a non-list
+    Given the manifest file "tests/data/jinja_for_invalid.yml" is parsed
+    When the parsing result is checked
+    Then parsing the manifest fails

--- a/tests/manifest_jinja_tests.rs
+++ b/tests/manifest_jinja_tests.rs
@@ -46,3 +46,72 @@ targets:
 
     assert!(manifest::from_str(yaml).is_err());
 }
+
+#[rstest]
+#[case(true, "echo on")]
+#[case(false, "echo off")]
+fn renders_if_blocks(#[case] flag: bool, #[case] expected: &str) {
+    let yaml = format!(
+        concat!(
+            "netsuke_version: 1.0.0\n",
+            "vars:\n",
+            "  flag: {flag}\n",
+            "targets:\n",
+            "  - name: test\n",
+            "    command: {{% if flag %}}echo on{{% else %}}echo off{{% endif %}}\n"
+        ),
+        flag = flag
+    );
+
+    let manifest = manifest::from_str(&yaml).expect("parse");
+    let first = manifest.targets.first().expect("target");
+    if let Recipe::Command { command } = &first.recipe {
+        assert_eq!(command, expected);
+    } else {
+        panic!("Expected command recipe, got: {:?}", first.recipe);
+    }
+}
+
+#[rstest]
+fn renders_for_loops() {
+    let yaml = r#"
+netsuke_version: 1.0.0
+vars:
+  items:
+    - a
+    - b
+targets:
+{% for item in items %}
+  - name: "{{ item }}"
+    command: "echo {{ item }}"
+{% endfor %}
+"#;
+
+    let manifest = manifest::from_str(yaml).expect("parse");
+    assert_eq!(manifest.targets.len(), 2);
+    let names: Vec<_> = manifest
+        .targets
+        .iter()
+        .map(|t| match &t.name {
+            netsuke::ast::StringOrList::String(s) => s.clone(),
+            other => panic!("Expected String, got: {other:?}"),
+        })
+        .collect();
+    assert_eq!(names, vec!["a", "b"]);
+}
+
+#[rstest]
+fn for_loop_non_iterable_errors() {
+    let yaml = r#"
+netsuke_version: 1.0.0
+vars:
+  items: 1
+targets:
+{% for item in items %}
+  - name: "{{ item }}"
+    command: "echo {{ item }}"
+{% endfor %}
+"#;
+
+    assert!(manifest::from_str(yaml).is_err());
+}

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -116,3 +116,36 @@ fn first_target_command(world: &mut CliWorld, command: String) {
         panic!("Expected command recipe, got: {:?}", first.recipe);
     }
 }
+
+#[then(expr = "the manifest has {int} targets")]
+fn manifest_has_targets(world: &mut CliWorld, count: usize) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    assert_eq!(manifest.targets.len(), count);
+}
+
+#[then(expr = "the target {int} name is {string}")]
+fn target_name_n(world: &mut CliWorld, index: usize, name: String) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    let target = manifest
+        .targets
+        .get(index - 1)
+        .unwrap_or_else(|| panic!("missing target {index}"));
+    match &target.name {
+        StringOrList::String(value) => assert_eq!(value, &name),
+        other => panic!("Expected StringOrList::String, got: {other:?}"),
+    }
+}
+
+#[then(expr = "the target {int} command is {string}")]
+fn target_command_n(world: &mut CliWorld, index: usize, command: String) {
+    let manifest = world.manifest.as_ref().expect("manifest");
+    let target = manifest
+        .targets
+        .get(index - 1)
+        .unwrap_or_else(|| panic!("missing target {index}"));
+    if let Recipe::Command { command: actual } = &target.recipe {
+        assert_eq!(actual, &command);
+    } else {
+        panic!("Expected command recipe, got: {:?}", target.recipe);
+    }
+}


### PR DESCRIPTION
## Summary
- allow non-string `vars` so Jinja `{% if %}` and `{% for %}` blocks can drive manifest generation
- exercise conditional and loop rendering via unit and cucumber tests
- document the design decision and mark roadmap item as complete

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68968181f9508322907fa84a09dcddf3