### PR TITLE
Clarify doc links

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,7 +94,7 @@ pub struct BuildArgs {
 /// Available top-level commands for Netsuke.
 #[derive(Debug, Subcommand, PartialEq, Eq, Clone)]
 pub enum Commands {
-    /// Build specified targets (or default targets if none are given) [default].
+    /// Build specified targets (or default targets if none are given) `default`.
     Build(BuildArgs),
 
     /// Remove build artifacts and intermediate files.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,6 @@
 //! CLI execution and command dispatch logic.
 //!
-//! This module keeps [`main`] minimal by providing a single entry point that
+//! This module keeps `main` minimal by providing a single entry point that
 //! handles command execution. It now delegates build requests to the Ninja
 //! subprocess, streaming its output back to the user.
 


### PR DESCRIPTION
## Summary
- prevent dead intra-doc links in runner by referring to `main` literally
- avoid broken link in CLI help text

## Testing
- `make fmt`
- `make lint`
- `make test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_689a9ae5485c83228b56687602156418