### PR TITLE
Refactor glob validation and separator handling

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -746,7 +746,7 @@ providing a secure bridge to the underlying system.
   as `[]`. Invalid patterns surface as `SyntaxError`; filesystem iteration
   errors surface as `InvalidOperation`, matching minijinja error semantics. On
   Unix, backslash escapes for glob metacharacters (`[`, `]`, `{`, `}`, `*`,
-  `?`) are preserved during separator normalisation. A backslash before `*` or
+  `?`) are preserved during separator normalization. A backslash before `*` or
   `?` is kept only when the wildcard is trailing or followed by an
   alphanumeric, `_`, or `-`; otherwise it becomes a path separator so
   `config\*.yml` maps to `config/*.yml`. On Windows, backslash escapes are not


### PR DESCRIPTION
## Summary
- simplify brace validation with position-aware errors
- consolidate path separator normalization logic
- broaden glob pattern tests and fix docs spelling

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68b1ebcafd6c832298188fbe7820a54b