### PR TITLE
Guard NINJA_ENV overrides with mockable Env

### DIFF
--- a/tests/assert_cmd_tests.rs
+++ b/tests/assert_cmd_tests.rs
@@ -8,6 +8,7 @@ use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;
 
+#[expect(unused, reason = "support module exports helpers unused in this test")]
 mod support;
 
 #[test]

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -28,6 +28,7 @@ mod check_ninja;
 #[path = "support/env.rs"]
 mod env;
 mod steps;
+#[expect(unused, reason = "support module exports helpers unused in this test")]
 mod support;
 
 #[tokio::main]

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -4,6 +4,10 @@ use std::env::VarError;
 use support::env_lock::EnvLock;
 use support::ninja_env::override_ninja_env;
 
+#[expect(
+    unused,
+    reason = "support module exports helpers unused in these tests"
+)]
 mod support;
 
 #[test]

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,5 +1,6 @@
 use mockable::MockEnv;
 use netsuke::runner::NINJA_ENV;
+use rstest::rstest;
 use std::env::VarError;
 use support::env_lock::EnvLock;
 use support::ninja_env::override_ninja_env;
@@ -10,55 +11,39 @@ use support::ninja_env::override_ninja_env;
 )]
 mod support;
 
-#[test]
-fn override_ninja_env_restores_original() {
+#[rstest]
+#[case(Some("orig"))]
+#[case(None)]
+#[case(Some(""))]
+fn override_ninja_env_restores(#[case] original: Option<&'static str>) {
     let mut env = MockEnv::new();
-    env.expect_raw()
-        .withf(|k| k == NINJA_ENV)
-        .times(1)
-        .returning(|_| Ok("orig".to_string()));
+    match original {
+        Some(val) => {
+            let returned = val.to_string();
+            env.expect_raw()
+                .withf(|k| k == NINJA_ENV)
+                .times(1)
+                .return_once(move |_| Ok(returned));
+        }
+        None => {
+            env.expect_raw()
+                .withf(|k| k == NINJA_ENV)
+                .times(1)
+                .return_once(|_| Err(VarError::NotPresent));
+        }
+    }
 
     {
         let _guard = override_ninja_env(EnvLock::acquire(), &env, "new");
         assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
     }
-    assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("orig"));
-    // Clean up to avoid leaking environment state. `remove_var` is `unsafe`
-    // on Rust 2024; a fresh lock serialises this mutation.
-    let _cleanup = EnvLock::acquire();
-    unsafe { std::env::remove_var(NINJA_ENV) };
-}
 
-#[test]
-fn override_ninja_env_removes_when_unset() {
-    let mut env = MockEnv::new();
-    env.expect_raw()
-        .withf(|k| k == NINJA_ENV)
-        .times(1)
-        .returning(|_| Err(VarError::NotPresent));
-
-    {
-        let _guard = override_ninja_env(EnvLock::acquire(), &env, "new");
-        assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
+    match original {
+        Some(val) => assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok(val)),
+        None => assert!(std::env::var(NINJA_ENV).is_err()),
     }
-    assert!(std::env::var(NINJA_ENV).is_err());
-    let _cleanup = EnvLock::acquire();
-    unsafe { std::env::remove_var(NINJA_ENV) };
-}
 
-#[test]
-fn override_ninja_env_restores_empty() {
-    let mut env = MockEnv::new();
-    env.expect_raw()
-        .withf(|k| k == NINJA_ENV)
-        .times(1)
-        .returning(|_| Ok(String::new()));
-
-    {
-        let _guard = override_ninja_env(EnvLock::acquire(), &env, "new");
-        assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
-    }
-    assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok(""));
     let _cleanup = EnvLock::acquire();
+    // SAFETY: `EnvLock` serialises this mutation; see above for details.
     unsafe { std::env::remove_var(NINJA_ENV) };
 }

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,5 +1,6 @@
 use mockable::MockEnv;
 use netsuke::runner::NINJA_ENV;
+use std::env::VarError;
 use support::env_lock::EnvLock;
 use support::ninja_env::override_ninja_env;
 
@@ -11,6 +12,7 @@ fn override_ninja_env_restores_original() {
     let mut env = MockEnv::new();
     env.expect_raw()
         .withf(|k| k == NINJA_ENV)
+        .times(1)
         .returning(|_| Ok("orig".to_string()));
 
     {
@@ -20,5 +22,39 @@ fn override_ninja_env_restores_original() {
     assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("orig"));
     // Clean up to avoid leaking environment state. `remove_var` is `unsafe`
     // on Rust 2024; the lock above serialises this mutation.
+    unsafe { std::env::remove_var(NINJA_ENV) };
+}
+
+#[test]
+fn override_ninja_env_removes_when_unset() {
+    let _lock = EnvLock::acquire();
+    let mut env = MockEnv::new();
+    env.expect_raw()
+        .withf(|k| k == NINJA_ENV)
+        .times(1)
+        .returning(|_| Err(VarError::NotPresent));
+
+    {
+        let _guard = override_ninja_env(&env, "new");
+        assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
+    }
+    assert!(std::env::var(NINJA_ENV).is_err());
+    unsafe { std::env::remove_var(NINJA_ENV) };
+}
+
+#[test]
+fn override_ninja_env_restores_empty() {
+    let _lock = EnvLock::acquire();
+    let mut env = MockEnv::new();
+    env.expect_raw()
+        .withf(|k| k == NINJA_ENV)
+        .times(1)
+        .returning(|_| Ok(String::new()));
+
+    {
+        let _guard = override_ninja_env(&env, "new");
+        assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
+    }
+    assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok(""));
     unsafe { std::env::remove_var(NINJA_ENV) };
 }

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,0 +1,24 @@
+use mockable::MockEnv;
+use netsuke::runner::NINJA_ENV;
+use support::env_lock::EnvLock;
+use support::ninja_env::override_ninja_env;
+
+mod support;
+
+#[test]
+fn override_ninja_env_restores_original() {
+    let _lock = EnvLock::acquire();
+    let mut env = MockEnv::new();
+    env.expect_raw()
+        .withf(|k| k == NINJA_ENV)
+        .returning(|_| Ok("orig".to_string()));
+
+    {
+        let _guard = override_ninja_env(&env, "new");
+        assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("new"));
+    }
+    assert_eq!(std::env::var(NINJA_ENV).as_deref(), Ok("orig"));
+    // Clean up to avoid leaking environment state. `remove_var` is `unsafe`
+    // on Rust 2024; the lock above serialises this mutation.
+    unsafe { std::env::remove_var(NINJA_ENV) };
+}

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -222,12 +222,12 @@ fn run_manifest_subcommand_writes_file() {
 #[serial]
 fn run_respects_env_override_for_ninja() {
     let (temp_dir, ninja_path) = support::fake_ninja(0);
+    // `NINJA_ENV` expects UTF-8; lossy conversion is acceptable in this test.
     let program = ninja_path.to_string_lossy().into_owned();
     let env = DefaultEnv::new();
-    let _lock = EnvLock::acquire();
     // `set_var` is `unsafe` on Rust 2024; the lock serialises the mutation and
     // `override_ninja_env` restores the original value via its guard.
-    let _guard = override_ninja_env(&env, &program);
+    let _guard = override_ninja_env(EnvLock::acquire(), &env, &program);
 
     let temp = tempfile::tempdir().expect("temp dir");
     let manifest_path = temp.path().join("Netsukefile");

--- a/tests/support/env_lock.rs
+++ b/tests/support/env_lock.rs
@@ -10,6 +10,7 @@ use std::sync::{Mutex, MutexGuard};
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[allow(dead_code, reason = "only some tests mutate PATH")]
+#[derive(Debug)]
 /// RAII guard that holds the global environment lock.
 pub struct EnvLock(MutexGuard<'static, ()>);
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,6 +4,7 @@
 //! logging utilities used in behavioural tests.
 
 pub mod env_lock;
+pub mod ninja_env;
 pub mod path_guard;
 
 #[expect(unused_imports, reason = "re-export for selective test crates")]
@@ -17,6 +18,7 @@ use tempfile::TempDir;
 /// Create a fake Ninja executable that exits with `exit_code`.
 ///
 /// Returns the temporary directory and the path to the executable.
+#[allow(dead_code, reason = "only some test crates spawn fake ninja binaries")]
 pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join("ninja");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -18,7 +18,13 @@ use tempfile::TempDir;
 /// Create a fake Ninja executable that exits with `exit_code`.
 ///
 /// Returns the temporary directory and the path to the executable.
-#[allow(dead_code, reason = "only some test crates spawn fake ninja binaries")]
+#[cfg_attr(
+    not(test),
+    expect(
+        unused_code,
+        reason = "only some test crates spawn fake ninja binaries"
+    )
+)]
 pub fn fake_ninja(exit_code: i32) -> (TempDir, PathBuf) {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join("ninja");

--- a/tests/support/ninja_env.rs
+++ b/tests/support/ninja_env.rs
@@ -5,15 +5,19 @@
 //! environment and captures the previous value through a `mockable::Env`
 //! implementation so tests can inject their own state.
 
+use super::env_lock::EnvLock;
 use mockable::Env;
 use netsuke::runner::NINJA_ENV;
 
 /// Guard that resets `NINJA_ENV` on drop.
 ///
 /// Holding the guard keeps the environment override in place. Dropping it
-/// restores the prior value, cleaning up global state even if a test panics.
+/// restores the prior value while releasing the environment lock, cleaning up
+/// global state even if a test panics.
+#[must_use]
 #[derive(Debug)]
 pub struct NinjaEnvGuard {
+    _lock: EnvLock,
     original: Option<String>,
 }
 
@@ -22,32 +26,39 @@ pub struct NinjaEnvGuard {
 ///
 /// # Thread Safety
 ///
-/// This function is **not thread-safe**. Callers must hold
-/// [`EnvLock`](super::env_lock::EnvLock) to serialise this mutation.
+/// This function is **not thread-safe**. Callers must supply an
+/// [`EnvLock`](super::env_lock::EnvLock), which is stored in the returned guard
+/// to serialise the mutation and ensure restoration occurs before the lock is
+/// released.
+///
+/// Drop order is enforced: dropping the guard restores [`NINJA_ENV`] and only
+/// then releases the lock.
 ///
 /// # Examples
 /// ```ignore
 /// use mockable::DefaultEnv;
-/// use tests::support::ninja_env::override_ninja_env;
+/// use crate::support::{env_lock::EnvLock, ninja_env::override_ninja_env};
 /// let env = DefaultEnv::new();
-/// let _guard = override_ninja_env(&env, "/usr/bin/ninja");
+/// let _guard = override_ninja_env(EnvLock::acquire(), &env, "/usr/bin/ninja");
 /// ```
 #[cfg_attr(
     not(test),
     expect(unused_code, reason = "only some tests override NINJA_ENV")
 )]
-pub fn override_ninja_env(env: &impl Env, value: &str) -> NinjaEnvGuard {
+pub fn override_ninja_env(lock: EnvLock, env: &impl Env, value: &str) -> NinjaEnvGuard {
     let original = env.raw(NINJA_ENV).ok();
-    // Callers must hold [`EnvLock`](super::env_lock::EnvLock) to serialise this
-    // mutation. `set_var` is `unsafe` on Rust 2024 and the guard restores the
-    // prior value on drop.
+    // Safety: `EnvLock` serialises this mutation. `set_var` is `unsafe` on Rust
+    // 2024 and the guard restores the prior value on drop.
     unsafe { std::env::set_var(NINJA_ENV, value) };
-    NinjaEnvGuard { original }
+    NinjaEnvGuard {
+        _lock: lock,
+        original,
+    }
 }
 
 impl Drop for NinjaEnvGuard {
     fn drop(&mut self) {
-        // Safety: callers hold [`EnvLock`] for the guard's lifetime, so these
+        // Safety: the guard holds [`EnvLock`] for its lifetime, so these
         // `set_var`/`remove_var` calls are serialised. Both functions are
         // `unsafe` on Rust 2024.
         unsafe {

--- a/tests/support/ninja_env.rs
+++ b/tests/support/ninja_env.rs
@@ -32,7 +32,10 @@ pub struct NinjaEnvGuard {
 /// let env = DefaultEnv::new();
 /// let _guard = override_ninja_env(&env, "/usr/bin/ninja");
 /// ```
-#[allow(dead_code, reason = "only some tests override NINJA_ENV")]
+#[cfg_attr(
+    not(test),
+    expect(unused_code, reason = "only some tests override NINJA_ENV")
+)]
 pub fn override_ninja_env(env: &impl Env, value: &str) -> NinjaEnvGuard {
     let original = env.raw(NINJA_ENV).ok();
     // Callers must hold [`EnvLock`](super::env_lock::EnvLock) to serialise this

--- a/tests/support/ninja_env.rs
+++ b/tests/support/ninja_env.rs
@@ -1,0 +1,50 @@
+//! Override and restore `NINJA_ENV` for tests.
+//!
+//! Provides a helper that sets the `NETSUKE_NINJA` environment variable while
+//! ensuring it is restored afterwards. This uses [`EnvLock`] to serialise
+//! mutations to the global environment and captures the previous value through a
+//! `mockable::Env` implementation so tests can inject their own state.
+
+use mockable::Env;
+use netsuke::runner::NINJA_ENV;
+
+/// Guard that resets `NINJA_ENV` on drop.
+///
+/// Holding the guard keeps the environment override in place. Dropping it
+/// restores the prior value, cleaning up global state even if a test panics.
+#[derive(Debug)]
+pub struct NinjaEnvGuard {
+    original: Option<String>,
+}
+
+/// Set `NINJA_ENV` to `value`, returning a guard that restores the previous
+/// value when dropped.
+///
+/// # Examples
+/// ```ignore
+/// use mockable::DefaultEnv;
+/// use tests::support::ninja_env::override_ninja_env;
+/// let env = DefaultEnv::new();
+/// let _guard = override_ninja_env(&env, "/usr/bin/ninja");
+/// ```
+#[allow(dead_code, reason = "only some tests override NINJA_ENV")]
+pub fn override_ninja_env(env: &impl Env, value: &str) -> NinjaEnvGuard {
+    let original = env.raw(NINJA_ENV).ok();
+    // Callers must hold [`EnvLock`](super::env_lock::EnvLock) to serialise this
+    // mutation. `set_var` is `unsafe` on Rust 2024 and the guard restores the
+    // prior value on drop.
+    unsafe { std::env::set_var(NINJA_ENV, value) };
+    NinjaEnvGuard { original }
+}
+
+impl Drop for NinjaEnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(ref val) = self.original {
+                std::env::set_var(NINJA_ENV, val);
+            } else {
+                std::env::remove_var(NINJA_ENV);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add NinjaEnvGuard helper to override and restore NETSUKE_NINJA
- use EnvLock when mutating NINJA_ENV during runner execution
- test NINJA_ENV restoration using mockable::MockEnv

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689a8cb37e3c83229e25c6278d6128fb

## Summary by Sourcery

Introduce a mockable environment guard to safely override and restore the NINJA_ENV variable in tests.

New Features:
- Add NinjaEnvGuard and override_ninja_env helper for safely setting and restoring NINJA_ENV in tests
- Integrate EnvLock to serialize unsafe environment mutations during runner execution

Enhancements:
- Refactor runner tests to use override_ninja_env and EnvLock instead of manual environment variable manipulation

Tests:
- Add a test validating that override_ninja_env restores the original NINJA_ENV using MockEnv