### PR TITLE
Inject Env abstraction into runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 serde_json = "1"
 serde_json_canonicalizer = "0.3"
 tempfile = "3.8.0"
+mockable = { version = "0.3", features = ["mock"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
@@ -66,7 +67,6 @@ cucumber = "0.20.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"], default-features = false }
 insta = { version = "1", features = ["yaml"] }
 assert_cmd = "2.0.17"
-mockable = { version = "0.3", features = ["mock"] }
 serial_test = "3"
 
 [[test]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //!
 //! Parses command-line arguments and delegates execution to [`runner::run`].
 
+use mockable::DefaultEnv;
 use netsuke::{cli::Cli, runner};
 use std::process::ExitCode;
 use tracing::Level;
@@ -12,7 +13,8 @@ fn main() -> ExitCode {
     if cli.verbose {
         fmt().with_max_level(Level::DEBUG).init();
     }
-    match runner::run(&cli) {
+    let env = DefaultEnv::new();
+    match runner::run(&cli, &env) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("{err}");


### PR DESCRIPTION
## Summary
- accept an `Env` implementation in `runner::run` and `resolve_ninja_program`
- look up `NINJA_ENV` via the injected environment
- exercise environment override using `MockEnv`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a356401788322ac8861510fbf227c