### PR TITLE
Use Display for manifest error chain

### DIFF
--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 tempfile = "3.8.0"
 mockable = { version = "0.3", features = ["mock"] }
 ninja_env = { path = "../ninja_env" }
-miette = "7.6.0"
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 tempfile = "3.8.0"
 mockable = { version = "0.3", features = ["mock"] }
 ninja_env = { path = "../ninja_env" }
+miette = "7.6.0"
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/test_support/src/error.rs
+++ b/test_support/src/error.rs
@@ -15,6 +15,7 @@ use std::error::Error;
 /// assert_eq!(display_error_chain(&err), "oops");
 /// ```
 pub fn display_error_chain(e: &(dyn Error + 'static)) -> String {
+    // `std::error::Error::sources` is unstable; traverse via `source` instead.
     let mut current: Option<&(dyn Error + 'static)> = Some(e);
     std::iter::from_fn(|| {
         let err = current?;

--- a/test_support/src/error.rs
+++ b/test_support/src/error.rs
@@ -5,9 +5,10 @@ use std::error::Error;
 /// Join an error and its sources (outermost → root cause) for stable
 /// assertions.
 ///
-/// ```ignore
-/// Works with any error implementing `std::error::Error`. Types like
+/// Works with any error implementing [`std::error::Error`]. Types like
 /// [`miette::Report`] can be passed via [`AsRef::as_ref`].
+///
+/// # Examples
 ///
 /// ```ignore
 /// let err = std::io::Error::new(std::io::ErrorKind::Other, "oops");

--- a/test_support/src/error.rs
+++ b/test_support/src/error.rs
@@ -1,0 +1,20 @@
+use miette::Report;
+
+/// Join an error and its sources (outermost → root cause) for stable
+/// assertions.
+///
+/// ```ignore
+/// use miette::Report;
+/// let err = Report::msg("oops");
+/// assert_eq!(display_error_chain(&err), "oops");
+/// ```
+pub fn display_error_chain(e: &Report) -> String {
+    let mut out = String::new();
+    for (i, cause) in e.chain().enumerate() {
+        if i > 0 {
+            out.push_str(": ");
+        }
+        out.push_str(&cause.to_string());
+    }
+    out
+}

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -21,6 +21,9 @@ pub use path_guard::PathGuard;
 /// Re-export of [`env_var_guard::EnvVarGuard`] for ergonomics in tests.
 pub use env_var_guard::EnvVarGuard;
 
+mod error;
+pub use error::display_error_chain;
+
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -22,6 +22,8 @@ pub use path_guard::PathGuard;
 pub use env_var_guard::EnvVarGuard;
 
 mod error;
+/// Format an error and its sources (outermost → root) using `Display`, joined
+/// with ": ", to produce deterministic text for test assertions.
 pub use error::display_error_chain;
 
 use std::fs::{self, File};

--- a/tests/manifest_glob_tests.rs
+++ b/tests/manifest_glob_tests.rs
@@ -6,6 +6,7 @@ use netsuke::{
 };
 use rstest::{fixture, rstest};
 use std::{fs, path::Path};
+use test_support::display_error_chain;
 
 fn manifest_yaml(body: &str) -> String {
     format!("netsuke_version: 1.0.0\n{body}")
@@ -148,7 +149,7 @@ fn glob_invalid_pattern_errors() {
     let yaml =
         manifest_yaml("targets:\n  - foreach: glob('[')\n    name: bad\n    command: echo hi\n");
     let err = manifest::from_str(&yaml).expect_err("invalid pattern should error");
-    let msg = format!("{err:#}");
+    let msg = display_error_chain(&err);
     assert!(msg.contains("invalid glob pattern"), "{msg}");
 }
 

--- a/tests/manifest_glob_tests.rs
+++ b/tests/manifest_glob_tests.rs
@@ -149,7 +149,7 @@ fn glob_invalid_pattern_errors() {
     let yaml =
         manifest_yaml("targets:\n  - foreach: glob('[')\n    name: bad\n    command: echo hi\n");
     let err = manifest::from_str(&yaml).expect_err("invalid pattern should error");
-    let msg = display_error_chain(&err);
+    let msg = display_error_chain(err.as_ref());
     assert!(msg.contains("invalid glob pattern"), "{msg}");
 }
 

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -1,12 +1,13 @@
 //! Step definitions for manifest feature tests.
 
-use crate::{CliWorld, steps::display_error_chain};
+use crate::CliWorld;
 use cucumber::{given, then, when};
 use netsuke::{
     ast::{Recipe, StringOrList, Target},
     manifest,
 };
 use std::ffi::OsStr;
+use test_support::display_error_chain;
 use test_support::env::{remove_var, set_var};
 
 const INDEX_KEY: &str = "index";

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -1,6 +1,6 @@
 //! Step definitions for manifest feature tests.
 
-use crate::CliWorld;
+use crate::{CliWorld, steps::display_error_chain};
 use cucumber::{given, then, when};
 use netsuke::{
     ast::{Recipe, StringOrList, Target},
@@ -27,16 +27,8 @@ fn parse_manifest_inner(world: &mut CliWorld, path: &str) {
         }
         Err(e) => {
             world.manifest = None;
-            // Collect the error chain using `Display` to keep messages concise
-            // while retaining underlying causes for substring checks.
-            let mut msg = String::new();
-            for (idx, cause) in e.chain().enumerate() {
-                if idx > 0 {
-                    msg.push_str(": ");
-                }
-                msg.push_str(&cause.to_string());
-            }
-            world.manifest_error = Some(msg);
+            // Record the error chain using `Display` for stable substring checks.
+            world.manifest_error = Some(display_error_chain(&e));
         }
     }
 }

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -27,7 +27,16 @@ fn parse_manifest_inner(world: &mut CliWorld, path: &str) {
         }
         Err(e) => {
             world.manifest = None;
-            world.manifest_error = Some(format!("{e:#}"));
+            // Collect the error chain using `Display` to keep messages concise
+            // while retaining underlying causes for substring checks.
+            let mut msg = String::new();
+            for (idx, cause) in e.chain().enumerate() {
+                if idx > 0 {
+                    msg.push_str(": ");
+                }
+                msg.push_str(&cause.to_string());
+            }
+            world.manifest_error = Some(msg);
         }
     }
 }

--- a/tests/steps/manifest_steps.rs
+++ b/tests/steps/manifest_steps.rs
@@ -29,7 +29,7 @@ fn parse_manifest_inner(world: &mut CliWorld, path: &str) {
         Err(e) => {
             world.manifest = None;
             // Record the error chain using `Display` for stable substring checks.
-            world.manifest_error = Some(display_error_chain(&e));
+            world.manifest_error = Some(display_error_chain(e.as_ref()));
         }
     }
 }

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -3,19 +3,3 @@ mod ir_steps;
 mod manifest_steps;
 mod ninja_steps;
 mod process_steps;
-
-use miette::Report;
-
-/// Join an error and its sources for stable assertions.
-///
-/// ```ignore
-/// use miette::Report;
-/// let err = Report::msg("oops");
-/// assert_eq!(display_error_chain(&err), "oops");
-/// ```
-pub(crate) fn display_error_chain(e: &Report) -> String {
-    e.chain()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(": ")
-}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -3,3 +3,19 @@ mod ir_steps;
 mod manifest_steps;
 mod ninja_steps;
 mod process_steps;
+
+use miette::Report;
+
+/// Join an error and its sources for stable assertions.
+///
+/// ```ignore
+/// use miette::Report;
+/// let err = Report::msg("oops");
+/// assert_eq!(display_error_chain(&err), "oops");
+/// ```
+pub(crate) fn display_error_chain(e: &Report) -> String {
+    e.chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(": ")
+}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,3 +1,7 @@
+//! Step utilities shared by Cucumber step modules.
+//!
+//! Groups reusable step definitions and helpers such as `display_error_chain`.
+
 mod cli_steps;
 mod ir_steps;
 mod manifest_steps;

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,6 +1,7 @@
 //! Step utilities shared by Cucumber step modules.
 //!
-//! Groups reusable step definitions and helpers such as `display_error_chain`.
+//! Provides helpers for stable error text (e.g., `display_error_chain`) used by
+//! step definitions.
 
 mod cli_steps;
 mod ir_steps;


### PR DESCRIPTION
## Summary
- capture manifest parsing errors via Display and include source chain for stable substring assertions

## Testing
- `make lint`
- `make test`
- `cargo test --test cucumber -- --name "invalid glob pattern"`
- `cargo test --test manifest_glob_tests glob_invalid_pattern_errors -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68ade8854f44832293cad51d12dcd82f

## Summary by Sourcery

Tests:
- Collect the manifest error chain by iterating over e.chain() and concatenating causes with Display instead of using a formatted pretty-print