### PR TITLE
Add guard for NINJA_ENV overrides

### DIFF
--- a/test_support/src/env.rs
+++ b/test_support/src/env.rs
@@ -86,3 +86,51 @@ pub fn prepend_dir_to_path(env: &impl EnvMut, dir: &Path) -> PathGuard {
     unsafe { env.set_var("PATH", &new_path) };
     PathGuard::new(original_os)
 }
+
+const NINJA_ENV: &str = "NETSUKE_NINJA";
+
+/// Guard that restores `NINJA_ENV` to its previous value on drop.
+#[derive(Debug)]
+pub struct NinjaEnvGuard {
+    original: Option<OsString>,
+}
+
+/// Override the `NINJA_ENV` variable with `path`, returning a guard that resets it.
+///
+/// In Rust 2024 `std::env::set_var` is `unsafe` because it mutates process-global
+/// state. `EnvLock` serialises the mutation and the guard restores the prior
+/// value, confining the unsafety to the scope of the guard.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+/// use test_support::env::{SystemEnv, override_ninja_env};
+///
+/// let env = SystemEnv::new();
+/// let guard = override_ninja_env(&env, Path::new("/tmp/ninja"));
+/// assert_eq!(std::env::var("NETSUKE_NINJA").unwrap(), "/tmp/ninja");
+/// drop(guard);
+/// assert!(std::env::var("NETSUKE_NINJA").is_err());
+/// ```
+pub fn override_ninja_env(env: &impl EnvMut, path: &Path) -> NinjaEnvGuard {
+    let original = env.raw(NINJA_ENV).ok().map(OsString::from);
+    let _lock = EnvLock::acquire();
+    // SAFETY: `EnvLock` serialises the mutation and the guard restores on drop.
+    unsafe { env.set_var(NINJA_ENV, path.as_os_str()) };
+    NinjaEnvGuard { original }
+}
+
+impl Drop for NinjaEnvGuard {
+    fn drop(&mut self) {
+        let _lock = EnvLock::acquire();
+        // SAFETY: `EnvLock` ensures exclusive access while the variable is reset.
+        unsafe {
+            if let Some(val) = self.original.take() {
+                std::env::set_var(NINJA_ENV, val);
+            } else {
+                std::env::remove_var(NINJA_ENV);
+            }
+        }
+    }
+}

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,0 +1,35 @@
+//! Tests for overriding the NINJA_ENV variable via a mock environment.
+
+use mockable::MockEnv;
+use netsuke::runner::NINJA_ENV;
+use rstest::rstest;
+use serial_test::serial;
+use std::path::Path;
+use test_support::{env::override_ninja_env, env_lock::EnvLock};
+
+#[rstest]
+#[serial]
+fn override_ninja_env_sets_and_restores() {
+    let before = std::env::var_os(NINJA_ENV);
+    let mut env = MockEnv::new();
+    env.expect_raw()
+        .withf(|k| k == NINJA_ENV)
+        .returning(|_| Ok("restored".to_string()));
+    {
+        let guard = override_ninja_env(&env, Path::new("/tmp/ninja"));
+        let after = std::env::var(NINJA_ENV).expect("env var");
+        assert_eq!(after, "/tmp/ninja");
+        drop(guard);
+    }
+    let restored = std::env::var(NINJA_ENV).expect("env var");
+    assert_eq!(restored, "restored");
+    let _lock = EnvLock::acquire();
+    // SAFETY: `EnvLock` serialises access while the variable is reset.
+    unsafe {
+        if let Some(val) = before {
+            std::env::set_var(NINJA_ENV, val);
+        } else {
+            std::env::remove_var(NINJA_ENV);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard NINJA_ENV with EnvLock and restoration guard
- add helper to override NINJA_ENV using dependency injection
- test NINJA_ENV override restoration with MockEnv

## Testing
- `make fmt`
- `make lint` *(fails: interrupted; command did not complete)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d10a97afc83229768883ca3244fb8