### PR TITLE
Add tag version check to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,14 @@ jobs:
 #            ext: ""
     steps:
       - uses: actions/checkout@v4
+      - name: Verify tag matches Cargo.toml
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          cargo_version=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f2)
+          if [ "$tag" != "$cargo_version" ]; then
+            echo "Tag version $tag does not match Cargo.toml version $cargo_version"
+            exit 1
+          fi
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Cache cross binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python 3.11
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -67,10 +68,14 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            python3 -c "import os, tomllib; print(tomllib.load(open(os.environ['CARGO_TOML_PATH'],'rb'))['package']['version'])" || echo ""
+            "${{ steps.setup-python.outputs.python-path }}" - <<'PY' || echo ""
+import os, tomllib
+with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
+    print(tomllib.load(f)['package']['version'])
+PY
           )"
           if [ -z "${cargo_version:-}" ]; then
-            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${toml_path}. Ensure Python ≥3.11 (tomllib available) and that the manifest contains [package]."
+            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${toml_path}. Ensure Python ≥3.11 (tomllib available) and that the manifest contains [package], or set CARGO_TOML_PATH to the crate's Cargo.toml."
             exit 1
           fi
           if [ "$tag" != "$cargo_version" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify tag matches Cargo.toml
         run: |
+          set -euo pipefail
           tag="${GITHUB_REF_NAME#v}"
-          cargo_version=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f2)
-          if [ "$tag" != "$cargo_version" ]; then
-            echo "Tag version $tag does not match Cargo.toml version $cargo_version"
+          cargo_version="$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml', 'rb'))['package']['version'])" 2>/dev/null || echo "")"
+          if [ -z "${cargo_version:-}" ]; then
+            echo "::error title=Cargo.toml parse failure::Could not find package.version in Cargo.toml"
             exit 1
           fi
+          if [ "$tag" != "$cargo_version" ]; then
+            echo "::error title=Tag/Cargo.toml mismatch::Tag version $tag does not match Cargo.toml version $cargo_version"
+            exit 1
+          fi
+          echo "Release tag $tag matches Cargo.toml version."
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Cache cross binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,21 @@ jobs:
 #            ext: ""
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Verify tag matches Cargo.toml
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME#v}"
-          cargo_version="$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml', 'rb'))['package']['version'])" 2>/dev/null || echo "")"
+          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          cargo_version="$(
+            CARGO_TOML_PATH="$toml_path" \
+            python3 -c "import os, tomllib; print(tomllib.load(open(os.environ['CARGO_TOML_PATH'],'rb'))['package']['version'])" || echo ""
+          )"
           if [ -z "${cargo_version:-}" ]; then
-            echo "::error title=Cargo.toml parse failure::Could not find package.version in Cargo.toml"
+            echo "::error title=Cargo.toml parse failure::Could not read package.version from ${toml_path}. Ensure Python ≥3.11 (tomllib available) and that the manifest contains [package]."
             exit 1
           fi
           if [ "$tag" != "$cargo_version" ]; then


### PR DESCRIPTION
## Summary
- ensure release tags match the `Cargo.toml` version before building

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a378fbab008322a5b6fcd819f916a6

## Summary by Sourcery

CI:
- Add a release workflow step that strips a leading 'v' from the tag name, compares it to the version field in Cargo.toml, and exits with an error if they differ.