### PR TITLE
Clarify Unix glob escape preservation in design doc

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -735,18 +735,19 @@ providing a secure bridge to the underlying system.
 - `glob(pattern: &str) -> Result<Vec<String>, Error>`: Expand filesystem
   patterns (e.g., `src/**/*.c`) into a list of matched paths. Results are
   yielded in lexicographic order by the iterator and returned unchanged.
-  Symlinks are followed by the `glob` crate by default. Matching is case-
+  Symlinks are followed by the `glob` crate by default. Matching is case
   sensitive on all platforms. `glob_with` enforces
   `require_literal_separator = true` internally, so wildcards do not cross path
   separators unless `**` is used. Callers may use `/` or `\` in patterns; these
-  are normalised to the host platform before matching. Results contain only
-  files (directories are ignored) and path separators are normalised to `/`.
-  Leading-dot entries are matched by wildcards. Empty results are represented
-  as `[]`. Invalid patterns surface as `SyntaxError`; filesystem iteration
-  errors surface as `InvalidOperation`, matching minijinja error semantics. On
-  Unix, backslash escapes for glob metacharacters (`[`, `]`, `{`, `}`, `*`,
-  `?`) are preserved during separator normalisation. This fills a Ninja gap
-  since Ninja itself does not support globbing.[^3]
+  are normalised to the host platform before matching. On Unix, backslash
+  escapes for glob metacharacters (`[`, `]`, `{`, `}`, `*`, `?`) are preserved
+  during separator normalisation, but Windows patterns do not support escape
+  sequences. Results contain only files (directories are ignored) and path
+  separators are normalised to `/`. Leading-dot entries are matched by
+  wildcards. Empty results are represented as `[]`. Invalid patterns surface as
+  `SyntaxError`; filesystem iteration errors surface as `InvalidOperation`
+  consistent with minijinja semantics. This provides globbing support not
+  available in Ninja.[^3]
 - `python_version(requirement: &str) -> Result<bool, Error>`: An example of a
   domain-specific helper function that demonstrates the extensibility of this
   architecture. This function would execute `python --version` or

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -27,8 +27,10 @@ fn glob_paths_invalid_pattern_sets_syntax_error() {
 
 #[cfg(unix)]
 #[test]
-fn normalise_separators_preserves_bracket_escape() {
+fn normalise_separators_preserves_escapes() {
     assert_eq!(super::normalise_separators("\\["), "\\[");
+    assert_eq!(super::normalise_separators("\\*"), "\\*");
+    assert_eq!(super::normalise_separators("\\?"), "\\?");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- note that Unix glob normalization preserves escaped metacharacters like `\*` and `\?`

## Testing
- `make fmt`
- `make markdownlint`
- `timeout 30 make nixie`
- `make lint`
- `make test`
- `make check-fmt`


------
https://chatgpt.com/codex/tasks/task_e_68ade6607ab08322b8fd561ffc89b184

## Summary by Sourcery

Documentation:
- Add `*` and `?` to the list of preserved glob metacharacters in the Unix separator normalization section.