### PR TITLE
Scope doctest imports to non-doc builds

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -24,13 +24,10 @@ pub const NINJA_ENV: &str = "NETSUKE_NINJA";
 
 // Public helpers for doctests only. This exposes internal helpers as a stable
 // testing surface without exporting them in release builds.
+#[cfg(doctest)]
 #[doc(hidden)]
 pub mod doc {
-    #[cfg_attr(
-        not(doc),
-        expect(unused_imports, reason = "doctest-only wrapper module")
-    )]
-    use super::*;
+    pub use super::CommandArg;
 
     // Public wrappers to expose crate-private helpers to doctests.
     #[must_use]
@@ -49,8 +46,6 @@ pub mod doc {
     pub fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
         super::redact_sensitive_args(args)
     }
-
-    pub use super::CommandArg;
 }
 
 #[derive(Debug, Clone)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,7 +26,10 @@ pub const NINJA_ENV: &str = "NETSUKE_NINJA";
 // testing surface without exporting them in release builds.
 #[doc(hidden)]
 pub mod doc {
-    #[allow(unused_imports, reason = "doctest-only wrapper module")]
+    #[cfg_attr(
+        not(doc),
+        allow(unused_imports, reason = "doctest-only wrapper module")
+    )]
     use super::*;
 
     // Public wrappers to expose crate-private helpers to doctests.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,7 +28,7 @@ pub const NINJA_ENV: &str = "NETSUKE_NINJA";
 pub mod doc {
     #[cfg_attr(
         not(doc),
-        allow(unused_imports, reason = "doctest-only wrapper module")
+        expect(unused_imports, reason = "doctest-only wrapper module")
     )]
     use super::*;
 


### PR DESCRIPTION
## Summary
- restrict doctest wrapper import allowance to non-doc builds

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `cargo build --quiet`
- `cargo doc --no-deps` *(fails: unresolved link to `default` and `main`)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d48edbc8322aa32458fa18d0d78

## Summary by Sourcery

Enhancements:
- Shield the doctest-only wrapper module's unused_imports allowance to non-doc builds using cfg_attr