### PR TITLE
Refactor diagnostics and broaden YAML error coverage

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,8 +1,44 @@
 use miette::{Context, IntoDiagnostic, Result};
 use std::fmt::Display;
 
+/// Extension methods for turning `Result` values into `miette` diagnostics.
+///
+/// # Examples
+///
+/// ```
+/// use miette::Result;
+/// use netsuke::diagnostics::ResultExt;
+/// use std::fs::File;
+///
+/// fn open(path: &str) -> Result<File> {
+///     File::open(path).diag("open file")
+/// }
+/// ```
 pub(crate) trait ResultExt<T> {
+    /// Attach a static context message to any error.
+    ///
+    /// ```
+    /// use miette::Result;
+    /// use netsuke::diagnostics::ResultExt;
+    /// use std::fs::read_to_string;
+    ///
+    /// fn read(path: &str) -> Result<String> {
+    ///     read_to_string(path).diag("read file")
+    /// }
+    /// ```
     fn diag(self, context: impl Display + Send + Sync + 'static) -> Result<T>;
+
+    /// Attach a lazily evaluated context message to any error.
+    ///
+    /// ```
+    /// use miette::Result;
+    /// use netsuke::diagnostics::ResultExt;
+    /// use std::{fs::File, path::Path};
+    ///
+    /// fn open(path: &Path) -> Result<File> {
+    ///     File::open(path).diag_with(|| format!("open {}", path.display()))
+    /// }
+    /// ```
     fn diag_with(self, f: impl FnOnce() -> String) -> Result<T>;
 }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,20 @@
+use miette::{Context, IntoDiagnostic, Result};
+use std::fmt::Display;
+
+pub(crate) trait ResultExt<T> {
+    fn diag(self, context: impl Display + Send + Sync + 'static) -> Result<T>;
+    fn diag_with(self, f: impl FnOnce() -> String) -> Result<T>;
+}
+
+impl<T, E> ResultExt<T> for std::result::Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn diag(self, context: impl Display + Send + Sync + 'static) -> Result<T> {
+        self.into_diagnostic().wrap_err(context)
+    }
+
+    fn diag_with(self, f: impl FnOnce() -> String) -> Result<T> {
+        self.into_diagnostic().wrap_err_with(f)
+    }
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -4,9 +4,9 @@
 //! converting errors into `miette` diagnostics with contextual messages.
 //!
 //! # Examples
-//! ```
+//! ```rust,ignore
 //! use miette::Result;
-//! use netsuke::diagnostics::ResultExt;
+//! use crate::diagnostics::ResultExt;
 //!
 //! fn load() -> Result<()> {
 //!     std::fs::read_to_string("Netsukefile").diag("read Netsukefile")?;
@@ -20,9 +20,9 @@ use std::fmt::Display;
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust,ignore
 /// use miette::Result;
-/// use netsuke::diagnostics::ResultExt;
+/// use crate::diagnostics::ResultExt;
 /// use std::fs::File;
 ///
 /// fn open(path: &str) -> Result<File> {
@@ -32,9 +32,9 @@ use std::fmt::Display;
 pub(crate) trait ResultExt<T> {
     /// Attach a static context message to any error.
     ///
-    /// ```
+    /// ```rust,ignore
     /// use miette::Result;
-    /// use netsuke::diagnostics::ResultExt;
+    /// use crate::diagnostics::ResultExt;
     /// use std::fs::read_to_string;
     ///
     /// fn read(path: &str) -> Result<String> {
@@ -45,9 +45,9 @@ pub(crate) trait ResultExt<T> {
 
     /// Attach a lazily evaluated context message to any error.
     ///
-    /// ```
+    /// ```rust,ignore
     /// use miette::Result;
-    /// use netsuke::diagnostics::ResultExt;
+    /// use crate::diagnostics::ResultExt;
     /// use std::{fs::File, path::Path};
     ///
     /// fn open(path: &Path) -> Result<File> {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,3 +1,18 @@
+//! Diagnostics utilities.
+//!
+//! Adds `.diag(...)` and `.diag_with(...)` extension methods to `Result` for
+//! converting errors into `miette` diagnostics with contextual messages.
+//!
+//! # Examples
+//! ```
+//! use miette::Result;
+//! use netsuke::diagnostics::ResultExt;
+//!
+//! fn load() -> Result<()> {
+//!     std::fs::read_to_string("Netsukefile").diag("read Netsukefile")?;
+//!     Ok(())
+//! }
+//! ```
 use miette::{Context, IntoDiagnostic, Result};
 use std::fmt::Display;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub mod ast;
 pub mod cli;
-pub mod diagnostics;
+pub(crate) mod diagnostics;
 pub mod hasher;
 pub mod ir;
 pub mod manifest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod ast;
 pub mod cli;
+pub mod diagnostics;
 pub mod hasher;
 pub mod ir;
 pub mod manifest;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -4,8 +4,11 @@
 //! preprocessing pass. The YAML is parsed first and Jinja expressions are
 //! evaluated only within string values or the `foreach` and `when` keys.
 
-use crate::ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars};
-use miette::{Context, Diagnostic, IntoDiagnostic, NamedSource, Report, Result, SourceSpan};
+use crate::{
+    ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars},
+    diagnostics::ResultExt,
+};
+use miette::{Diagnostic, NamedSource, Report, Result, SourceSpan};
 use minijinja::{Environment, UndefinedBehavior, context, value::Value};
 use serde_yml::{Error as YamlError, Location};
 use serde_yml::{Mapping as YamlMapping, Value as YamlValue};
@@ -13,6 +16,16 @@ use std::{fs, path::Path};
 use thiserror::Error;
 
 const ERR_MANIFEST_PARSE: &str = "manifest parse error";
+const YAML_HINTS: &[(&str, &str)] = &[
+    (
+        "did not find expected '-'",
+        "Start list items with '-' and ensure proper indentation.",
+    ),
+    (
+        "expected ':'",
+        "Ensure each key is followed by ':' separating key and value.",
+    ),
+];
 
 // Compute a narrow highlight span from a location.
 fn to_span(src: &str, loc: Location) -> SourceSpan {
@@ -50,36 +63,35 @@ pub(crate) struct YamlDiagnostic {
     message: String,
 }
 
+fn has_tab_indent(src: &str, loc: Option<Location>) -> bool {
+    let Some(loc) = loc else { return false };
+    let idx = loc.index();
+    let bytes = src.as_bytes();
+    let line_start = bytes
+        .get(..idx)
+        .and_then(|b| b.iter().rposition(|b| *b == b'\n').map(|p| p + 1))
+        .unwrap_or(0);
+    let line_end = bytes
+        .get(idx..)
+        .and_then(|b| b.iter().position(|b| *b == b'\n').map(|p| idx + p))
+        .unwrap_or(bytes.len());
+    bytes
+        .get(line_start..line_end)
+        .unwrap_or(&[])
+        .iter()
+        .take_while(|b| **b == b' ' || **b == b'\t')
+        .any(|b| *b == b'\t')
+}
+
 fn hint_for(err_str: &str, src: &str, loc: Option<Location>) -> Option<String> {
+    if has_tab_indent(src, loc) {
+        return Some("Use spaces for indentation; tabs are invalid in YAML.".into());
+    }
     let lower = err_str.to_lowercase();
-    if let Some(loc) = loc {
-        let idx = loc.index();
-        let bytes = src.as_bytes();
-        let line_start = bytes
-            .get(..idx)
-            .and_then(|b| b.iter().rposition(|b| *b == b'\n').map(|p| p + 1))
-            .unwrap_or(0);
-        let line_end = bytes
-            .get(idx..)
-            .and_then(|b| b.iter().position(|b| *b == b'\n').map(|p| idx + p))
-            .unwrap_or(bytes.len());
-        if bytes
-            .get(line_start..line_end)
-            .unwrap_or(&[])
-            .iter()
-            .take_while(|b| **b == b' ' || **b == b'\t')
-            .any(|b| *b == b'\t')
-        {
-            return Some("Use spaces for indentation; tabs are invalid in YAML.".into());
-        }
-    }
-    if lower.contains("did not find expected '-'") {
-        Some("Start list items with '-' and ensure proper indentation.".into())
-    } else if lower.contains("expected ':'") {
-        Some("Ensure each key is followed by ':' separating key and value.".into())
-    } else {
-        None
-    }
+    YAML_HINTS
+        .iter()
+        .find(|(needle, _)| lower.contains(needle))
+        .map(|(_, hint)| (*hint).into())
 }
 
 fn map_yaml_error(err: YamlError, src: &str, name: &str) -> Report {
@@ -129,9 +141,7 @@ fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
 
     expand_foreach(&mut doc, &env)?;
 
-    let manifest: NetsukeManifest = serde_yml::from_value(doc)
-        .into_diagnostic()
-        .wrap_err(ERR_MANIFEST_PARSE)?;
+    let manifest: NetsukeManifest = serde_yml::from_value(doc).diag(ERR_MANIFEST_PARSE)?;
 
     render_manifest(manifest, &env)
 }
@@ -194,8 +204,7 @@ fn parse_foreach_values(expr_val: &YamlValue, env: &Environment) -> Result<Vec<V
     let seq = eval_expression(env, "foreach", expr, context! {})?;
     let iter = seq
         .try_iter()
-        .into_diagnostic()
-        .wrap_err("foreach expression did not yield an iterable")?;
+        .diag("foreach expression did not yield an iterable")?;
     Ok(iter.collect())
 }
 
@@ -228,9 +237,7 @@ fn inject_iteration_vars(map: &mut YamlMapping, item: &Value, index: usize) -> R
     };
     vars.insert(
         YamlValue::String("item".into()),
-        serde_yml::to_value(item)
-            .into_diagnostic()
-            .wrap_err("serialise item")?,
+        serde_yml::to_value(item).diag("serialise item")?,
     );
     vars.insert(
         YamlValue::String("index".into()),
@@ -248,11 +255,9 @@ fn as_str<'a>(value: &'a YamlValue, field: &str) -> Result<&'a str> {
 
 fn eval_expression(env: &Environment, name: &str, expr: &str, ctx: Value) -> Result<Value> {
     env.compile_expression(expr)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("{name} expression parse error"))?
+        .diag_with(|| format!("{name} expression parse error"))?
         .eval(ctx)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("{name} evaluation error"))
+        .diag_with(|| format!("{name} evaluation error"))
 }
 
 /// Render a Jinja template and label any error with the given context.
@@ -262,9 +267,7 @@ fn render_str_with(
     ctx: &impl serde::Serialize,
     what: impl FnOnce() -> String,
 ) -> Result<String> {
-    env.render_str(tpl, ctx)
-        .into_diagnostic()
-        .wrap_err_with(what)
+    env.render_str(tpl, ctx).diag_with(what)
 }
 
 /// Render all templated strings in the manifest.
@@ -352,7 +355,20 @@ fn render_string_or_list(value: &mut StringOrList, env: &Environment, ctx: &Vars
 pub fn from_path(path: impl AsRef<Path>) -> Result<NetsukeManifest> {
     let path_ref = path.as_ref();
     let data = fs::read_to_string(path_ref)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to read {}", path_ref.display()))?;
+        .diag_with(|| format!("Failed to read {}", path_ref.display()))?;
     from_str_named(&data, &path_ref.display().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::Error as _;
+
+    #[test]
+    fn yaml_error_without_location_defaults_to_first_line() {
+        let err = YamlError::custom("boom");
+        let report = map_yaml_error(err, "", "test");
+        let msg = report.to_string();
+        assert!(msg.contains("line 1, column 1"), "message: {msg}");
+    }
 }

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -35,6 +35,18 @@ fn normalise_report(report: &str) -> String {
     "targets:\n  - name: 'unterminated\n",
     &["YAML parse error", "line 2"],
 )]
+#[case(
+    "",
+    &[
+        "manifest parse error",
+        "missing field",
+        "netsuke_version",
+    ],
+)]
+#[case(
+    "not: yaml: at all: %$#@!",
+    &["YAML parse error", "line 1"],
+)]
 fn yaml_diagnostics_are_actionable(#[case] yaml: &str, #[case] needles: &[&str]) {
     let err = manifest::from_str(yaml).expect_err("parse should fail");
     let mut msg = String::new();

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -44,6 +44,22 @@ fn normalise_report(report: &str) -> String {
     ],
 )]
 #[case(
+    "    \n    ",
+    &[
+        "manifest parse error",
+        "missing field",
+        "netsuke_version",
+    ],
+)]
+#[case(
+    "# just a comment\n# another comment",
+    &[
+        "manifest parse error",
+        "missing field",
+        "netsuke_version",
+    ],
+)]
+#[case(
     "not: yaml: at all: %$#@!",
     &["YAML parse error", "line 1"],
 )]

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -59,9 +59,10 @@ fn normalise_report(report: &str) -> String {
         "netsuke_version",
     ],
 )]
+// No location information should default to the start of the file.
 #[case(
     "not: yaml: at all: %$#@!",
-    &["YAML parse error", "line 1"],
+    &["YAML parse error", "line 1, column 1"],
 )]
 fn yaml_diagnostics_are_actionable(#[case] yaml: &str, #[case] needles: &[&str]) {
     let err = manifest::from_str(yaml).expect_err("parse should fail");


### PR DESCRIPTION
## Summary
- add ResultExt trait to simplify diagnostic wrapping
- streamline YAML hint generation and error mapping
- cover empty and invalid YAML inputs and location-less errors

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d1c11d308322a9b2084a5e2f6c0b

## Summary by Sourcery

Refactor and unify diagnostic handling, introduce broader YAML error detection with contextual hints, and expand YAML error test coverage

New Features:
- Broaden YAML error coverage to handle empty input and location-less errors with default location
- Add tab-indentation detection and static hint table for common YAML mistakes

Enhancements:
- Introduce ResultExt trait with diag and diag_with methods to simplify error wrapping
- Centralize YAML hint logic into a constant table and helper function
- Add diagnostics module for shared error utilities

Tests:
- Add unit test for mapping YAML errors without location to default position
- Extend existing YAML error tests to cover empty and invalid inputs