### PR TITLE
Document YAML-first templating pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ release: target/release/$(APP) ## Build release binary
 
 all: release ## Default target builds release binary
 
-clean: ## Remove build artifacts
+clean: ## Remove build artefacts
 	$(CARGO) clean
 
 test: ## Run tests with warnings treated as errors

--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -18,7 +18,7 @@ stakeholders can use to describe and agree upon software requirements.[^2] This
 process is centred on conversation; the discussions about how a feature should
 behave are the most valuable output of BDD.[^3]
 
-The tangible artefact of these conversations is a set of specifications written
+The tangible artifact of these conversations is a set of specifications written
 in a structured, natural language format. These specifications serve a dual
 purpose: they are human-readable documentation of the system's features, and
 they are also executable tests that verify the system's behaviour. This

--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -18,7 +18,7 @@ stakeholders can use to describe and agree upon software requirements.[^2] This
 process is centred on conversation; the discussions about how a feature should
 behave are the most valuable output of BDD.[^3]
 
-The tangible artifact of these conversations is a set of specifications written
+The tangible artefact of these conversations is a set of specifications written
 in a structured, natural language format. These specifications serve a dual
 purpose: they are human-readable documentation of the system's features, and
 they are also executable tests that verify the system's behaviour. This
@@ -979,7 +979,7 @@ The process involves two main steps:
 2. **Publish reports:** Many CI platforms can parse and display test results
    in a structured format. The `cucumber` crate supports generating JUnit XML
    reports via the `output-junit` feature flag.[^16] These XML files can then
-   be published as test artifacts for platforms like GitHub Actions, GitLab
+   be published as test artefacts for platforms like GitHub Actions, GitLab
    CI,[^34] or Jenkins to consume.[^33]
 
 This CI integration closes the BDD loop. The `.feature` files, once checked

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -34,7 +34,7 @@ architecture.
 ### 1.2 The Six Stages of a Netsuke Build
 
 The process of transforming a user's `Netsukefile` manifest into a completed
-build artefact now follows a six-stage pipeline. This data flow validates the
+build artifact now follows a six-stage pipeline. This data flow validates the
 manifest as YAML first, then resolves all dynamic logic into a static plan
 before execution, a critical requirement for compatibility with Ninja.
 
@@ -77,7 +77,7 @@ before execution, a critical requirement for compatibility with Ninja.
 6. Stage 6: Ninja Synthesis & Execution
 
    The final, validated IR is traversed by a code generator. This generator
-   synthesises the content of a `build.ninja` file, translating the IR's nodes
+   synthesizes the content of a `build.ninja` file, translating the IR's nodes
    and edges into corresponding Ninja rule and build statements. Once the file
    is written, Netsuke invokes the `ninja` executable as a subprocess, passing
    control to it for the final dependency checking and command-execution phase.
@@ -88,18 +88,12 @@ before execution, a critical requirement for compatibility with Ninja.
    output suitable for caching or source control.
 
 ```mermaid
-sequenceDiagram
-    participant User
-    participant Netsuke
-    participant IR_Generator
-    participant Ninja
-
-    User->>Netsuke: Provide Netsukefile and environment
-    Netsuke->>IR_Generator: Parse and validate manifest
-    IR_Generator->>IR_Generator: Generate deterministic BuildGraph (IR)
-    IR_Generator->>Netsuke: Return BuildGraph (byte-for-byte deterministic)
-    Netsuke->>Ninja: Synthesize build.ninja and invoke Ninja
-    Ninja-->>User: Execute build and report results
+flowchart TD
+    A[Stage 1:\nManifest Ingestion] --> B[Stage 2:\nInitial YAML Parsing]
+    B --> C[Stage 3:\nTemplate Expansion]
+    C --> D[Stage 4:\nDeserialisation & Final Rendering]
+    D --> E[Stage 5:\nIR Generation & Validation]
+    E --> F[Stage 6:\nNinja Synthesis & Execution]
 ```
 
 ### 1.3 The Static Graph Mandate
@@ -598,7 +592,7 @@ preserved for Jinja control flow. Targets also accept optional `phony` and
 `always` booleans. They default to `false`, making it explicit when an action
 should run regardless of file timestamps. Targets listed in the `actions`
 section are deserialised using a custom helper so they are always treated as
-`phony` tasks. This ensures preparation actions never generate build artefacts.
+`phony` tasks. This ensures preparation actions never generate build artifacts.
 Convenience functions in `src/manifest.rs` load a manifest from a string or a
 file path, returning `anyhow::Result` for straightforward error handling.
 
@@ -1406,7 +1400,7 @@ struct Cli { /// Path to the Netsuke manifest file to use.
 enum Commands { /// Build specified targets (or default targets if none are
 given). /// This is the default subcommand. Build(BuildArgs),
 
-    /// Remove build artefacts and intermediate files. Clean,
+    /// Remove build artifacts and intermediate files. Clean,
 
     /// Display the build dependency graph in DOT format for visualisation.
     Graph,
@@ -1434,13 +1428,13 @@ treated as the default subcommand if none is provided, allowing for the common*
 The behaviour of each subcommand is clearly defined:
 
 - `Netsuke build [--emit FILE] [targets...]`: This is the primary and default
-command. It executes the full six-stage pipeline: ingestion, Jinja
-  rendering, YAML parsing, IR generation, and Ninja synthesis. By default the
-  generated Ninja file is written to a securely created temporary location and
-  removed after the build completes. Supplying `--emit FILE` writes the Ninja
-  file to `FILE` and retains it. If no targets are provided on the command
-  line, the targets listed in the `defaults` section of the manifest are
-  built.
+command. It executes the full six-stage pipeline: Manifest Ingestion, Initial
+YAML Parsing, Template Expansion, Deserialisation & Final Rendering, IR
+Generation & Validation, and Ninja Synthesis & Execution. By default the
+generated Ninja file is written to a securely created temporary location and
+removed after the build completes. Supplying `--emit FILE` writes the Ninja
+file to `FILE` and retains it. If no targets are provided on the command line,
+the targets listed in the `defaults` section of the manifest are built.
 
 - `Netsuke clean`: This command provides a convenient way to clean the build
   directory. It will invoke the Ninja backend with the appropriate flags, such

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -34,7 +34,7 @@ architecture.
 ### 1.2 The Six Stages of a Netsuke Build
 
 The process of transforming a user's `Netsukefile` manifest into a completed
-build artifact now follows a six-stage pipeline. This data flow validates the
+build artefact now follows a six-stage pipeline. This data flow validates the
 manifest as YAML first, then resolves all dynamic logic into a static plan
 before execution, a critical requirement for compatibility with Ninja.
 
@@ -347,10 +347,15 @@ iteration is preserved for later rendering.
   sources: "{{ item }}"
 ```
 
-Each element in the sequence produces a separate target. Jinja control
-structures cannot shape the YAML; all templating must occur within the string
-values. The resulting build graph is still fully static and behaves the same as
-if every target were declared explicitly.
+Each element in the sequence produces a separate target. Per-iteration context:
+
+- item: current element
+- index: 0-based index (optional)
+- vars: resolved in order `globals` < `target.vars` < per-iteration locals
+
+Jinja control structures cannot shape the YAML; all templating must occur
+within the string values. The resulting build graph is still fully static and
+behaves the same as if every target were declared explicitly.
 
 ### 2.6 Table: Netsuke Manifest vs. Makefile
 
@@ -592,7 +597,7 @@ preserved for Jinja control flow. Targets also accept optional `phony` and
 `always` booleans. They default to `false`, making it explicit when an action
 should run regardless of file timestamps. Targets listed in the `actions`
 section are deserialised using a custom helper so they are always treated as
-`phony` tasks. This ensures preparation actions never generate build artifacts.
+`phony` tasks. This ensures preparation actions never generate build artefacts.
 Convenience functions in `src/manifest.rs` load a manifest from a string or a
 file path, returning `anyhow::Result` for straightforward error handling.
 
@@ -1400,7 +1405,7 @@ struct Cli { /// Path to the Netsuke manifest file to use.
 enum Commands { /// Build specified targets (or default targets if none are
 given). /// This is the default subcommand. Build(BuildArgs),
 
-    /// Remove build artifacts and intermediate files. Clean,
+    /// Remove build artefacts and intermediate files. Clean,
 
     /// Display the build dependency graph in DOT format for visualisation.
     Graph,
@@ -1497,7 +1502,7 @@ goal.
 
   - **Success Criterion:** Netsuke can successfully take a `Netsukefile` file
     *without any Jinja syntax* and compile it to a `build.ninja` file, then
-    execute it to produce the correct artifacts. This phase validates the
+    execute it to produce the correct artefacts. This phase validates the
     entire static compilation pipeline.
 
 - **Phase 2: The Dynamic Engine**
@@ -1567,7 +1572,7 @@ powerful build tool. The use of a decoupled IR, in particular, opens up many
 possibilities for future enhancements beyond the initial scope.
 
 - **Advanced Caching:** While Ninja provides excellent file-based incremental
-  build caching, Netsuke could implement a higher-level artifact caching layer.
+  build caching, Netsuke could implement a higher-level artefact caching layer.
   This could involve caching build outputs in a shared network location (e.g.,
   S3) or a local content-addressed store, allowing for cache hits across
   different machines or clean checkouts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,19 +79,21 @@ configurations with variables, control flow, and custom functions.
 
   - [x] Integrate the `minijinja` crate into the build pipeline.
 
-  - [x] Implement the two-pass parsing mechanism: the first pass renders the
-    manifest as a Jinja template, and the second pass parses the resulting pure
-    YAML string with serde_yml.
+  - [x] Implement data-first parsing: parse the manifest into a
+    `serde_yml::Value`, expand `foreach` and `when` entries with a Jinja
+    environment, then deserialize the expanded tree into the typed AST and
+    render remaining string fields.
 
   - [x] Create a minijinja::Environment and populate its initial context with
     the global vars defined in the manifest.
 
 - [ ] **Dynamic Features and Custom Functions:**
 
-  - [x] Implement support for basic Jinja control structures (`{% if %}` and
-        `{% for %}`)
+  - [x] Evaluate Jinja expressions only within string values, forbidding
+        structural tags such as `{% if %}` and `{% for %}`.
 
-  - [ ] Implement the foreach key for target generation.
+  - [ ] Implement the `foreach` and `when` keys for target generation, carrying
+        the iteration context into subsequent rendering phases.
 
   - [ ] Implement the essential custom Jinja function env(var_name) to read
     system environment variables.
@@ -105,8 +107,9 @@ configurations with variables, control flow, and custom functions.
 - **Success Criterion:**
 
   - [ ] Netsuke can successfully build a manifest that uses variables,
-    conditional logic, the foreach loop, custom macros, and the glob() function
-    to discover and operate on source files.
+    conditional logic within string values, the `foreach` and `when` keys,
+    custom macros, and the `glob()` function to discover and operate on source
+    files.
 
 ## Phase 3: The "Friendly" Polish 🛡️
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,8 +93,10 @@ configurations with variables, control flow, and custom functions.
   - [x] Evaluate Jinja expressions only within string values, forbidding
         structural tags such as `{% if %}` and `{% for %}`.
 
-  - [ ] Implement the `foreach` and `when` keys for target generation, carrying
-        the iteration context into subsequent rendering phases.
+  - [ ] Implement the `foreach` and `when` keys for target generation,
+        exposing `item` and optional `index` variables and layering
+        per-iteration locals over `target.vars` and manifest globals for
+        subsequent rendering phases.
 
   - [ ] Implement the essential custom Jinja function env(var_name) to read
     system environment variables.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,7 @@ compilation pipeline from parsing to execution.
 
   - [x] Netsuke can successfully take a Netsukefile without any Jinja syntax,
     compile it to a `build.ninja` file, and execute it via the ninja subprocess
-    to produce the correct build artefacts. *(validated via CI workflow)*
+    to produce the correct build artifacts. *(validated via CI workflow)*
 
 ## Phase 2: The Dynamic Engine ✨
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,7 +68,7 @@ compilation pipeline from parsing to execution.
 
   - [x] Netsuke can successfully take a Netsukefile without any Jinja syntax,
     compile it to a `build.ninja` file, and execute it via the ninja subprocess
-    to produce the correct build artifacts. *(validated via CI workflow)*
+    to produce the correct build artefacts. *(validated via CI workflow)*
 
 ## Phase 2: The Dynamic Engine ✨
 
@@ -80,9 +80,10 @@ configurations with variables, control flow, and custom functions.
   - [x] Integrate the `minijinja` crate into the build pipeline.
 
   - [x] Implement data-first parsing: parse the manifest into a
-    `serde_yml::Value`, expand `foreach` and `when` entries with a Jinja
-    environment, then deserialize the expanded tree into the typed AST and
-    render remaining string fields.
+    `serde_yml::Value` (Stage 2: Initial YAML Parsing), expand `foreach` and
+    `when` entries with a Jinja environment (Stage 3: Template Expansion), then
+    deserialise the expanded tree into the typed AST and render remaining
+    string fields (Stage 4: Deserialisation & Final Rendering).
 
   - [x] Create a minijinja::Environment and populate its initial context with
     the global vars defined in the manifest.

--- a/scripts/assert-file-absent.sh
+++ b/scripts/assert-file-absent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensures the Netsuke build did not produce an unexpected artifact.
-# If the artifact is present and `NINJA_MANIFEST` is set, the referenced
+# Ensures the Netsuke build did not produce an unexpected artefact.
+# If the artefact is present and `NINJA_MANIFEST` is set, the referenced
 # Ninja manifest is dumped to stderr for debugging.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ fi
 file="$1"
 
 if [[ -f "$file" ]]; then
-  echo "Unexpected build artifact '$file' present." >&2
+  echo "Unexpected build artefact '$file' present." >&2
   if [[ -n "${NINJA_MANIFEST:-}" && -f "$NINJA_MANIFEST" ]]; then
     echo "Ninja manifest '$NINJA_MANIFEST' for debugging:" >&2
     echo "-----BEGIN NINJA MANIFEST-----" >&2

--- a/scripts/assert-file-absent.sh
+++ b/scripts/assert-file-absent.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $(basename "$0") <file>" >&2
-  exit 2   # usage error
+  exit 64   # EX_USAGE
 fi
 
 file="$1"

--- a/scripts/assert-file-absent.sh
+++ b/scripts/assert-file-absent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensures the Netsuke build did not produce an unexpected artefact.
-# If the artefact is present and `NINJA_MANIFEST` is set, the referenced
+# Ensures the Netsuke build did not produce an unexpected artifact.
+# If the artifact is present and `NINJA_MANIFEST` is set, the referenced
 # Ninja manifest is dumped to stderr for debugging.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ fi
 file="$1"
 
 if [[ -f "$file" ]]; then
-  echo "Unexpected build artefact '$file' present." >&2
+  echo "Unexpected build artifact '$file' present." >&2
   if [[ -n "${NINJA_MANIFEST:-}" && -f "$NINJA_MANIFEST" ]]; then
     echo "Ninja manifest '$NINJA_MANIFEST' for debugging:" >&2
     echo "-----BEGIN NINJA MANIFEST-----" >&2

--- a/scripts/assert-file-exists.sh
+++ b/scripts/assert-file-exists.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensures the Netsuke build produced the expected artifact.
-# If the artifact is absent and `NINJA_MANIFEST` is set, the referenced
+# Ensures the Netsuke build produced the expected artefact.
+# If the artefact is absent and `NINJA_MANIFEST` is set, the referenced
 # Ninja manifest is dumped to stderr for debugging.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ fi
 file="$1"
 
 if [[ ! -f "$file" ]]; then
-  echo "Expected build artifact '$file' to exist." >&2
+  echo "Expected build artefact '$file' to exist." >&2
   if [[ -n "${NINJA_MANIFEST:-}" && -f "$NINJA_MANIFEST" ]]; then
     echo "Ninja manifest '$NINJA_MANIFEST' for debugging:" >&2
     echo "-----BEGIN NINJA MANIFEST-----" >&2

--- a/scripts/assert-file-exists.sh
+++ b/scripts/assert-file-exists.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ensures the Netsuke build produced the expected artefact.
-# If the artefact is absent and `NINJA_MANIFEST` is set, the referenced
+# Ensures the Netsuke build produced the expected artifact.
+# If the artifact is absent and `NINJA_MANIFEST` is set, the referenced
 # Ninja manifest is dumped to stderr for debugging.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ fi
 file="$1"
 
 if [[ ! -f "$file" ]]; then
-  echo "Expected build artefact '$file' to exist." >&2
+  echo "Expected build artifact '$file' to exist." >&2
   if [[ -n "${NINJA_MANIFEST:-}" && -f "$NINJA_MANIFEST" ]]; then
     echo "Ninja manifest '$NINJA_MANIFEST' for debugging:" >&2
     echo "-----BEGIN NINJA MANIFEST-----" >&2

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,7 +97,7 @@ pub enum Commands {
     /// Build specified targets (or default targets if none are given) `default`.
     Build(BuildArgs),
 
-    /// Remove build artifacts and intermediate files.
+    /// Remove build artefacts and intermediate files.
     Clean,
 
     /// Display the build dependency graph in DOT format for visualization.

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -119,7 +119,7 @@ fn run_executes_ninja_without_persisting_file() {
     // Ensure no ninja file remains in project directory
     assert!(!temp.path().join("build.ninja").exists());
 
-    // Drop the fake ninja artifacts. PATH is restored by guard drop.
+    // Drop the fake ninja artefacts. PATH is restored by guard drop.
     drop(ninja_path);
 }
 
@@ -150,7 +150,7 @@ fn run_build_with_emit_keeps_file() {
     assert!(emitted.contains("build "));
     assert!(!temp.path().join("build.ninja").exists());
 
-    // Drop the fake ninja artifacts. PATH is restored by guard drop.
+    // Drop the fake ninja artefacts. PATH is restored by guard drop.
     drop(ninja_path);
 }
 
@@ -179,7 +179,7 @@ fn run_build_with_emit_creates_parent_dirs() {
     assert!(emit_path.exists());
     assert!(nested_dir.exists());
 
-    // Drop the fake ninja artifacts. PATH is restored by guard drop.
+    // Drop the fake ninja artefacts. PATH is restored by guard drop.
     drop(ninja_path);
 }
 


### PR DESCRIPTION
## Summary
- describe six-stage YAML-first build pipeline with deferred Jinja rendering
- clarify foreach/when semantics and prohibition on structural Jinja
- refresh roadmap for data-first parsing and iteration context

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Runtime error while rendering diagram)*

------
https://chatgpt.com/codex/tasks/task_e_689e835a8678832297752b53416887f0

## Summary by Sourcery

Document the transition to a six-stage YAML-first templating pipeline, clarify Jinja usage constraints, and update the development roadmap accordingly.

New Features:
- Introduce documentation for the six-stage YAML-first build pipeline with deferred Jinja rendering

Enhancements:
- Clarify the semantics of the foreach and when keys and prohibit structural Jinja control blocks
- Update the roadmap to reflect data-first parsing, iteration context preservation, and the two-pass expansion model

Documentation:
- Revise design documentation to describe the new pipeline stages and the prohibition of structural templating
- Refresh roadmap entries to align with the enhanced parsing and rendering workflow