### PR TITLE
Use list for deps in writing example

### DIFF
--- a/examples/writing.yml
+++ b/examples/writing.yml
@@ -20,7 +20,8 @@ targets:
     name: "{{ build_dir }}/{{ item | basename | replace('.md', '.tex') }}"
     rule: tex
     sources: "{{ item }}"
-    deps: "{{ build_dir }}"
+    deps:
+      - "{{ build_dir }}"
 
   - name: "{{ build_dir }}/book.pdf"
     rule: combine


### PR DESCRIPTION
## Summary
- represent `deps` as a list in `examples/writing.yml` to avoid type ambiguity

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a12ba925fc8322bbf4dd2a9316b93a

## Summary by Sourcery

Documentation:
- Update examples/writing.yml to define deps as a list rather than a string