### PR TITLE
Inject environment into Cucumber world for isolated tests

### DIFF
--- a/tests/cli_world_tests.rs
+++ b/tests/cli_world_tests.rs
@@ -1,0 +1,27 @@
+//! Tests for environment restoration in `CliWorld`.
+
+mod world;
+use mockable::MockEnv;
+use world::CliWorld;
+
+#[test]
+fn drop_restores_path() {
+    let original = std::env::var("PATH").unwrap_or_default();
+    {
+        let mut env = MockEnv::new();
+        let original_clone = original.clone();
+        env.expect_raw()
+            .withf(|key| key == "PATH")
+            .returning(move |_| Ok(original_clone.clone()));
+        let mut world = CliWorld::default();
+        world.env = Box::new(env);
+        world.original_path = Some(world.env.raw("PATH").expect("retrieve PATH").into());
+        unsafe {
+            std::env::set_var("PATH", "temp-path");
+        }
+    }
+    assert_eq!(
+        std::env::var("PATH").expect("read PATH after drop"),
+        original
+    );
+}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,38 +1,8 @@
-//! Cucumber test runner and world state.
+//! Cucumber test runner.
 
-use cucumber::World;
-
-/// Shared state for Cucumber scenarios.
-#[derive(Debug, Default, World)]
-pub struct CliWorld {
-    pub cli: Option<netsuke::cli::Cli>,
-    pub cli_error: Option<String>,
-    pub manifest: Option<netsuke::ast::NetsukeManifest>,
-    pub manifest_error: Option<String>,
-    pub build_graph: Option<netsuke::ir::BuildGraph>,
-    /// Generated Ninja file content.
-    pub ninja: Option<String>,
-    /// Status of the last process execution (true for success, false for
-    /// failure).
-    pub run_status: Option<bool>,
-    /// Error message from the last failed process execution.
-    pub run_error: Option<String>,
-    /// Temporary directory handle for test isolation.
-    pub temp: Option<tempfile::TempDir>,
-    /// Original `PATH` value restored after each scenario.
-    pub original_path: Option<std::ffi::OsString>,
-}
-
-impl Drop for CliWorld {
-    fn drop(&mut self) {
-        if let Some(path) = self.original_path.take() {
-            // SAFETY: nightly marks `set_var` as unsafe; restore path for isolation.
-            unsafe {
-                std::env::set_var("PATH", path);
-            }
-        }
-    }
-}
+mod world;
+use cucumber::World as _;
+pub use world::CliWorld;
 
 mod steps;
 mod support;

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -3,6 +3,7 @@
 use crate::{CliWorld, support};
 use cucumber::{given, then, when};
 use netsuke::runner::{self, BuildTargets, NINJA_PROGRAM};
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::{NamedTempFile, TempDir};
@@ -13,9 +14,13 @@ use tempfile::{NamedTempFile, TempDir};
     reason = "helper owns path for simplicity"
 )]
 fn install_test_ninja(world: &mut CliWorld, dir: TempDir, ninja_path: PathBuf) {
-    let original = world
-        .original_path
-        .get_or_insert_with(|| std::env::var_os("PATH").unwrap_or_default());
+    let original = world.original_path.get_or_insert_with(|| {
+        world
+            .env
+            .raw("PATH")
+            .map(OsString::from)
+            .unwrap_or_default()
+    });
 
     let new_path = format!("{}:{}", dir.path().display(), original.to_string_lossy());
     // SAFETY: nightly marks `set_var` as unsafe; override path for test isolation.

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -1,0 +1,76 @@
+//! Shared test world for Cucumber scenarios.
+
+use cucumber::World;
+use mockable::{Env, MockEnv};
+
+/// Shared state for Cucumber scenarios.
+#[derive(World)]
+pub struct CliWorld {
+    pub cli: Option<netsuke::cli::Cli>,
+    pub cli_error: Option<String>,
+    pub manifest: Option<netsuke::ast::NetsukeManifest>,
+    pub manifest_error: Option<String>,
+    pub build_graph: Option<netsuke::ir::BuildGraph>,
+    /// Generated Ninja file content.
+    pub ninja: Option<String>,
+    /// Status of the last process execution (true for success, false for
+    /// failure).
+    pub run_status: Option<bool>,
+    /// Error message from the last failed process execution.
+    pub run_error: Option<String>,
+    /// Temporary directory handle for test isolation.
+    pub temp: Option<tempfile::TempDir>,
+    /// Mockable environment access.
+    pub env: Box<dyn Env>,
+    /// Original `PATH` value restored after each scenario.
+    pub original_path: Option<std::ffi::OsString>,
+}
+
+impl std::fmt::Debug for CliWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CliWorld")
+            .field("cli", &self.cli)
+            .field("cli_error", &self.cli_error)
+            .field("manifest", &self.manifest)
+            .field("manifest_error", &self.manifest_error)
+            .field("build_graph", &self.build_graph)
+            .field("ninja", &self.ninja)
+            .field("run_status", &self.run_status)
+            .field("run_error", &self.run_error)
+            .field("temp", &self.temp)
+            .field("env", &"<env>")
+            .field("original_path", &self.original_path)
+            .finish()
+    }
+}
+
+impl Default for CliWorld {
+    fn default() -> Self {
+        let mut env = MockEnv::new();
+        env.expect_raw().returning(|key| std::env::var(key));
+        Self {
+            cli: None,
+            cli_error: None,
+            manifest: None,
+            manifest_error: None,
+            build_graph: None,
+            ninja: None,
+            run_status: None,
+            run_error: None,
+            temp: None,
+            env: Box::new(env),
+            original_path: None,
+        }
+    }
+}
+
+impl Drop for CliWorld {
+    fn drop(&mut self) {
+        if let Some(path) = self.original_path.take() {
+            // SAFETY: Rust 2024 marks `set_var` as unsafe. Dropping `CliWorld`
+            // reinstates the original `PATH`, ensuring scenarios cannot leak
+            // environment changes into subsequent tests.
+            unsafe { std::env::set_var("PATH", path) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- inject mockable Env into CliWorld and default to a MockEnv
- explain unsafe `set_var` and reset PATH on drop for test isolation
- test environment restoration through dependency injection

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a355f02d483228f58a6d116c00e0e

## Summary by Sourcery

Refactor Cucumber test harness to inject a mockable environment into the CliWorld, defaulting to a MockEnv implementation, and restore the original PATH on drop to ensure test isolation.

New Features:
- Inject a mockable Env trait into CliWorld for environment access in tests
- Default to a MockEnv instance in CliWorld::default for predictable env behavior

Enhancements:
- Extract CliWorld definition into a separate tests/world.rs module
- Implement Drop for CliWorld to restore the original PATH after each scenario
- Update Cucumber step definitions to use the injected env.raw("PATH") instead of std::env directly

Tests:
- Add cli_world_tests.rs to verify that dropping CliWorld restores the original PATH