### PR TITLE
Refine ninja env docs and tests

### DIFF
--- a/ninja_env/src/lib.rs
+++ b/ninja_env/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
-//! Shared environment constants used across netsuke crates (library, tests,
-//! and helpers).
+//! Shared environment constants used across netsuke crates (library, tests, and
+//! helpers).
 
 /// Environment variable override for the Ninja executable.
 ///
@@ -10,7 +10,10 @@
 /// ```
 /// use ninja_env::NINJA_ENV;
 /// std::env::set_var(NINJA_ENV, "/usr/bin/ninja");
-/// assert_eq!(std::env::var(NINJA_ENV).unwrap(), "/usr/bin/ninja");
+/// assert_eq!(
+///     std::env::var(NINJA_ENV).expect("NINJA_ENV should be set"),
+///     "/usr/bin/ninja",
+/// );
 /// std::env::remove_var(NINJA_ENV);
 /// ```
 pub const NINJA_ENV: &str = "NETSUKE_NINJA";


### PR DESCRIPTION
## Summary
- tidy ninja env crate docs
- compare `NINJA_ENV` with `OsString` and share temp path via rstest fixture

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f13d1b0488322ba63228624031770

## Summary by Sourcery

Refine ninja_env crate by updating documentation formatting and improving tests for NINJA_ENV override behavior.

Enhancements:
- Replace inline temp path construction in tests with a rstest fixture returning a shared PathBuf
- Change NINJA_ENV comparisons in tests to use OsString for direct equality checks
- Simplify test comments and remove 'SAFETY' annotations in favor of plain comments

Documentation:
- Reformat crate-level documentation comments for consistency and multiline code examples

Tests:
- Add rstest fixture for temporary ninja path and inject it into override_ninja_env tests
- Refactor override_ninja_env tests to leverage PathBuf fixture and OsString assertions