### PR TITLE
Add env() Jinja function for environment variables

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -677,11 +677,10 @@ targets:
     #...
 ```
 
-To extract the `vars` mapping without triggering errors for undefined
-placeholders elsewhere in the template, Netsuke first renders the manifest with
-lenient undefined behaviour. The resulting YAML is parsed to obtain the global
-variables, which are then injected into the environment before a second, strict
-render pass produces the final manifest for deserialisation.
+The `vars` mapping is read directly from the raw YAML before any Jinja is
+evaluated. This avoids a lenient rendering pass for undefined placeholders and
+keeps evaluation deterministic. The values are injected into the environment
+prior to rendering.
 
 The parser copies `vars` values into the environment using
 `Value::from_serializable`. This preserves native YAML types so Jinja's

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -729,7 +729,9 @@ providing a secure bridge to the underlying system.
 
 - `env(var_name: &str) -> Result<String, Error>`: A function that reads an
   environment variable from the system. This allows build configurations to be
-  influenced by the external environment (e.g., `PATH`, `CC`).
+  influenced by the external environment (e.g., `PATH`, `CC`). It returns an
+  error if the variable is undefined or contains invalid UTF-8 to ensure
+  manifests fail fast on missing inputs.
 
 - `glob(pattern: &str) -> Result<Vec<String>, Error>`: A function that performs
   file path globbing. This is a critical feature for any modern build tool,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,7 +101,7 @@ configurations with variables, control flow, and custom functions.
         per-iteration locals over `target.vars` and manifest globals for
         subsequent rendering phases.
 
-  - [ ] Implement the essential custom Jinja function env(var_name) to read
+  - [x] Implement the essential custom Jinja function env(var_name) to read
     system environment variables.
 
   - [ ] Implement the critical glob(pattern) custom function to perform file

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,7 +8,7 @@
 
 use crate::ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars};
 use miette::{Context, Diagnostic, IntoDiagnostic, NamedSource, Report, Result, SourceSpan};
-use minijinja::{context, value::Value, Environment, Error, ErrorKind, UndefinedBehavior};
+use minijinja::{Environment, Error, ErrorKind, UndefinedBehavior, context, value::Value};
 use serde_yml::{Error as YamlError, Location};
 use serde_yml::{Mapping as YamlMapping, Value as YamlValue};
 use std::{fs, path::Path};
@@ -177,7 +177,9 @@ fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
 /// # Errors
 ///
 /// Returns an error if YAML parsing or Jinja evaluation fails.
-pub fn from_str(yaml: &str) -> Result<NetsukeManifest> { from_str_named(yaml, "Netsukefile") }
+pub fn from_str(yaml: &str) -> Result<NetsukeManifest> {
+    from_str_named(yaml, "Netsukefile")
+}
 
 /// Expand `foreach` entries within the raw YAML document.
 fn expand_foreach(doc: &mut YamlValue, env: &Environment) -> Result<()> {

--- a/test_support/src/env.rs
+++ b/test_support/src/env.rs
@@ -95,10 +95,7 @@ impl VarGuard {
     /// assert_eq!(std::env::var("HELLO").expect("HELLO"), "world");
     /// ```
     pub fn set(key: &str, value: &OsStr) -> Self {
-        let _lock = EnvLock::acquire();
-        let previous = std::env::var_os(key);
-        // SAFETY: `EnvLock` serialises mutations.
-        unsafe { std::env::set_var(key, value) };
+        let previous = set_var(key, value);
         Self {
             key: key.to_string(),
             previous,
@@ -107,10 +104,7 @@ impl VarGuard {
 
     /// Remove `key`, returning a guard that restores the prior value.
     pub fn unset(key: &str) -> Self {
-        let _lock = EnvLock::acquire();
-        let previous = std::env::var_os(key);
-        // SAFETY: `EnvLock` serialises mutations.
-        unsafe { std::env::remove_var(key) };
+        let previous = remove_var(key);
         Self {
             key: key.to_string(),
             previous,

--- a/test_support/src/env.rs
+++ b/test_support/src/env.rs
@@ -189,7 +189,10 @@ pub struct NinjaEnvGuard {
 /// let env = SystemEnv::new();
 /// let path = std::env::temp_dir().join("ninja");
 /// let guard = override_ninja_env(&env, path.as_path());
-/// assert_eq!(std::env::var(NINJA_ENV).unwrap(), path.to_string_lossy());
+/// assert_eq!(
+///     std::env::var(NINJA_ENV).expect("NINJA_ENV"),
+///     path.to_string_lossy()
+/// );
 /// drop(guard);
 /// assert!(std::env::var(NINJA_ENV).is_err());
 /// ```

--- a/test_support/src/env.rs
+++ b/test_support/src/env.rs
@@ -92,7 +92,7 @@ impl VarGuard {
     /// use test_support::env::VarGuard;
     ///
     /// let _guard = VarGuard::set("HELLO", OsStr::new("world"));
-    /// assert_eq!(std::env::var("HELLO").unwrap(), "world");
+    /// assert_eq!(std::env::var("HELLO").expect("HELLO"), "world");
     /// ```
     pub fn set(key: &str, value: &OsStr) -> Self {
         let _lock = EnvLock::acquire();

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -26,7 +26,8 @@ pub struct CliWorld {
     pub temp: Option<tempfile::TempDir>,
     /// Guard that restores `PATH` after each scenario.
     pub path_guard: Option<PathGuard>,
-    /// Environment variables overridden during a scenario.
+    /// Snapshot of pre-scenario values for environment variables that were overridden.
+    /// Stores the original value (`Some`) or `None` if the variable was previously unset.
     pub env_vars: HashMap<String, Option<OsString>>,
 }
 

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -2,10 +2,7 @@
 
 use cucumber::World;
 use std::{collections::HashMap, ffi::OsString};
-use test_support::{
-    PathGuard,
-    env::{remove_var, set_var},
-};
+use test_support::{PathGuard, env::restore_many};
 
 /// Shared state for Cucumber scenarios.
 #[derive(Debug, Default, World)]
@@ -35,15 +32,8 @@ mod steps;
 
 impl Drop for CliWorld {
     fn drop(&mut self) {
-        if self.env_vars.is_empty() {
-            return;
-        }
-        for (key, val) in self.env_vars.drain() {
-            if let Some(v) = val {
-                let _ = set_var(&key, &v);
-            } else {
-                let _ = remove_var(&key);
-            }
+        if !self.env_vars.is_empty() {
+            restore_many(self.env_vars.drain().collect());
         }
     }
 }

--- a/tests/data/jinja_env.yml
+++ b/tests/data/jinja_env.yml
@@ -1,0 +1,4 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello
+    command: "echo {{ env('NETSUKE_TEST_ENV') }}"

--- a/tests/data/jinja_env_missing.yml
+++ b/tests/data/jinja_env_missing.yml
@@ -1,0 +1,4 @@
+netsuke_version: "1.0.0"
+targets:
+  - name: hello
+    command: "echo {{ env('NETSUKE_UNDEFINED_ENV') }}"

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -56,6 +56,17 @@ Feature: Manifest Parsing
     When the parsing result is checked
     Then parsing the manifest fails
 
+  Scenario: Reading environment variables in a manifest
+    Given the environment variable "NETSUKE_TEST_ENV" is set to "world"
+    And the manifest file "tests/data/jinja_env.yml" is parsed
+    When the manifest is checked
+    Then the first target command is "echo world"
+
+  Scenario: Parsing fails when an environment variable is undefined
+    Given the manifest file "tests/data/jinja_env_missing.yml" is parsed
+    When the parsing result is checked
+    Then parsing the manifest fails
+
   Scenario: Rendering Jinja conditionals in a manifest
     Given the manifest file "tests/data/jinja_if.yml" is parsed
     When the manifest is checked

--- a/tests/features/manifest.feature
+++ b/tests/features/manifest.feature
@@ -63,7 +63,8 @@ Feature: Manifest Parsing
     Then the first target command is "echo world"
 
   Scenario: Parsing fails when an environment variable is undefined
-    Given the manifest file "tests/data/jinja_env_missing.yml" is parsed
+    Given the environment variable "NETSUKE_UNDEFINED_ENV" is unset
+    And the manifest file "tests/data/jinja_env_missing.yml" is parsed
     When the parsing result is checked
     Then parsing the manifest fails
 

--- a/tests/manifest_env_tests.rs
+++ b/tests/manifest_env_tests.rs
@@ -1,0 +1,116 @@
+//! Tests for environment variable access via the Jinja `env()` helper.
+
+use netsuke::{ast::Recipe, manifest};
+use rstest::rstest;
+use serial_test::serial;
+use std::ffi::OsStr;
+use test_support::env_lock::EnvLock;
+
+fn set_var(key: &str, value: &OsStr) {
+    // SAFETY: `EnvLock` serialises mutations.
+    unsafe { std::env::set_var(key, value) };
+}
+
+fn remove_var(key: &str) {
+    // SAFETY: `EnvLock` serialises mutations.
+    unsafe { std::env::remove_var(key) };
+}
+
+fn manifest_yaml(body: &str) -> String {
+    format!("netsuke_version: 1.0.0\n{body}")
+}
+
+#[rstest]
+#[serial]
+fn env_var_renders() {
+    let key = "NETSUKE_ENV_TEST";
+    let yaml = manifest_yaml(
+        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_TEST') }}\"\n",
+    );
+    {
+        let _lock = EnvLock::acquire();
+        set_var(key, OsStr::new("world"));
+    }
+    let manifest = manifest::from_str(&yaml).expect("parse");
+    let first = manifest.targets.first().expect("target");
+    if let Recipe::Command { command } = &first.recipe {
+        assert_eq!(command, "echo world");
+    } else {
+        panic!("Expected command recipe, got: {:?}", first.recipe);
+    }
+    {
+        let _lock = EnvLock::acquire();
+        remove_var(key);
+    }
+}
+
+#[rstest]
+#[serial]
+fn env_var_with_special_chars_renders() {
+    let key = "NETSUKE_ENV_SPECIAL";
+    let value = "spaced value $with #symbols";
+    let yaml = manifest_yaml(
+        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_SPECIAL') }}\"\n",
+    );
+    {
+        let _lock = EnvLock::acquire();
+        set_var(key, OsStr::new(value));
+    }
+    let manifest = manifest::from_str(&yaml).expect("parse");
+    let first = manifest.targets.first().expect("target");
+    if let Recipe::Command { command } = &first.recipe {
+        assert_eq!(command, &format!("echo {value}"));
+    } else {
+        panic!("Expected command recipe, got: {:?}", first.recipe);
+    }
+    {
+        let _lock = EnvLock::acquire();
+        remove_var(key);
+    }
+}
+
+#[rstest]
+#[serial]
+fn missing_env_var_errors() {
+    let key = "NETSUKE_ENV_MISSING";
+    {
+        let _lock = EnvLock::acquire();
+        remove_var(key);
+    }
+    let yaml = manifest_yaml(
+        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_MISSING') }}\"\n",
+    );
+    assert!(manifest::from_str(&yaml).is_err());
+}
+
+#[cfg(unix)]
+#[rstest]
+#[serial]
+fn non_unicode_env_var_errors() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let key = "NETSUKE_ENV_NON_UNICODE";
+    let yaml = manifest_yaml(
+        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_NON_UNICODE') }}\"\n",
+    );
+
+    {
+        let _lock = EnvLock::acquire();
+        // Construct a non-UTF-8 value: [0x66, 0xFF, 0x6F] ~= "f" + invalid + "o"
+        let val = OsString::from_vec(vec![0x66, 0xFF, 0x6F]);
+        set_var(key, val.as_os_str());
+    }
+
+    let err = manifest::from_str(&yaml).expect_err("parse should fail on non-UTF-8");
+    assert!(
+        err.chain()
+            .any(|e| e.to_string().to_lowercase().contains("invalid utf-8")),
+        "unexpected error: {err}"
+    );
+
+    {
+        let _lock = EnvLock::acquire();
+        remove_var(key);
+    }
+}

--- a/tests/manifest_env_tests.rs
+++ b/tests/manifest_env_tests.rs
@@ -12,6 +12,7 @@ fn manifest_yaml(body: &str) -> String {
 
 #[rstest]
 #[case("NETSUKE_ENV_TEST", "world", "echo world")]
+#[case("NETSUKE_ENV_EMPTY", "", "echo ")]
 #[case(
     "NETSUKE_ENV_SPECIAL",
     "spaced value $with #symbols",

--- a/tests/manifest_jinja_tests.rs
+++ b/tests/manifest_jinja_tests.rs
@@ -3,8 +3,6 @@
 
 use netsuke::{ast::Recipe, manifest};
 use rstest::rstest;
-use serial_test::serial;
-use test_support::env_lock::EnvLock;
 
 fn manifest_yaml(body: &str) -> String {
     format!("netsuke_version: 1.0.0\n{body}")
@@ -78,74 +76,6 @@ fn undefined_variable_errors() {
 fn syntax_error_errors() {
     let yaml = manifest_yaml("targets:\n  - name: hello\n    command: echo {{ who\n");
 
-    assert!(manifest::from_str(&yaml).is_err());
-}
-
-#[rstest]
-#[serial]
-fn env_var_renders() {
-    let key = "NETSUKE_ENV_TEST";
-    let yaml = manifest_yaml(
-        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_TEST') }}\"\n",
-    );
-    {
-        let _lock = EnvLock::acquire();
-        // SAFETY: guarded by `EnvLock` to serialise mutations.
-        unsafe { std::env::set_var(key, "world") };
-    }
-    let manifest = manifest::from_str(&yaml).expect("parse");
-    let first = manifest.targets.first().expect("target");
-    if let Recipe::Command { command } = &first.recipe {
-        assert_eq!(command, "echo world");
-    } else {
-        panic!("Expected command recipe, got: {:?}", first.recipe);
-    }
-    {
-        let _lock = EnvLock::acquire();
-        // SAFETY: guarded by `EnvLock` to serialise mutations.
-        unsafe { std::env::remove_var(key) };
-    }
-}
-
-#[rstest]
-#[serial]
-fn env_var_with_special_chars_renders() {
-    let key = "NETSUKE_ENV_SPECIAL";
-    let value = "spaced value $with #symbols";
-    let yaml = manifest_yaml(
-        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_SPECIAL') }}\"\n",
-    );
-    {
-        let _lock = EnvLock::acquire();
-        // SAFETY: guarded by `EnvLock` to serialise mutations.
-        unsafe { std::env::set_var(key, value) };
-    }
-    let manifest = manifest::from_str(&yaml).expect("parse");
-    let first = manifest.targets.first().expect("target");
-    if let Recipe::Command { command } = &first.recipe {
-        assert_eq!(command, &format!("echo {value}"));
-    } else {
-        panic!("Expected command recipe, got: {:?}", first.recipe);
-    }
-    {
-        let _lock = EnvLock::acquire();
-        // SAFETY: guarded by `EnvLock` to serialise mutations.
-        unsafe { std::env::remove_var(key) };
-    }
-}
-
-#[rstest]
-#[serial]
-fn missing_env_var_errors() {
-    let key = "NETSUKE_ENV_MISSING";
-    {
-        let _lock = EnvLock::acquire();
-        // SAFETY: guarded by `EnvLock` to serialise mutations.
-        unsafe { std::env::remove_var(key) };
-    }
-    let yaml = manifest_yaml(
-        "targets:\n  - name: hello\n    command: \"echo {{ env('NETSUKE_ENV_MISSING') }}\"\n",
-    );
     assert!(manifest::from_str(&yaml).is_err());
 }
 

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -7,7 +7,7 @@ use netsuke::{
     manifest,
 };
 use std::ffi::OsStr;
-use test_support::env_lock::EnvLock;
+use test_support::env::{remove_var, set_var};
 
 const INDEX_KEY: &str = "index";
 
@@ -17,16 +17,6 @@ fn get_string_from_string_or_list(value: &StringOrList, field_name: &str) -> Str
         StringOrList::List(list) if list.len() == 1 => list.first().expect("one element").clone(),
         other => panic!("Expected String or single-item List for {field_name}, got: {other:?}"),
     }
-}
-
-fn set_var(key: &str, value: &OsStr) {
-    // SAFETY: `EnvLock` serialises mutations and the world restores on drop.
-    unsafe { std::env::set_var(key, value) };
-}
-
-fn remove_var(key: &str) {
-    // SAFETY: `EnvLock` serialises mutations and the world restores on drop.
-    unsafe { std::env::remove_var(key) };
 }
 
 fn parse_manifest_inner(world: &mut CliWorld, path: &str) {
@@ -71,17 +61,13 @@ fn get_target(world: &CliWorld, index: usize) -> &Target {
     reason = "Cucumber step requires owned String"
 )]
 fn set_env_var(world: &mut CliWorld, key: String, value: String) {
-    let _lock = EnvLock::acquire();
-    let previous = std::env::var_os(&key);
-    set_var(&key, OsStr::new(&value));
+    let previous = set_var(&key, OsStr::new(&value));
     world.env_vars.insert(key, previous);
 }
 
 #[given(expr = "the environment variable {string} is unset")]
 fn unset_env_var(world: &mut CliWorld, key: String) {
-    let _lock = EnvLock::acquire();
-    let previous = std::env::var_os(&key);
-    remove_var(&key);
+    let previous = remove_var(&key);
     world.env_vars.insert(key, previous);
 }
 

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -64,14 +64,14 @@ fn set_env_var(world: &mut CliWorld, key: String, value: String) {
     // Central helper acquires the global lock and returns the prior value so
     // the scenario can restore it afterwards.
     let previous = set_var(&key, OsStr::new(&value));
-    world.env_vars.insert(key, previous);
+    world.env_vars.entry(key).or_insert(previous);
 }
 
 #[given(expr = "the environment variable {string} is unset")]
 fn unset_env_var(world: &mut CliWorld, key: String) {
     // Capture any previous value for restoration when the scenario ends.
     let previous = remove_var(&key);
-    world.env_vars.insert(key, previous);
+    world.env_vars.entry(key).or_insert(previous);
 }
 
 #[given(expr = "the manifest file {string} is parsed")]

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -67,6 +67,15 @@ fn set_env_var(world: &mut CliWorld, key: String, value: String) {
     world.env_vars.insert(key, previous);
 }
 
+#[given(expr = "the environment variable {string} is unset")]
+fn unset_env_var(world: &mut CliWorld, key: String) {
+    let _lock = EnvLock::acquire();
+    let previous = std::env::var(&key).ok();
+    // SAFETY: `EnvLock` serialises mutations and the world restores on drop.
+    unsafe { std::env::remove_var(&key) };
+    world.env_vars.insert(key, previous);
+}
+
 #[given(expr = "the manifest file {string} is parsed")]
 #[expect(
     clippy::needless_pass_by_value,

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -61,12 +61,15 @@ fn get_target(world: &CliWorld, index: usize) -> &Target {
     reason = "Cucumber step requires owned String"
 )]
 fn set_env_var(world: &mut CliWorld, key: String, value: String) {
+    // Central helper acquires the global lock and returns the prior value so
+    // the scenario can restore it afterwards.
     let previous = set_var(&key, OsStr::new(&value));
     world.env_vars.insert(key, previous);
 }
 
 #[given(expr = "the environment variable {string} is unset")]
 fn unset_env_var(world: &mut CliWorld, key: String) {
+    // Capture any previous value for restoration when the scenario ends.
     let previous = remove_var(&key);
     world.env_vars.insert(key, previous);
 }


### PR DESCRIPTION
## Summary
- expose `env()` Jinja helper to read environment variables during manifest rendering
- document custom function behaviour and mark roadmap item complete
- test environment-driven templating with unit and Cucumber scenarios

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68a2ca7a8e188322a4106b7a01b55086

## Summary by Sourcery

Add a custom Jinja `env()` function to read environment variables with strict error handling in manifest rendering; provide accompanying test support utilities for safely setting, unsetting, and restoring process-wide environment variables; update documentation and add unit and Cucumber tests to validate environment-driven templating.

New Features:
- Introduce `env(name)` Jinja helper to retrieve environment variables or error on missing/invalid UTF-8

Enhancements:
- Implement test-support functions (`set_var`, `remove_var`, `restore_many`, `VarGuard`) to safely mutate and restore environment variables under a global lock
- Add Cucumber steps to set/unset environment variables within scenarios and restore them automatically

Documentation:
- Update design documentation to describe direct `vars` mapping and `env()` function behavior
- Mark the `env(var_name)` roadmap item as completed

Tests:
- Add parameterized unit tests (`tests/manifest_env_tests.rs`) covering successful, missing, and non-UTF-8 environment values
- Extend feature file and Cucumber world to validate `env()` behavior in manifest parsing