### PR TITLE
Explain PATH mutability hazards in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "itoa",
  "minijinja",
  "mockable",
+ "mockall",
  "rstest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ insta = { version = "1", features = ["yaml"] }
 assert_cmd = "2.0.17"
 mockable = { version = "0.3", features = ["mock"] }
 serial_test = "3"
+mockall = "0.11"
 
 [[test]]
 name = "cucumber"

--- a/tests/env_path_tests.rs
+++ b/tests/env_path_tests.rs
@@ -1,11 +1,14 @@
-use mockable::{DefaultEnv as SystemEnv, Env};
+//! Tests for scoped manipulation of `PATH` via `prepend_dir_to_path` and
+//! `PathGuard`.
+
+use mockable::Env;
 use rstest::rstest;
 use serial_test::serial;
 
 #[path = "support/env.rs"]
 mod env;
 mod support;
-use env::{mocked_path_env, prepend_dir_to_path};
+use env::{SystemEnv, mocked_path_env, prepend_dir_to_path};
 use support::env_lock::EnvLock;
 
 #[rstest]

--- a/tests/env_path_tests.rs
+++ b/tests/env_path_tests.rs
@@ -1,0 +1,25 @@
+use mockable::Env;
+use rstest::rstest;
+use serial_test::serial;
+
+#[path = "support/env.rs"]
+mod env;
+mod support;
+use env::{mocked_path_env, prepend_dir_to_path};
+
+#[rstest]
+#[serial]
+fn prepend_dir_to_path_sets_and_restores() {
+    let env = mocked_path_env();
+    let original = env.raw("PATH").expect("PATH missing in mock");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let guard = prepend_dir_to_path(&env, dir.path());
+    let after = std::env::var("PATH").expect("path var");
+    let first = std::env::split_paths(&std::ffi::OsString::from(&after))
+        .next()
+        .expect("first path");
+    assert_eq!(first, dir.path());
+    drop(guard);
+    let restored = std::env::var("PATH").expect("path var");
+    assert_eq!(restored, original);
+}

--- a/tests/env_path_tests.rs
+++ b/tests/env_path_tests.rs
@@ -19,9 +19,7 @@ fn prepend_dir_to_path_sets_and_restores() {
     let dir = tempfile::tempdir().expect("temp dir");
     let guard = prepend_dir_to_path(&env, dir.path());
     let after = std::env::var("PATH").expect("path var");
-    let first = std::env::split_paths(&std::ffi::OsString::from(&after))
-        .next()
-        .expect("first path");
+    let first = std::env::split_paths(&after).next().expect("first path");
     assert_eq!(first, dir.path());
     drop(guard);
     let restored = std::env::var("PATH").expect("path var");

--- a/tests/path_guard_tests.rs
+++ b/tests/path_guard_tests.rs
@@ -1,0 +1,42 @@
+//! Tests for PATH restoration behaviour using mock environments.
+//!
+//! Verifies that `PathGuard` restores `PATH` without mutating the real
+//! process environment.
+
+#[path = "support/env_lock.rs"]
+mod env_lock;
+#[path = "support/path_guard.rs"]
+mod path_guard;
+
+use mockall::{Sequence, mock};
+use path_guard::{Env, PathGuard};
+use std::ffi::OsStr;
+
+mock! {
+    pub Env {}
+    impl Env for Env {
+        unsafe fn set_var(&mut self, key: &str, val: &OsStr);
+    }
+}
+
+#[test]
+fn restores_path_without_touching_real_env() {
+    let mut env = MockEnv::new();
+    let mut seq = Sequence::new();
+    env.expect_set_var()
+        .withf(|k, v| k == "PATH" && v == OsStr::new("/tmp"))
+        .times(1)
+        .in_sequence(&mut seq)
+        .return_const(());
+    env.expect_set_var()
+        .withf(|k, v| k == "PATH" && v == OsStr::new("/orig"))
+        .times(1)
+        .in_sequence(&mut seq)
+        .return_const(());
+    {
+        let mut guard = PathGuard::with_env("/orig".into(), env);
+        unsafe {
+            guard.env_mut().set_var("PATH", OsStr::new("/tmp"));
+        }
+    }
+}

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,4 +1,3 @@
-use mockable::DefaultEnv as SystemEnv;
 use netsuke::cli::{BuildArgs, Cli, Commands};
 use netsuke::runner::{BuildTargets, NINJA_ENV, run, run_ninja};
 use rstest::{fixture, rstest};
@@ -10,7 +9,7 @@ mod check_ninja;
 #[path = "support/env.rs"]
 mod env;
 mod support;
-use env::prepend_dir_to_path;
+use env::{SystemEnv, prepend_dir_to_path};
 use support::path_guard::PathGuard;
 
 /// Fixture: Put a fake `ninja` (that checks for a build file) on `PATH`.

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,4 +1,4 @@
-use mockable::DefaultEnv;
+use mockable::DefaultEnv as SystemEnv;
 use netsuke::cli::{BuildArgs, Cli, Commands};
 use netsuke::runner::{BuildTargets, NINJA_ENV, run, run_ninja};
 use rstest::{fixture, rstest};
@@ -23,7 +23,7 @@ use support::path_guard::PathGuard;
 #[fixture]
 fn ninja_in_path() -> (tempfile::TempDir, PathBuf, PathGuard) {
     let (ninja_dir, ninja_path) = check_ninja::fake_ninja_check_build_file();
-    let env = DefaultEnv::new();
+    let env = SystemEnv::new();
     let guard = prepend_dir_to_path(&env, ninja_dir.path());
     (ninja_dir, ninja_path, guard)
 }
@@ -38,7 +38,7 @@ fn ninja_in_path() -> (tempfile::TempDir, PathBuf, PathGuard) {
 #[fixture]
 fn ninja_with_exit_code(#[default(0)] exit_code: i32) -> (tempfile::TempDir, PathBuf, PathGuard) {
     let (ninja_dir, ninja_path) = support::fake_ninja(exit_code);
-    let env = DefaultEnv::new();
+    let env = SystemEnv::new();
     let guard = prepend_dir_to_path(&env, ninja_dir.path());
     (ninja_dir, ninja_path, guard)
 }

--- a/tests/support/env.rs
+++ b/tests/support/env.rs
@@ -58,7 +58,8 @@ pub fn prepend_dir_to_path(env: &impl Env, dir: &Path) -> PathGuard {
     paths.insert(0, dir.to_path_buf());
     let new_path = std::env::join_paths(paths).expect("join paths");
     let _lock = EnvLock::acquire();
-    // SAFETY: protected by `EnvLock` and reverted by the returned `PathGuard`.
+    // Mockable's `Env` trait cannot mutate variables, so call directly.
+    // SAFETY: `EnvLock` serialises mutations and the guard restores on drop.
     unsafe { std::env::set_var("PATH", &new_path) };
     PathGuard::new(original_os)
 }

--- a/tests/support/env.rs
+++ b/tests/support/env.rs
@@ -3,14 +3,41 @@
 //! Provides fixtures and utilities for managing `PATH` and writing minimal
 //! manifests.
 
-use mockable::{Env, MockEnv};
+use mockable::{DefaultEnv, Env, MockEnv};
 use rstest::fixture;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Write};
 use std::path::Path;
 
 use crate::support::env_lock::EnvLock;
 use crate::support::path_guard::PathGuard;
+
+/// Alias for the real process environment.
+#[allow(dead_code, reason = "re-exported for tests")]
+pub type SystemEnv = DefaultEnv;
+
+/// Environment trait with mutation capabilities.
+pub trait EnvMut: Env {
+    /// Set `key` to `value` within the environment.
+    ///
+    /// # Safety
+    ///
+    /// Mutating global state is `unsafe` in Rust 2024. Callers must ensure the
+    /// operation is serialised and rolled back appropriately.
+    unsafe fn set_var(&self, key: &str, value: &OsStr);
+}
+
+impl EnvMut for DefaultEnv {
+    unsafe fn set_var(&self, key: &str, value: &OsStr) {
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+impl EnvMut for MockEnv {
+    unsafe fn set_var(&self, key: &str, value: &OsStr) {
+        unsafe { std::env::set_var(key, value) };
+    }
+}
 
 /// Fixture: capture the original `PATH` via a mocked environment.
 ///
@@ -47,22 +74,21 @@ pub fn write_manifest(file: &mut impl Write) -> io::Result<()> {
 
 /// Prepend `dir` to the real `PATH`, returning a guard that restores it.
 ///
-/// `std::env::set_var` is `unsafe` in Rust 2024 because it mutates process
-/// globals. `EnvLock` serialises access and `PathGuard` rolls back the change,
-/// keeping the unsafety scoped to a single test.
+/// Mutating `PATH` is `unsafe` in Rust 2024 because it alters process globals.
+/// `EnvLock` serialises access and `PathGuard` rolls back the change, keeping
+/// the unsafety scoped to a single test.
 #[allow(dead_code, reason = "used in runner tests")]
-pub fn prepend_dir_to_path(env: &impl Env, dir: &Path) -> PathGuard {
+pub fn prepend_dir_to_path(env: &impl EnvMut, dir: &Path) -> PathGuard {
     let original = env.raw("PATH").ok();
     let original_os = original.clone().map(OsString::from);
     let mut paths: Vec<_> = original_os
-        .clone()
-        .map(|os| std::env::split_paths(&os).collect())
+        .as_ref()
+        .map(|os| std::env::split_paths(os).collect())
         .unwrap_or_default();
     paths.insert(0, dir.to_path_buf());
-    let new_path = std::env::join_paths(&paths).expect("failed to join PATH entries");
+    let new_path = std::env::join_paths(&paths).expect("Failed to join PATH entries");
     let _lock = EnvLock::acquire();
-    // Mockable's `Env` trait cannot mutate variables, so call directly.
     // SAFETY: `EnvLock` serialises mutations and the guard restores on drop.
-    unsafe { std::env::set_var("PATH", &new_path) };
+    unsafe { env.set_var("PATH", &new_path) };
     PathGuard::new(original_os)
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -17,6 +17,7 @@ use tempfile::TempDir;
 /// Create a fake Ninja executable that exits with `exit_code`.
 ///
 /// Returns the temporary directory and the path to the executable.
+#[allow(dead_code, reason = "used in other test crates")]
 pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join("ninja");

--- a/tests/support/path_guard.rs
+++ b/tests/support/path_guard.rs
@@ -26,6 +26,8 @@ pub struct PathGuard {
 
 impl PathGuard {
     /// Create a guard capturing the current `PATH`.
+    ///
+    /// Returns a guard that restores the variable when dropped.
     #[allow(dead_code, reason = "only some tests mutate PATH")]
     pub fn new(original: Option<OsString>) -> Self {
         let state = original.map_or(OriginalPath::Unset, OriginalPath::Set);

--- a/tests/support/path_guard.rs
+++ b/tests/support/path_guard.rs
@@ -3,9 +3,29 @@
 //! Provides a guard that resets the environment variable on drop so tests do
 //! not pollute global state.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 
 use super::env_lock::EnvLock;
+
+/// Environment abstraction for setting variables.
+pub trait Env {
+    /// Set `key` to `val` within the environment.
+    ///
+    /// # Safety
+    ///
+    /// Mutating process globals is `unsafe` in Rust 2024. Callers must ensure
+    /// access is serialised and state is restored.
+    unsafe fn set_var(&mut self, key: &str, val: &OsStr);
+}
+
+#[derive(Debug)]
+pub struct StdEnv;
+
+impl Env for StdEnv {
+    unsafe fn set_var(&mut self, key: &str, val: &OsStr) {
+        unsafe { std::env::set_var(key, val) };
+    }
+}
 
 /// Original `PATH` state captured by `PathGuard`.
 #[allow(dead_code, reason = "only some tests mutate PATH")]
@@ -20,30 +40,46 @@ enum OriginalPath {
 /// This uses RAII to ensure the environment is reset even if a test panics.
 #[allow(dead_code, reason = "only some tests mutate PATH")]
 #[derive(Debug)]
-pub struct PathGuard {
+pub struct PathGuard<E: Env = StdEnv> {
     original: Option<OriginalPath>,
+    env: E,
 }
 
 impl PathGuard {
-    /// Create a guard capturing the current `PATH`.
+    /// Create a guard capturing the current `PATH` using the real environment.
     ///
     /// Returns a guard that restores the variable when dropped.
     #[allow(dead_code, reason = "only some tests mutate PATH")]
     pub fn new(original: Option<OsString>) -> Self {
         let state = original.map_or(OriginalPath::Unset, OriginalPath::Set);
-        Self {
-            original: Some(state),
-        }
+        Self { original: Some(state), env: StdEnv }
     }
 }
 
-impl Drop for PathGuard {
+impl<E: Env> PathGuard<E> {
+    /// Create a guard that uses `env` to restore `PATH`.
+    #[allow(dead_code, reason = "only some tests mutate PATH")]
+    pub fn with_env(original: OsString, env: E) -> Self {
+        Self {
+            original: Some(OriginalPath::Set(original)),
+            env,
+        }
+    }
+
+    /// Access the underlying environment.
+    #[allow(dead_code, reason = "only some tests mutate PATH")]
+    pub fn env_mut(&mut self) -> &mut E {
+        &mut self.env
+    }
+}
+
+impl<E: Env> Drop for PathGuard<E> {
     fn drop(&mut self) {
         let _lock = EnvLock::acquire();
         match self.original.take() {
             Some(OriginalPath::Set(path)) => {
                 // Nightly marks `set_var` unsafe; restoring cleans up global state.
-                unsafe { std::env::set_var("PATH", path) };
+                unsafe { self.env.set_var("PATH", &path) };
             }
             Some(OriginalPath::Unset) | None => unsafe { std::env::remove_var("PATH") },
         }

--- a/tests/support/path_guard.rs
+++ b/tests/support/path_guard.rs
@@ -52,7 +52,10 @@ impl PathGuard {
     #[allow(dead_code, reason = "only some tests mutate PATH")]
     pub fn new(original: Option<OsString>) -> Self {
         let state = original.map_or(OriginalPath::Unset, OriginalPath::Set);
-        Self { original: Some(state), env: StdEnv }
+        Self {
+            original: Some(state),
+            env: StdEnv,
+        }
     }
 }
 

--- a/tests/support/path_guard.rs
+++ b/tests/support/path_guard.rs
@@ -7,6 +7,7 @@ use std::ffi::OsString;
 
 use super::env_lock::EnvLock;
 
+/// Original `PATH` state captured by `PathGuard`.
 #[allow(dead_code, reason = "only some tests mutate PATH")]
 #[derive(Debug)]
 enum OriginalPath {
@@ -24,8 +25,8 @@ pub struct PathGuard {
 }
 
 impl PathGuard {
-    #[allow(dead_code, reason = "only some tests mutate PATH")]
     /// Create a guard capturing the current `PATH`.
+    #[allow(dead_code, reason = "only some tests mutate PATH")]
     pub fn new(original: Option<OsString>) -> Self {
         let state = original.map_or(OriginalPath::Unset, OriginalPath::Set);
         Self {


### PR DESCRIPTION
## Summary
- document Rust 2024 `set_var` unsafety in PATH fixtures
- inject `Env` into PATH helper and fixtures
- test PATH guard behaviour with mock environment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a8cdfc7d08322b0fc8982a7d7474f

## Summary by Sourcery

Refactor test fixtures to use a new Env-based helper for scoped PATH mutations, document the unsafety of std::env::set_var under Rust 2024, and add tests to validate PathGuard behavior.

Enhancements:
- Extract common PATH manipulation into prepend_dir_to_path helper that uses Env and EnvLock
- Refactor ninja_in_path and ninja_with_exit_code fixtures to invoke prepend_dir_to_path instead of manual set_var logic
- Add allow dead_code annotations for support functions to clarify their use in various test contexts

Documentation:
- Explain in comments that std::env::set_var is unsafe in Rust 2024 and describe how EnvLock and PathGuard confine the mutation

Tests:
- Introduce env_path_tests to verify that prepend_dir_to_path correctly sets the first PATH entry and restores the original value on guard drop