### PR TITLE
Document NINJA_ENV usage and restore via OsString

### DIFF
--- a/ninja_env/src/lib.rs
+++ b/ninja_env/src/lib.rs
@@ -1,6 +1,16 @@
 #![forbid(unsafe_code)]
 
-//! Shared environment constants for netsuke tests.
+//! Shared environment constants used across netsuke crates (library, tests,
+//! and helpers).
 
 /// Environment variable override for the Ninja executable.
+///
+/// # Examples
+///
+/// ```
+/// use ninja_env::NINJA_ENV;
+/// std::env::set_var(NINJA_ENV, "/usr/bin/ninja");
+/// assert_eq!(std::env::var(NINJA_ENV).unwrap(), "/usr/bin/ninja");
+/// std::env::remove_var(NINJA_ENV);
+/// ```
 pub const NINJA_ENV: &str = "NETSUKE_NINJA";

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -30,7 +30,7 @@ fn override_ninja_env_sets_and_restores() {
 #[rstest]
 #[serial]
 fn override_ninja_env_unset_removes_variable() {
-    let before = std::env::var(NINJA_ENV).ok();
+    let before = std::env::var_os(NINJA_ENV);
     {
         let _lock = EnvLock::acquire();
         // SAFETY: `EnvLock` serialises mutations during setup.
@@ -47,7 +47,7 @@ fn override_ninja_env_unset_removes_variable() {
         let after = std::env::var(NINJA_ENV).expect("NINJA_ENV should be set after override");
         assert_eq!(after, target.to_string_lossy().as_ref());
     }
-    assert!(std::env::var(NINJA_ENV).is_err());
+    assert!(std::env::var_os(NINJA_ENV).is_none());
 
     // Restore original global state for isolation
     {


### PR DESCRIPTION
## Summary
- clarify NINJA_ENV docs and include a doctest
- capture and restore NINJA_ENV as an `OsString` in tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f064599b08322addd207d669a40a6