### PR TITLE
Demonstrate foreach and when in Netsukefile workflow

### DIFF
--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -46,14 +46,21 @@ jobs:
               script: |
                 #!/bin/sh
                 touch inline-script.txt
+            - foreach:
+                - a
+                - skip
+                - b
+              when: item != 'skip'
+              name: "{{ item }}-foreach.txt"
+              command: "touch {{ item }}-foreach.txt"
           actions:
             - name: say-hello
               command: "touch action-called.txt"
             - name: unused-action
               command: "touch unused.txt"
           MANIFEST
-      - name: Build dependent and inline targets
-        run: ./target/debug/netsuke --verbose build --emit build.ninja dependent.txt inline-command.txt inline-script.txt
+      - name: Build dependent, inline, and foreach targets
+        run: ./target/debug/netsuke --verbose build --emit build.ninja dependent.txt inline-command.txt inline-script.txt a-foreach.txt b-foreach.txt
       - name: Assert dependent artefacts exist
         env:
           NINJA_MANIFEST: build.ninja
@@ -68,6 +75,16 @@ jobs:
         env:
           NINJA_MANIFEST: build.ninja
         run: scripts/assert-file-exists.sh inline-script.txt
+      - name: Assert foreach artefacts exist
+        env:
+          NINJA_MANIFEST: build.ninja
+        run: |
+          scripts/assert-file-exists.sh a-foreach.txt
+          scripts/assert-file-exists.sh b-foreach.txt
+      - name: Assert skipped foreach artefact absent
+        env:
+          NINJA_MANIFEST: build.ninja
+        run: scripts/assert-file-absent.sh skip-foreach.txt
       - name: Run action target
         run: ./target/debug/netsuke --verbose build --emit action.ninja say-hello
       - name: Assert action artefact exists


### PR DESCRIPTION
## Summary
- exercise `foreach` and `when` in the Netsukefile used by CI
- verify generated artefacts and filter behaviour in the workflow test

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a2722e85cc8322b2e10abe7af02264

## Summary by Sourcery

Demonstrate the use of foreach and when in the Netsukefile CI workflow by generating per-item targets, updating the build invocation, and verifying the resulting artifacts.

Enhancements:
- Introduce a foreach loop over items ['a','skip','b'] with a when filter to skip 'skip' in the workflow test
- Update the build step to include generated foreach targets in the build invocation

Tests:
- Add assertions to check existence of a-foreach.txt and b-foreach.txt
- Add assertion to verify that skip-foreach.txt is not generated