### PR TITLE
Extract manifest setup into test helper

### DIFF
--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -19,8 +19,8 @@ pub use path_guard::PathGuard;
 
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::PathBuf;
-use tempfile::TempDir;
+use std::path::{Path, PathBuf};
+use tempfile::{NamedTempFile, TempDir};
 
 /// Create a fake Ninja executable that exits with `exit_code`.
 ///
@@ -95,6 +95,42 @@ pub fn fake_ninja(exit_code: u8) -> (TempDir, PathBuf) {
     }
 
     (dir, path)
+}
+
+/// Resolve `cli_file` relative to `temp_dir` and ensure it exists.
+///
+/// When `cli_file` is relative, it is joined with `temp_dir`. If the resulting
+/// path does not exist, a minimal manifest is written to that location. The
+/// resolved path is returned to allow callers to update their configuration.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::PathBuf;
+/// use tempfile::TempDir;
+/// use test_support::ensure_manifest_exists;
+///
+/// let temp = TempDir::new().expect("temp dir");
+/// let cli_file = PathBuf::from("manifest.yml");
+/// let manifest = ensure_manifest_exists(temp.path(), &cli_file);
+/// assert!(manifest.exists());
+/// ```
+pub fn ensure_manifest_exists(temp_dir: &Path, cli_file: &Path) -> PathBuf {
+    let manifest_path = if cli_file.is_absolute() {
+        cli_file.to_path_buf()
+    } else {
+        temp_dir.join(cli_file)
+    };
+
+    if !manifest_path.exists() {
+        let mut file =
+            NamedTempFile::new_in(temp_dir).expect("Failed to create temporary manifest file");
+        crate::env::write_manifest(&mut file).expect("Failed to write manifest content");
+        file.persist(&manifest_path)
+            .expect("Failed to persist manifest file");
+    }
+
+    manifest_path
 }
 
 // Additional helpers can be added here as the test suite evolves.

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -5,9 +5,9 @@ use cucumber::{given, then, when};
 use netsuke::runner::{self, BuildTargets, NINJA_PROGRAM};
 use std::fs;
 use std::path::{Path, PathBuf};
-use tempfile::{NamedTempFile, TempDir};
+use tempfile::TempDir;
 use test_support::{
-    check_ninja,
+    check_ninja, ensure_manifest_exists,
     env::{self, EnvMut},
     fake_ninja,
 };
@@ -80,27 +80,9 @@ fn build_dir_exists(world: &mut CliWorld) {
 #[when("the ninja process is run")]
 fn run(world: &mut CliWorld) {
     let dir = world.temp.as_ref().expect("temp dir");
-    let manifest_path = {
-        let cli = world.cli.as_ref().expect("cli");
-        if cli.file.is_absolute() {
-            cli.file.clone()
-        } else {
-            dir.path().join(&cli.file)
-        }
-    };
-
-    if !manifest_path.exists() {
-        let mut file =
-            NamedTempFile::new_in(dir.path()).expect("Failed to create temporary manifest file");
-        env::write_manifest(&mut file).expect("Failed to write manifest content");
-        file.persist(&manifest_path)
-            .expect("Failed to persist manifest file");
-    }
-
-    {
-        let cli = world.cli.as_mut().expect("cli");
-        cli.file.clone_from(&manifest_path);
-    }
+    let cli_file = world.cli.as_ref().expect("cli").file.clone();
+    let manifest_path = ensure_manifest_exists(dir.path(), &cli_file);
+    world.cli.as_mut().expect("cli").file = manifest_path;
 
     let cli = world.cli.as_ref().expect("cli");
     let program = if let Some(ninja) = &world.ninja {


### PR DESCRIPTION
## Summary
- factor verbose manifest path handling into `ensure_manifest_exists`
- simplify `process_steps::run` by reusing the new helper

Closes #59

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f22080548322848c740fcb361a81