### PR TITLE
Rename normalise_separators to normalize_separators

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -739,14 +739,14 @@ providing a secure bridge to the underlying system.
   sensitive on all platforms. `glob_with` enforces
   `require_literal_separator = true` internally, so wildcards do not cross path
   separators unless `**` is used. Callers may use `/` or `\` in patterns; these
-  are normalised to the host platform before matching. Results contain only
-  files (directories are ignored) and path separators are normalised to `/`.
+  are normalized to the host platform before matching. Results contain only
+  files (directories are ignored) and path separators are normalized to `/`.
   Leading-dot entries are matched by wildcards. Empty results are represented
   as `[]`. Invalid patterns surface as `SyntaxError`; filesystem iteration
-  errors surface as `InvalidOperation`, matching minijinja error semantics.
-  On Unix, backslash escapes for glob metacharacters (`[`, `]`, `{`, `}`) are
-  preserved during separator normalisation.
-  This fills a Ninja gap since Ninja itself does not support globbing.[^3]
+  errors surface as `InvalidOperation`, matching minijinja error semantics. On
+  Unix, backslash escapes for glob metacharacters (`[`, `]`, `{`, `}`) are
+  preserved during separator normalization. This fills a Ninja gap since Ninja
+  itself does not support globbing.[^3]
 - `python_version(requirement: &str) -> Result<bool, Error>`: An example of a
   domain-specific helper function that demonstrates the extensibility of this
   architecture. This function would execute `python --version` or

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -144,10 +144,10 @@ fn env_var(name: &str) -> std::result::Result<String, Error> {
     }
 }
 
-/// Process a single glob entry and normalise its output.
+/// Process a single glob entry and normalize its output.
 ///
 /// Returns the entry path when it points to a file, skipping directories.
-/// Requires matched paths to be valid UTF-8; output is normalised to use
+/// Requires matched paths to be valid UTF-8; output is normalized to use
 /// forward slashes.
 ///
 /// # Examples
@@ -208,7 +208,7 @@ fn process_glob_entry(
 /// matched by wildcards.
 /// Convert `/` and `\` to the host separator while preserving escapes for
 /// glob metacharacters on Unix.
-fn normalise_separators(pattern: &str) -> String {
+fn normalize_separators(pattern: &str) -> String {
     let native = std::path::MAIN_SEPARATOR;
     #[cfg(unix)]
     {
@@ -246,8 +246,8 @@ fn glob_paths(pattern: &str) -> std::result::Result<Vec<String>, Error> {
         require_literal_leading_dot: false,
     };
 
-    // Normalise separators so `/` and `\\` behave the same on all platforms.
-    let normalized = normalise_separators(pattern);
+    // Normalize separators so `/` and `\\` behave the same on all platforms.
+    let normalized = normalize_separators(pattern);
 
     let entries = glob_with(&normalized, opts).map_err(|e| {
         Error::new(

--- a/src/manifest/tests.rs
+++ b/src/manifest/tests.rs
@@ -27,8 +27,8 @@ fn glob_paths_invalid_pattern_sets_syntax_error() {
 
 #[cfg(unix)]
 #[test]
-fn normalise_separators_preserves_bracket_escape() {
-    assert_eq!(super::normalise_separators("\\["), "\\[");
+fn normalize_separators_preserves_bracket_escape() {
+    assert_eq!(super::normalize_separators("\\["), "\\[");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- rename `normalise_separators` to `normalize_separators` for en-GB-oxendict style
- update unit test and design docs for normalized spelling

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68ade7f74c888322a98909161f215b8e

## Summary by Sourcery

Rename normalise_separators to normalize_separators and update all references to use American English spelling

Enhancements:
- Rename the 'normalise_separators' function and its references in src/manifest.rs to 'normalize_separators'

Documentation:
- Update design documentation to use 'normalize' spelling in docs/netsuke-design.md

Tests:
- Update manifest tests to rename the test and assertions for 'normalize_separators'