### PR TITLE
Improve YAML error reporting with miette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.4.2",
+ "terminal_size",
 ]
 
 [[package]]
@@ -570,7 +570,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.104",
- "textwrap 0.16.2",
+ "textwrap",
  "thiserror",
  "typed-builder",
 ]
@@ -628,12 +628,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
@@ -703,17 +697,6 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -833,30 +816,28 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miette"
-version = "5.10.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "backtrace",
  "backtrace-ext",
- "is-terminal",
+ "cfg-if",
  "miette-derive",
- "once_cell",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.1.17",
- "textwrap 0.15.2",
- "thiserror",
+ "terminal_size",
+ "textwrap",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "5.10.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -956,7 +937,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "serde_spanned",
  "serde_yml",
  "serial_test",
  "sha2",
@@ -1047,9 +1027,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking_lot"
@@ -1418,15 +1398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,31 +1500,24 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "supports-color"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
- "is-terminal",
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "supports-unicode"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
-dependencies = [
- "is-terminal",
-]
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -1625,16 +1589,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
@@ -1656,17 +1610,6 @@ dependencies = [
  "mockable",
  "ninja_env",
  "tempfile",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,7 +203,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
+ "terminal_size 0.4.2",
 ]
 
 [[package]]
@@ -230,7 +239,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.1",
  "windows-sys 0.59.0",
 ]
 
@@ -561,7 +570,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.104",
- "textwrap",
+ "textwrap 0.16.2",
  "thiserror",
  "typed-builder",
 ]
@@ -619,6 +628,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
@@ -689,6 +704,23 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -800,6 +832,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size 0.1.17",
+ "textwrap 0.15.2",
+ "thiserror",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "minijinja"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +946,7 @@ dependencies = [
  "insta",
  "itertools 0.12.1",
  "itoa",
+ "miette",
  "minijinja",
  "mockable",
  "mockall",
@@ -891,6 +956,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
+ "serde_spanned",
  "serde_yml",
  "serial_test",
  "sha2",
@@ -978,6 +1044,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -1346,6 +1418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1528,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1625,16 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
@@ -1541,13 +1660,24 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -1699,6 +1829,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "serde_yml",
  "serial_test",
  "sha2",
+ "strip-ansi-escapes",
  "tempfile",
  "test_support",
  "thiserror",
@@ -1493,6 +1494,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1812,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ mockable = { version = "0.3", features = ["mock"] }
 serial_test = "3"
 mockall = "0.11"
 test_support = { path = "test_support" }
+strip-ansi-escapes = "0.2"
 
 [[test]]
 name = "cucumber"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ minijinja = "2.11.0"
 semver = { version = "1", features = ["serde"] }
 anyhow = "1"
 thiserror = "1"
+miette = { version = "5", features = ["fancy"] }
+serde_spanned = "1"
 sha2 = "0.10"
 itoa = "1"
 itertools = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ minijinja = "2.11.0"
 semver = { version = "1", features = ["serde"] }
 anyhow = "1"
 thiserror = "1"
-miette = { version = "5", features = ["fancy"] }
-serde_spanned = "1"
+miette = { version = "7.6.0", features = ["fancy"] }
 sha2 = "0.10"
 itoa = "1"
 itertools = "0.12"

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1269,12 +1269,13 @@ three fundamental questions:
    Found a tab character, which is not allowed. Hint: Use spaces for
    indentation instead.").
 
-### 7.2 Crate Selection and Strategy: `anyhow` and `thiserror`
+### 7.2 Crate Selection and Strategy: `anyhow`, `thiserror`, and `miette`
 
-To implement this philosophy, Netsuke will adopt a hybrid error handling
-strategy using the `anyhow` and `thiserror` crates. This is a common and highly
-effective pattern in the Rust ecosystem for creating robust applications and
-libraries.[^27]
+To implement this philosophy, Netsuke adopts a hybrid error handling strategy
+using the `anyhow`, `thiserror`, and `miette` crates. This is a common and
+highly effective pattern in the Rust ecosystem for creating robust applications
+and libraries.[^27] `miette` renders user-facing diagnostics, underlining spans
+from `serde_spanned`.
 
 - `thiserror`: This crate will be used *within* Netsuke's internal library
   modules (e.g., `parser`, `ir`, `ninja_gen`) to define specific, structured
@@ -1315,6 +1316,9 @@ pub enum IrGenError {
   `?` operator for clean error propagation and the `.context()` and
   `.with_context()` methods for adding high-level, human-readable context to
   errors as they bubble up the call stack.[^31]
+
+- `miette`: Presents human-friendly diagnostics, leveraging spans from
+  `serde_spanned` to highlight exact error locations.
 
 ### 7.3 Error Handling Flow
 
@@ -1563,15 +1567,15 @@ goal.
 This table serves as a quick-reference guide to the core third-party crates
 selected for this project and the rationale for their inclusion.
 
-| Component      | Recommended Crate  | Rationale                                                                                                               |
-| -------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| CLI Parsing    | clap               | The Rust standard for powerful, derive-based CLI development.                                                           |
-| YAML Parsing   | serde_yml          | Mature, stable, and provides seamless integration with the serde framework.                                             |
-| Templating     | minijinja          | High compatibility with Jinja2, minimal dependencies, and supports runtime template loading.                            |
-| Shell Quoting  | shell-quote        | A critical security component; provides robust, shell-specific escaping for command arguments.                          |
-| Error Handling | anyhow + thiserror | An idiomatic and powerful combination for creating rich, contextual, and user-friendly error reports.                   |
-| Logging        | tracing            | Structured, levelled diagnostic output for debugging and insight.                                                       |
-| Versioning     | semver             | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field. |
+| Component      | Recommended Crate                           | Rationale                                                                                                                       |
+| -------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| CLI Parsing    | clap                                        | The Rust standard for powerful, derive-based CLI development.                                                                   |
+| YAML Parsing   | serde_yml                                   | Mature, stable, and provides seamless integration with the serde framework.                                                     |
+| Templating     | minijinja                                   | High compatibility with Jinja2, minimal dependencies, and supports runtime template loading.                                    |
+| Shell Quoting  | shell-quote                                 | A critical security component; provides robust, shell-specific escaping for command arguments.                                  |
+| Error Handling | anyhow + thiserror + miette + serde_spanned | An idiomatic and powerful combination for creating rich, contextual, and user-friendly error reports with precise source spans. |
+| Logging        | tracing                                     | Structured, levelled diagnostic output for debugging and insight.                                                               |
+| Versioning     | semver                                      | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field.         |
 
 ### 9.3 Future Enhancements
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1274,8 +1274,8 @@ three fundamental questions:
 To implement this philosophy, Netsuke adopts a hybrid error handling strategy
 using the `anyhow`, `thiserror`, and `miette` crates. This is a common and
 highly effective pattern in the Rust ecosystem for creating robust applications
-and libraries.[^27] `miette` renders user-facing diagnostics, underlining spans
-from `serde_spanned`.
+and libraries.[^27] `miette` renders user-facing diagnostics, computing spans
+directly from parser locations.
 
 - `thiserror`: This crate will be used *within* Netsuke's internal library
   modules (e.g., `parser`, `ir`, `ninja_gen`) to define specific, structured
@@ -1317,8 +1317,8 @@ pub enum IrGenError {
   `.with_context()` methods for adding high-level, human-readable context to
   errors as they bubble up the call stack.[^31]
 
-- `miette`: Presents human-friendly diagnostics, leveraging spans from
-  `serde_spanned` to highlight exact error locations.
+- `miette`: Presents human-friendly diagnostics, highlighting exact error
+  locations with computed spans.
 
 ### 7.3 Error Handling Flow
 
@@ -1567,15 +1567,15 @@ goal.
 This table serves as a quick-reference guide to the core third-party crates
 selected for this project and the rationale for their inclusion.
 
-| Component      | Recommended Crate                           | Rationale                                                                                                                       |
-| -------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| CLI Parsing    | clap                                        | The Rust standard for powerful, derive-based CLI development.                                                                   |
-| YAML Parsing   | serde_yml                                   | Mature, stable, and provides seamless integration with the serde framework.                                                     |
-| Templating     | minijinja                                   | High compatibility with Jinja2, minimal dependencies, and supports runtime template loading.                                    |
-| Shell Quoting  | shell-quote                                 | A critical security component; provides robust, shell-specific escaping for command arguments.                                  |
-| Error Handling | anyhow + thiserror + miette + serde_spanned | An idiomatic and powerful combination for creating rich, contextual, and user-friendly error reports with precise source spans. |
-| Logging        | tracing                                     | Structured, levelled diagnostic output for debugging and insight.                                                               |
-| Versioning     | semver                                      | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field.         |
+| Component      | Recommended Crate           | Rationale                                                                                                                       |
+| -------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| CLI Parsing    | clap                        | The Rust standard for powerful, derive-based CLI development.                                                                   |
+| YAML Parsing   | serde_yml                   | Mature, stable, and provides seamless integration with the serde framework.                                                     |
+| Templating     | minijinja                   | High compatibility with Jinja2, minimal dependencies, and supports runtime template loading.                                    |
+| Shell Quoting  | shell-quote                 | A critical security component; provides robust, shell-specific escaping for command arguments.                                  |
+| Error Handling | anyhow + thiserror + miette | An idiomatic and powerful combination for creating rich, contextual, and user-friendly error reports with precise source spans. |
+| Logging        | tracing                     | Structured, levelled diagnostic output for debugging and insight.                                                               |
+| Versioning     | semver                      | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field.         |
 
 ### 9.3 Future Enhancements
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -6,12 +6,80 @@
 
 use crate::ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars};
 use anyhow::{Context, Result, anyhow};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use minijinja::{Environment, UndefinedBehavior, context, value::Value};
+use serde_spanned::Spanned;
+use serde_yml::{Error as YamlError, Location};
 use serde_yml::{Mapping as YamlMapping, Value as YamlValue};
+use std::fmt::Write;
 use std::{fs, path::Path};
+use thiserror::Error;
 
-const ERR_INITIAL_YAML_PARSE: &str = "initial YAML parse error";
 const ERR_MANIFEST_PARSE: &str = "manifest parse error";
+
+// Compute a narrow highlight span from a location.
+fn to_span(src: &str, loc: Location) -> SourceSpan {
+    let at = loc.index();
+    let end = if src.as_bytes().get(at).is_some_and(|b| *b != b'\n') {
+        at + 1
+    } else {
+        at
+    };
+    let span = Spanned::new(at..end, ());
+    SourceSpan::new(span.span().start.into(), span.span().len().into())
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("{message}")]
+struct YamlDiagnostic {
+    #[source_code]
+    src: NamedSource,
+    #[label("{label}")]
+    span: Option<SourceSpan>,
+    #[help]
+    help: Option<String>,
+    #[source]
+    source: Option<anyhow::Error>,
+    #[diagnostic(code(netsuke.yaml.parse))]
+    message: String,
+    label: String,
+}
+
+fn hint_for(err_str: &str, src: &str) -> Option<String> {
+    let lower = err_str.to_lowercase();
+    if src.contains('\t') {
+        Some("Use spaces for indentation; tabs are invalid in YAML.".into())
+    } else if lower.contains("did not find expected '-'") {
+        Some("Start list items with '-' and ensure proper indentation.".into())
+    } else if lower.contains("expected ':'") {
+        Some("Ensure each key is followed by ':' separating key and value.".into())
+    } else {
+        None
+    }
+}
+
+fn map_yaml_error(err: &YamlError, src: &str) -> anyhow::Error {
+    let (line, col, span) = err.location().map_or((1, 1, None), |l| {
+        (l.line(), l.column(), Some(to_span(src, l)))
+    });
+    let err_str = err.to_string();
+    let hint = hint_for(&err_str, src);
+    let mut message = format!("YAML parse error at line {line}, column {col}: {err_str}");
+    if let Some(h) = &hint {
+        write!(message, " Hint: {h}").expect("string write");
+    }
+
+    let diag = YamlDiagnostic {
+        src: NamedSource::new("manifest.yml", src.to_string()),
+        span,
+        help: hint,
+        source: Some(anyhow::Error::msg(err_str.clone())),
+        message,
+        label: "parse error here".into(),
+    };
+
+    anyhow::Error::new(diag)
+}
 
 /// Parse a manifest string using Jinja for value templating.
 ///
@@ -22,7 +90,7 @@ const ERR_MANIFEST_PARSE: &str = "manifest parse error";
 ///
 /// Returns an error if YAML parsing or Jinja evaluation fails.
 pub fn from_str(yaml: &str) -> Result<NetsukeManifest> {
-    let mut doc: YamlValue = serde_yml::from_str(yaml).context(ERR_INITIAL_YAML_PARSE)?;
+    let mut doc: YamlValue = serde_yml::from_str(yaml).map_err(|e| map_yaml_error(&e, yaml))?;
 
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -11,7 +11,6 @@ use minijinja::{Environment, UndefinedBehavior, context, value::Value};
 use serde_spanned::Spanned;
 use serde_yml::{Error as YamlError, Location};
 use serde_yml::{Mapping as YamlMapping, Value as YamlValue};
-use std::fmt::Write;
 use std::{fs, path::Path};
 use thiserror::Error;
 
@@ -31,7 +30,8 @@ fn to_span(src: &str, loc: Location) -> SourceSpan {
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("{message}")]
-struct YamlDiagnostic {
+#[doc(hidden)]
+pub struct YamlDiagnostic {
     #[source_code]
     src: NamedSource,
     #[label("{label}")]
@@ -64,10 +64,7 @@ fn map_yaml_error(err: &YamlError, src: &str) -> anyhow::Error {
     });
     let err_str = err.to_string();
     let hint = hint_for(&err_str, src);
-    let mut message = format!("YAML parse error at line {line}, column {col}: {err_str}");
-    if let Some(h) = &hint {
-        write!(message, " Hint: {h}").expect("string write");
-    }
+    let message = format!("YAML parse error at line {line}, column {col}: {err_str}");
 
     let diag = YamlDiagnostic {
         src: NamedSource::new("manifest.yml", src.to_string()),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -253,7 +253,7 @@ fn write_ninja_file(path: &Path, content: &NinjaContent) -> Result<()> {
 fn generate_ninja(cli: &Cli) -> Result<NinjaContent> {
     let manifest_path = resolve_manifest_path(cli);
     let manifest = manifest::from_path(&manifest_path)
-        .wrap_err_with(|| format!("loading manifest at {}", manifest_path.display()))?;
+        .with_context(|| format!("loading manifest at {}", manifest_path.display()))?;
     let ast_json = serde_json::to_string_pretty(&manifest)
         .into_diagnostic()
         .wrap_err("serialising manifest")?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,7 @@
 
 use crate::cli::{BuildArgs, Cli, Commands};
 use crate::{ir::BuildGraph, manifest, ninja_gen};
-use anyhow::{Context, Error, Result};
+use miette::{Context, IntoDiagnostic, Result};
 use serde_json;
 use std::borrow::Cow;
 use std::fs;
@@ -174,7 +174,9 @@ fn handle_build(cli: &Cli, args: &BuildArgs) -> Result<()> {
     }
 
     let program = resolve_ninja_program();
-    run_ninja(program.as_path(), cli, build_path.as_ref(), &targets)?;
+    run_ninja(program.as_path(), cli, build_path.as_ref(), &targets)
+        .into_diagnostic()
+        .wrap_err("run ninja")?;
     drop(tmp_file);
     Ok(())
 }
@@ -196,7 +198,8 @@ fn create_temp_ninja_file(content: &NinjaContent) -> Result<NamedTempFile> {
         .prefix("netsuke.")
         .suffix(".ninja")
         .tempfile()
-        .context("create temp file")?;
+        .into_diagnostic()
+        .wrap_err("create temp file")?;
     write_ninja_file(tmp.path(), content)?;
     Ok(tmp)
 }
@@ -217,10 +220,12 @@ fn write_ninja_file(path: &Path, content: &NinjaContent) -> Result<()> {
     // do not attempt to create the current directory on some platforms.
     if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to create parent directory {}", parent.display()))?;
     }
     fs::write(path, content.as_str())
-        .with_context(|| format!("failed to write Ninja file to {}", path.display()))?;
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to write Ninja file to {}", path.display()))?;
     info!("Generated Ninja file at {}", path.display());
     Ok(())
 }
@@ -247,15 +252,15 @@ fn write_ninja_file(path: &Path, content: &NinjaContent) -> Result<()> {
 /// ```
 fn generate_ninja(cli: &Cli) -> Result<NinjaContent> {
     let manifest_path = resolve_manifest_path(cli);
-    let manifest = manifest::from_path(&manifest_path).map_err(|e| {
-        Error::msg(format!(
-            "loading manifest at {}: {e}",
-            manifest_path.display()
-        ))
-    })?;
-    let ast_json = serde_json::to_string_pretty(&manifest).context("serialising manifest")?;
+    let manifest = manifest::from_path(&manifest_path)
+        .wrap_err_with(|| format!("loading manifest at {}", manifest_path.display()))?;
+    let ast_json = serde_json::to_string_pretty(&manifest)
+        .into_diagnostic()
+        .wrap_err("serialising manifest")?;
     debug!("AST:\n{ast_json}");
-    let graph = BuildGraph::from_manifest(&manifest).context("building graph")?;
+    let graph = BuildGraph::from_manifest(&manifest)
+        .into_diagnostic()
+        .wrap_err("building graph")?;
     Ok(NinjaContent::new(ninja_gen::generate(&graph)))
 }
 

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -1,11 +1,12 @@
 //! Unit tests for Netsuke manifest AST deserialisation.
 
+use miette::Result;
 use netsuke::{ast::*, manifest};
 use rstest::rstest;
 use semver::Version;
 
 /// Convenience wrapper around the library manifest parser for tests.
-fn parse_manifest(yaml: &str) -> anyhow::Result<NetsukeManifest> {
+fn parse_manifest(yaml: &str) -> Result<NetsukeManifest> {
     manifest::from_str(yaml)
 }
 

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -70,7 +70,12 @@ fn run_exits_with_manifest_error_on_invalid_version() {
     let result = run(&cli);
     assert!(result.is_err());
     let err = result.expect_err("should have error");
-    assert!(err.to_string().contains("manifest parse error"));
+    let chain: Vec<_> = err.chain().map(std::string::ToString::to_string).collect();
+    assert!(
+        chain.iter().any(|s| s.contains("manifest parse error")),
+        "expected error chain to include 'manifest parse error', got: {chain:?}"
+    );
+    assert!(err.to_string().contains("loading manifest at"));
 }
 
 #[rstest]

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -69,10 +69,10 @@ fn run_exits_with_manifest_error_on_invalid_version() {
 
     let err = run(&cli).expect_err("should have error");
     assert!(err.to_string().contains("loading manifest at"));
-    let source = err.source().expect("source error").to_string();
+    let chain: Vec<String> = err.chain().map(ToString::to_string).collect();
     assert!(
-        source.contains("manifest parse error"),
-        "expected parse error in source, got: {source}"
+        chain.iter().any(|s| s.contains("manifest parse error")),
+        "expected error chain to include 'manifest parse error', got: {chain:?}"
     );
 }
 

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -70,7 +70,7 @@ fn run_exits_with_manifest_error_on_invalid_version() {
     let result = run(&cli);
     assert!(result.is_err());
     let err = result.expect_err("should have error");
-    assert!(err.chain().any(|e| e.to_string().contains("version")));
+    assert!(err.to_string().contains("manifest parse error"));
 }
 
 #[rstest]

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -67,15 +67,13 @@ fn run_exits_with_manifest_error_on_invalid_version() {
         })),
     };
 
-    let result = run(&cli);
-    assert!(result.is_err());
-    let err = result.expect_err("should have error");
-    let chain: Vec<_> = err.chain().map(std::string::ToString::to_string).collect();
-    assert!(
-        chain.iter().any(|s| s.contains("manifest parse error")),
-        "expected error chain to include 'manifest parse error', got: {chain:?}"
-    );
+    let err = run(&cli).expect_err("should have error");
     assert!(err.to_string().contains("loading manifest at"));
+    let source = err.source().expect("source error").to_string();
+    assert!(
+        source.contains("manifest parse error"),
+        "expected parse error in source, got: {source}"
+    );
 }
 
 #[rstest]

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -2,6 +2,7 @@
 
 use crate::CliWorld;
 use cucumber::{given, then, when};
+use miette::IntoDiagnostic;
 use netsuke::ir::BuildGraph;
 
 fn assert_graph(world: &CliWorld) {
@@ -50,7 +51,7 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
 #[when(expr = "the manifest file {string} is compiled to IR")]
 fn compile_manifest(world: &mut CliWorld, path: String) {
     match netsuke::manifest::from_path(&path)
-        .and_then(|m| BuildGraph::from_manifest(&m).map_err(|e| miette::Report::msg(e.to_string())))
+        .and_then(|m| BuildGraph::from_manifest(&m).into_diagnostic())
     {
         Ok(graph) => {
             world.build_graph = Some(graph);

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -2,7 +2,7 @@
 
 use crate::CliWorld;
 use cucumber::{given, then, when};
-use miette::IntoDiagnostic;
+use miette::{Context, IntoDiagnostic};
 use netsuke::ir::BuildGraph;
 
 fn assert_graph(world: &CliWorld) {
@@ -52,6 +52,7 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
 fn compile_manifest(world: &mut CliWorld, path: String) {
     match netsuke::manifest::from_path(&path)
         .and_then(|m| BuildGraph::from_manifest(&m).into_diagnostic())
+        .with_context(|| format!("IR generation failed for {path}"))
     {
         Ok(graph) => {
             world.build_graph = Some(graph);

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -50,7 +50,7 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
 #[when(expr = "the manifest file {string} is compiled to IR")]
 fn compile_manifest(world: &mut CliWorld, path: String) {
     match netsuke::manifest::from_path(&path)
-        .and_then(|m| BuildGraph::from_manifest(&m).map_err(anyhow::Error::from))
+        .and_then(|m| BuildGraph::from_manifest(&m).map_err(|e| miette::Report::msg(e.to_string())))
     {
         Ok(graph) => {
             world.build_graph = Some(graph);

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -51,7 +51,11 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
 #[when(expr = "the manifest file {string} is compiled to IR")]
 fn compile_manifest(world: &mut CliWorld, path: String) {
     match netsuke::manifest::from_path(&path)
-        .and_then(|m| BuildGraph::from_manifest(&m).into_diagnostic())
+        .and_then(|m| {
+            BuildGraph::from_manifest(&m)
+                .into_diagnostic()
+                .wrap_err("building IR from manifest")
+        })
         .with_context(|| format!("IR generation failed for {path}"))
     {
         Ok(graph) => {

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -1,0 +1,26 @@
+use netsuke::manifest;
+
+#[test]
+fn reports_line_and_column_with_tab_hint() {
+    let yaml = "targets:\n\t- name: test\n";
+    let err = manifest::from_str(yaml).expect_err("parse should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("line 2, column 1"), "missing location: {msg}");
+    assert!(
+        msg.contains("Use spaces for indentation"),
+        "missing hint: {msg}"
+    );
+}
+
+#[test]
+fn suggests_colon_when_missing() {
+    let yaml = "targets:\n  - name: hi\n    command echo\n";
+    let err = manifest::from_str(yaml).expect_err("parse should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("line 3"), "missing line info: {msg}");
+    assert!(msg.contains("expected ':'"), "missing error detail: {msg}");
+    assert!(
+        msg.contains("Ensure each key is followed by ':'"),
+        "missing suggestion: {msg}"
+    );
+}

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -1,10 +1,17 @@
-use netsuke::manifest;
+use miette::GraphicalReportHandler;
+use netsuke::manifest::{self, YamlDiagnostic};
 
 #[test]
 fn reports_line_and_column_with_tab_hint() {
     let yaml = "targets:\n\t- name: test\n";
     let err = manifest::from_str(yaml).expect_err("parse should fail");
-    let msg = err.to_string();
+    let diag = err
+        .downcast_ref::<YamlDiagnostic>()
+        .expect("diagnostic type");
+    let mut msg = String::new();
+    GraphicalReportHandler::new()
+        .render_report(&mut msg, diag)
+        .expect("render yaml error");
     assert!(msg.contains("line 2, column 1"), "missing location: {msg}");
     assert!(
         msg.contains("Use spaces for indentation"),
@@ -16,7 +23,13 @@ fn reports_line_and_column_with_tab_hint() {
 fn suggests_colon_when_missing() {
     let yaml = "targets:\n  - name: hi\n    command echo\n";
     let err = manifest::from_str(yaml).expect_err("parse should fail");
-    let msg = err.to_string();
+    let diag = err
+        .downcast_ref::<YamlDiagnostic>()
+        .expect("diagnostic type");
+    let mut msg = String::new();
+    GraphicalReportHandler::new()
+        .render_report(&mut msg, diag)
+        .expect("render yaml error");
     assert!(msg.contains("line 3"), "missing line info: {msg}");
     assert!(msg.contains("expected ':'"), "missing error detail: {msg}");
     assert!(

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -11,6 +11,20 @@ use rstest::rstest;
     "targets:\n  - name: hi\n    command echo\n",
     &["line 3", "expected ':'", "Ensure each key is followed by ':'"],
 )]
+#[case(
+    concat!(
+        "targets:\n",
+        "  - name: ok\n",
+        "    command: echo\n",
+        "  name: missing\n",
+        "    command: echo\n",
+    ),
+    &["line 4", "did not find expected '-'", "Start list items with '-'"],
+)]
+#[case(
+    "targets:\n  - command: [echo\n",
+    &["line 2", "did not find expected ',' or ']'"],
+)]
 fn yaml_diagnostics_are_actionable(#[case] yaml: &str, #[case] needles: &[&str]) {
     let err = manifest::from_str(yaml).expect_err("parse should fail");
     let diag = err


### PR DESCRIPTION
## Summary
- use miette and serde_spanned to highlight YAML parse errors with spans and actionable hints
- document miette-based diagnostics in design guidelines

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`

closes #49

------
https://chatgpt.com/codex/tasks/task_e_68a2c9e1467483229721c7ed29af854b

## Summary by Sourcery

Introduce miette-powered diagnostics for YAML parsing and migrate existing error handling to miette across the codebase

New Features:
- Add span-aware YAML parsing errors with YamlDiagnostic producing precise source labels and suggestions
- Provide actionable hints for common YAML mistakes like tab indentation, missing list items, or missing colons

Enhancements:
- Replace anyhow contexts with miette’s IntoDiagnostic and wrap_err in manifest parsing, Jinja rendering, file I/O, and Ninja runner
- Add render_str_with helper to unify Jinja template error reporting
- Refactor manifest parsing to accept named sources for better diagnostic context

Build:
- Add miette and strip-ansi-escapes dependencies to Cargo.toml

Documentation:
- Document miette-based diagnostics in design guidelines and update crate selection table to include miette

Tests:
- Add regression tests for YAML parse errors verifying line/column spans and hints
- Update runner, cucumber, and AST tests to assert miette-style error chains