### PR TITLE
Warn on invalid SOURCE_DATE_EPOCH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
 
 concurrency:
   group: release-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     permissions:
@@ -78,7 +79,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            python - <<'PY' || echo ""
+            ${{ steps.setup-python.outputs.python-path }} - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -98,7 +99,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            ${{ steps.setup-python.outputs.python-path }} - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -192,7 +193,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            ${{ steps.bin-name.outputs.python-path }} - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -99,7 +99,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -193,7 +193,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            ${{ steps.setup-python.outputs.python-path }} - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -99,7 +99,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            ${{ steps.setup-python.outputs.python-path }} - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -193,7 +193,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            ${{ steps.bin-name.outputs.python-path }} - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:
@@ -238,7 +238,7 @@ PY
       - name: Generate man page
         run: cargo build -q --features manpage --no-default-features
       - name: Setup jq
-        uses: vegardit/gha-setup-jq@v1
+        uses: vegardit/gha-setup-jq@491c577e0d5e6512cf02b06cf439b1fc4165aad1
       - name: Verify man page exists
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,15 +236,20 @@ PY
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Generate man page
         run: cargo build -q --features manpage --no-default-features
+      - name: Setup jq
+        uses: vegardit/gha-setup-jq@v1
       - name: Verify man page exists
         run: |
           set -euo pipefail
           host=$(rustc -Vv | awk '/^host:/ {print $2}')
-          test -f "target/generated-man/${host}/debug/netsuke.1" || {
-            echo "::error title=Manpage missing::target/generated-man/${host}/debug/netsuke.1 not found"; exit 1; }
-          cp "target/generated-man/${host}/debug/netsuke.1" target/generated-man/netsuke.1
-      - name: Setup jq
-        uses: vegardit/gha-setup-jq@v1
+          BIN_NAME="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' \
+            | head -n 1)"
+          man_src="target/generated-man/${host}/debug/${BIN_NAME}.1"
+          test -f "$man_src" || {
+            echo "::error title=Manpage missing::${man_src} not found"; exit 1; }
+          mkdir -p target/generated-man
+          cp "$man_src" "target/generated-man/${BIN_NAME}.1"
       - name: Prepare GoReleaser dist
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 
 concurrency:
   group: release-${{ github.ref }}
-
+  cancel-in-progress: false
 jobs:
   build:
     permissions:
@@ -79,7 +79,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -99,7 +99,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -193,7 +193,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python - <<'PY' || echo ""
+            python3 - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:
@@ -240,8 +240,8 @@ PY
       - name: Verify man page exists
         run: test -f target/generated-man/netsuke.1 || {
           echo "::error title=Manpage missing::target/generated-man/netsuke.1 not found"; exit 1; }
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Setup jq
+        uses: vegardit/gha-setup-jq@v1
       - name: Prepare GoReleaser dist
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ env:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -80,7 +79,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            "${{ steps.setup-python.outputs.python-path }}" - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -100,7 +99,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            "${{ steps.setup-python.outputs.python-path }}" - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -194,7 +193,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            "${{ steps.bin-name.outputs.python-path }}" - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:
@@ -241,6 +240,8 @@ PY
       - name: Verify man page exists
         run: test -f target/generated-man/netsuke.1 || {
           echo "::error title=Manpage missing::target/generated-man/netsuke.1 not found"; exit 1; }
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Prepare GoReleaser dist
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ env:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
 jobs:
   build:
     permissions:
@@ -79,7 +78,7 @@ jobs:
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           cargo_version="$(
             CARGO_TOML_PATH="$toml_path" \
-            python3 - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 with open(os.environ['CARGO_TOML_PATH'], 'rb') as f:
     print(tomllib.load(f)['package']['version'])
@@ -99,7 +98,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python3 - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib
 path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
 with open(path, 'rb') as f:
@@ -193,7 +192,7 @@ PY
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
           BIN_NAME="$(
-            python3 - <<'PY' || echo ""
+            python - <<'PY' || echo ""
 import os, tomllib, sys
 path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
 with open(path,'rb') as f:
@@ -238,8 +237,12 @@ PY
       - name: Generate man page
         run: cargo build -q --features manpage --no-default-features
       - name: Verify man page exists
-        run: test -f target/generated-man/netsuke.1 || {
-          echo "::error title=Manpage missing::target/generated-man/netsuke.1 not found"; exit 1; }
+        run: |
+          set -euo pipefail
+          host=$(rustc -Vv | awk '/^host:/ {print $2}')
+          test -f "target/generated-man/${host}/debug/netsuke.1" || {
+            echo "::error title=Manpage missing::target/generated-man/${host}/debug/netsuke.1 not found"; exit 1; }
+          cp "target/generated-man/${host}/debug/netsuke.1" target/generated-man/netsuke.1
       - name: Setup jq
         uses: vegardit/gha-setup-jq@v1
       - name: Prepare GoReleaser dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ rust-version = "1.89.0"
 include = [
     "src/**",
     "Cargo.toml",
-    "Cargo.lock",
     "README.md",
     "LICENSE",
     "build.rs",

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Release builds include a `netsuke.1` manual page generated from the Clap
 definitions, providing the same flags and subcommands documented via `--help`.
 Manual page generation honours `SOURCE_DATE_EPOCH` for reproducible dates. The
 published crate does not include this file; packagers can source it from
-release artefacts under `target/generated-man/`.
+release artefacts under `target/generated-man/<target>/<profile>/`.
 
 ## 🚧 Status
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Release builds include a `netsuke.1` manual page generated from the Clap
 definitions, providing the same flags and subcommands documented via `--help`.
 Manual page generation honours `SOURCE_DATE_EPOCH` for reproducible dates. If
 the value is invalid, a warning is emitted and the date falls back to
-`1970-01-01`. The published crate does not include this file; packagers can
-source it from release artefacts under
+`1970-01-01`. If `SOURCE_DATE_EPOCH` is unset, the date deterministically falls
+back to `1970-01-01` without a warning. The published crate does not include
+this file; packagers can source it from release artefacts under
 `target/generated-man/<target>/<profile>/`.
 
 ## 🚧 Status

--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ You can also pass:
 
 Release builds include a `netsuke.1` manual page generated from the Clap
 definitions, providing the same flags and subcommands documented via `--help`.
-Manual page generation honours `SOURCE_DATE_EPOCH` for reproducible dates. The
-published crate does not include this file; packagers can source it from
-release artefacts under `target/generated-man/<target>/<profile>/`.
+Manual page generation honours `SOURCE_DATE_EPOCH` for reproducible dates. If
+the value is invalid, a warning is emitted and the date falls back to
+`1970-01-01`. The published crate does not include this file; packagers can
+source it from release artefacts under
+`target/generated-man/<target>/<profile>/`.
 
 ## 🚧 Status
 

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,8 @@ use clap_mangen::Man;
 use std::{env, fs, path::PathBuf};
 use time::{OffsetDateTime, format_description::well_known::Iso8601};
 
+const FALLBACK_DATE: &str = "1970-01-01";
+
 #[path = "src/cli.rs"]
 #[expect(
     dead_code,
@@ -53,10 +55,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .and_then(|dt| dt.format(&Iso8601::DATE).ok())
                 .or_else(|| {
                     println!("cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'");
-                    Some("1970-01-01".into())
+                    Some(FALLBACK_DATE.into())
                 })
         })
-        .unwrap_or_else(|| "1970-01-01".into());
+        .unwrap_or_else(|| FALLBACK_DATE.into());
     let man = Man::new(cmd)
         .section("1")
         .source(format!("{cargo_bin} {version}"))

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,12 @@ fn manual_date() -> String {
     })
 }
 
+fn out_dir_for_target_profile() -> PathBuf {
+    let target = env::var("TARGET").unwrap_or_else(|_| "unknown-target".into());
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown-profile".into());
+    PathBuf::from(format!("target/generated-man/{target}/{profile}"))
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Regenerate the manual page when the CLI or metadata changes.
     println!("cargo:rerun-if-changed=src/cli.rs");
@@ -54,9 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=PROFILE");
 
     // Packagers expect man pages under target/generated-man/<target>/<profile>.
-    let target = env::var("TARGET").unwrap_or_else(|_| "unknown-target".into());
-    let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown-profile".into());
-    let out_dir = PathBuf::from(format!("target/generated-man/{target}/{profile}"));
+    let out_dir = out_dir_for_target_profile();
     fs::create_dir_all(&out_dir)?;
 
     // The top-level page documents the entire command interface.

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-env-changed=CARGO_PKG_DESCRIPTION");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_AUTHORS");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo:rerun-if-env-changed=PROFILE");
 
     // Packagers expect man pages under target/generated-man/<target>/<profile>.
     let target = env::var("TARGET").unwrap_or_else(|_| "unknown-target".into());

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,33 @@ const FALLBACK_DATE: &str = "1970-01-01";
 )]
 mod cli;
 
+fn manual_date() -> String {
+    let Ok(raw) = env::var("SOURCE_DATE_EPOCH") else {
+        return FALLBACK_DATE.into();
+    };
+
+    let Ok(ts) = raw.parse::<i64>() else {
+        println!(
+            "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; expected integer seconds since Unix epoch; falling back to {FALLBACK_DATE}"
+        );
+        return FALLBACK_DATE.into();
+    };
+
+    let Ok(dt) = OffsetDateTime::from_unix_timestamp(ts) else {
+        println!(
+            "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; not a valid Unix timestamp; falling back to {FALLBACK_DATE}"
+        );
+        return FALLBACK_DATE.into();
+    };
+
+    dt.format(&Iso8601::DATE).unwrap_or_else(|_| {
+        println!(
+            "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; formatting failed; falling back to {FALLBACK_DATE}"
+        );
+        FALLBACK_DATE.into()
+    })
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Regenerate the manual page when the CLI or metadata changes.
     println!("cargo:rerun-if-changed=src/cli.rs");
@@ -49,43 +76,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION must be set");
 
-    #[allow(
-        clippy::option_if_let_else,
-        clippy::single_match_else,
-        reason = "Explicit matches make invalid SOURCE_DATE_EPOCH handling linear and readable"
-    )]
-    let date = match env::var("SOURCE_DATE_EPOCH") {
-        Ok(raw) => match raw.parse::<i64>() {
-            Ok(ts) => match OffsetDateTime::from_unix_timestamp(ts) {
-                Ok(dt) => match dt.format(&Iso8601::DATE) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        println!(
-                            "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; formatting failed; falling back to {FALLBACK_DATE}"
-                        );
-                        FALLBACK_DATE.into()
-                    }
-                },
-                Err(_) => {
-                    println!(
-                        "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; not a valid Unix timestamp; falling back to {FALLBACK_DATE}"
-                    );
-                    FALLBACK_DATE.into()
-                }
-            },
-            Err(_) => {
-                println!(
-                    "cargo:warning=Invalid SOURCE_DATE_EPOCH '{raw}'; expected integer seconds since Unix epoch; falling back to {FALLBACK_DATE}"
-                );
-                FALLBACK_DATE.into()
-            }
-        },
-        Err(_) => FALLBACK_DATE.into(),
-    };
     let man = Man::new(cmd)
         .section("1")
         .source(format!("{cargo_bin} {version}"))
-        .date(date);
+        .date(manual_date());
     let mut buf = Vec::new();
     man.render(&mut buf)?;
     let out_path = out_dir.join(format!("{cargo_bin}.1"));

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1502,10 +1502,10 @@ enumeration in unit tests and via Cucumber steps for behavioural coverage.
 ### 8.5 Manual Pages
 
 The CLI definition doubles as the source for user documentation. A build script
-uses `clap_mangen` to emit a `netsuke.1` manual page in `target/generated-man`.
-Release artefacts include this platform‑agnostic man page; the published crate
-remains code‑only. The build script honours `SOURCE_DATE_EPOCH` to produce
-reproducible dates.
+uses `clap_mangen` to emit a `netsuke.1` manual page in
+`target/generated-man/<target>/<profile>`. Release artefacts include this
+platform‑agnostic man page; the published crate remains code‑only. The build
+script honours `SOURCE_DATE_EPOCH` to produce reproducible dates.
 
 ## Section 9: Implementation Roadmap and Strategic Recommendations
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1505,7 +1505,8 @@ The CLI definition doubles as the source for user documentation. A build script
 uses `clap_mangen` to emit a `netsuke.1` manual page in
 `target/generated-man/<target>/<profile>`. Release artefacts include this
 platform‑agnostic man page; the published crate remains code‑only. The build
-script honours `SOURCE_DATE_EPOCH` to produce reproducible dates.
+script honours `SOURCE_DATE_EPOCH` to produce reproducible dates, emitting a
+warning and falling back to `1970-01-01` when the environment value is invalid.
 
 ## Section 9: Implementation Roadmap and Strategic Recommendations
 

--- a/scripts/package-artifact.sh
+++ b/scripts/package-artifact.sh
@@ -37,7 +37,7 @@ require_file "$bin_src" "binary missing" "Did the build succeed for target=${tar
 cp "$bin_src" "$bin_dst"
 hash256 "$bin_dst" > "${bin_dst}.sha256"
 
-man_src="target/generated-man/${bin_name}.1"
+man_src="target/generated-man/${target}/release/${bin_name}.1"
 man_dst="$out_dir/${bin_name}-${os}-${arch}.1"
 require_file "$man_src" "man page missing" "Did build.rs run and write ${bin_name}.1?"
 cp "$man_src" "$man_dst"


### PR DESCRIPTION
## Summary
- warn when SOURCE_DATE_EPOCH is invalid and fall back deterministically
- track TARGET and PROFILE in build script to avoid stale man pages
- fix release workflow Python usage and ensure jq is installed
- exclude Cargo.lock from published crate

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b778fe06c8832282246365ee23be2e

## Summary by Sourcery

Improve build reproducibility and release automation by validating and tracking build metadata, refining CI steps, and streamlining packaging

Enhancements:
- Warn and fall back to a default date when SOURCE_DATE_EPOCH is invalid
- Rerun build script when TARGET or PROFILE changes to regenerate man pages

CI:
- Use system python in release workflow instead of step output path
- Install jq before preparing GoReleaser distribution

Chores:
- Exclude Cargo.lock from the published crate