### PR TITLE
Use prebuilt man pages in release packaging

### DIFF
--- a/.github/actions/export-bin-name/action.yml
+++ b/.github/actions/export-bin-name/action.yml
@@ -1,0 +1,26 @@
+name: Export binary name
+description: Derive the crate's binary name from Cargo.toml and export BIN_NAME
+runs:
+  using: composite
+  steps:
+    - name: Derive binary name
+      shell: bash
+      run: |
+        set -euo pipefail
+        toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
+        BIN_NAME="$(
+          python3 - <<'PY' || echo ''
+import os, tomllib
+path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
+with open(path, 'rb') as f:
+    data = tomllib.load(f)
+name = (data.get('package') or {}).get('name')
+bins = [b.get('name') for b in data.get('bin', []) if 'name' in b]
+print((bins[0] if bins else name) or '')
+PY
+        )"
+        if [ -z "${BIN_NAME:-}" ]; then
+          echo "::error title=Binary name not found::Set package.name or [[bin]] name in ${toml_path}"
+          exit 1
+        fi
+        echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,8 @@ PY
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+        - name: Clean generated man pages
+          run: rm -rf target/generated-man
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -246,23 +248,19 @@ PY
           if [ -z "${BIN_NAME:-}" ]; then
             echo "::error title=Binary name not found::No binary target in Cargo.toml"; exit 1; fi
           echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
-      - name: Stage man page
-        run: |
-          set -euo pipefail
-          man_src=$(find dist -name "${BIN_NAME}-*.1" | head -n 1)
-          if [ -z "${man_src:-}" ]; then
-            echo "::error title=Manpage missing::${BIN_NAME}-*.1 not found in dist"; exit 1; fi
-          mkdir -p target/generated-man
-          cp "$man_src" "target/generated-man/${BIN_NAME}.1"
       - name: Prepare GoReleaser dist
         run: |
-          set -euo pipefail
-          printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
-            mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
-            mv "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}" \
-               "dist/netsuke_${dst_os}_${dst_arch}/netsuke"
-            rm -rf "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}"
-          done
+            set -euo pipefail
+            man_src="dist/${{ env.REPO_NAME }}-linux-x86_64/${BIN_NAME}-linux-x86_64.1"
+            if [ ! -f "$man_src" ]; then
+              echo "::error title=Manpage missing::${man_src} not found"; exit 1; fi
+            cp "$man_src" dist/netsuke.1
+            printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
+              mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
+              mv "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}" \
+                 "dist/netsuke_${dst_os}_${dst_arch}/netsuke"
+              rm -rf "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}"
+            done
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811  # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,8 @@ PY
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
-        - name: Clean generated man pages
-          run: rm -rf target/generated-man
+      - name: Clean generated man pages
+        run: rm -rf target/generated-man
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,35 +229,54 @@ PY
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - name: Setup Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.11'
       - name: Clean generated man pages
         run: rm -rf target/generated-man
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: dist
-      - name: Set up Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
-      - name: Setup jq
-        uses: vegardit/gha-setup-jq@491c577e0d5e6512cf02b06cf439b1fc4165aad1
+      # (Removed) No Rust needed in packaging after switching BIN_NAME to Python tomllib.
       - name: Export BIN_NAME
         run: |
           set -euo pipefail
-          BIN_NAME="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' \
-            | head -n 1)"
+          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          BIN_NAME="$(
+            python3 - <<'PY' || echo ""
+import os, tomllib
+path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
+with open(path, 'rb') as f:
+    data = tomllib.load(f)
+name = (data.get('package') or {}).get('name')
+bins = [b.get('name') for b in data.get('bin', []) if 'name' in b]
+print((bins[0] if bins else name) or '')
+PY
+          )"
           if [ -z "${BIN_NAME:-}" ]; then
-            echo "::error title=Binary name not found::No binary target in Cargo.toml"; exit 1; fi
+            echo "::error title=Binary name not found::Set package.name or [[bin]] name in ${toml_path}"
+            exit 1
+          fi
           echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
       - name: Prepare GoReleaser dist
         run: |
             set -euo pipefail
-            man_src="dist/${{ env.REPO_NAME }}-linux-x86_64/${BIN_NAME}-linux-x86_64.1"
-            if [ ! -f "$man_src" ]; then
-              echo "::error title=Manpage missing::${man_src} not found"; exit 1; fi
+            man_src="$(ls dist/${{ env.REPO_NAME }}-*/*-*.1 2>/dev/null | head -n1 || true)"
+            if [ -z "${man_src:-}" ] || [ ! -f "$man_src" ]; then
+              echo "::error title=Manpage missing::No prebuilt man page found under dist/${{ env.REPO_NAME }}-*/"
+              exit 1
+            fi
             cp "$man_src" dist/netsuke.1
             printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
               mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
-              mv "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}" \
+              src="dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}"
+              if [ ! -f "$src" ]; then
+                echo "::error title=Missing binary::${src} not found (did the ${src_os}/${src_arch} build upload?)"
+                exit 1
+              fi
+              mv "$src" \
                  "dist/netsuke_${dst_os}_${dst_arch}/netsuke"
               rm -rf "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}"
             done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,26 +94,7 @@ PY
             exit 1
           fi
           echo "Release tag $tag matches Cargo.toml version."
-      - name: Export BIN_NAME
-        run: |
-          set -euo pipefail
-          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          BIN_NAME="$(
-            python3 - <<'PY' || echo ""
-import os, tomllib
-path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
-with open(path, 'rb') as f:
-    data = tomllib.load(f)
-name = (data.get('package') or {}).get('name')
-bins = [b.get('name') for b in data.get('bin', []) if 'name' in b]
-print((bins[0] if bins else name) or '')
-PY
-          )"
-          if [ -z "${BIN_NAME:-}" ]; then
-            echo "::error title=Binary name not found::Set package.name or [[bin]] name in ${toml_path}"
-            exit 1
-          fi
-          echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/export-bin-name
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
       - name: Install MSRV toolchain
@@ -183,31 +164,11 @@ PY
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-
             ${{ runner.os }}-cargo-
-      - name: Resolve binary name from Cargo.toml
-        id: bin-name
+      - name: Setup Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
-      - name: Export BIN_NAME
-        run: |
-          set -euo pipefail
-          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          BIN_NAME="$(
-            python3 - <<'PY' || echo ""
-import os, tomllib, sys
-path=os.environ.get("CARGO_TOML_PATH","Cargo.toml")
-with open(path,'rb') as f:
-  m=tomllib.load(f)
-name = (m.get('package') or {}).get('name')
-bins = [b.get('name') for b in m.get('bin',[]) if 'name' in b]
-print((bins[0] if bins else name) or "")
-PY
-          )"
-          if [ -z "${BIN_NAME:-}" ]; then
-            echo "::error title=Binary name not found::Set package.name or [[bin]] name in ${toml_path}"
-            exit 1
-          fi
-          echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/export-bin-name
       - name: Build macOS
         uses: ./.github/actions/cross-build-macos
         with:
@@ -240,31 +201,12 @@ PY
         with:
           path: dist
       # (Removed) No Rust needed in packaging after switching BIN_NAME to Python tomllib.
-      - name: Export BIN_NAME
-        run: |
-          set -euo pipefail
-          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          BIN_NAME="$(
-            python3 - <<'PY' || echo ""
-import os, tomllib
-path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
-with open(path, 'rb') as f:
-    data = tomllib.load(f)
-name = (data.get('package') or {}).get('name')
-bins = [b.get('name') for b in data.get('bin', []) if 'name' in b]
-print((bins[0] if bins else name) or '')
-PY
-          )"
-          if [ -z "${BIN_NAME:-}" ]; then
-            echo "::error title=Binary name not found::Set package.name or [[bin]] name in ${toml_path}"
-            exit 1
-          fi
-          echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/export-bin-name
       - name: Prepare GoReleaser dist
         run: |
             set -euo pipefail
             shopt -s nullglob
-            candidates=(dist/${{ env.REPO_NAME }}-*/*-*.1)
+            candidates=(dist/${{ env.REPO_NAME }}-*/*${BIN_NAME}-*.1{,.gz})
             count="${#candidates[@]}"
             if [ "$count" -eq 0 ]; then
               echo "::error title=Manpage missing::No prebuilt man page found under dist/${{ env.REPO_NAME }}-*/"
@@ -274,7 +216,11 @@ PY
               echo "::error title=Ambiguous manpage::Multiple candidates found. Produce a single canonical manpage or set MANPAGE_SRC."
               exit 1
             fi
-            cp "${candidates[0]}" dist/netsuke.1
+            src="${candidates[0]}"
+            case "$src" in
+              *.gz) cp "$src" dist/netsuke.1.gz ;;
+              *.1)  cp "$src" dist/netsuke.1 && gzip -n -f dist/netsuke.1 ;;
+            esac
             printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
               mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
               src="dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,12 +263,18 @@ PY
       - name: Prepare GoReleaser dist
         run: |
             set -euo pipefail
-            man_src="$(ls dist/${{ env.REPO_NAME }}-*/*-*.1 2>/dev/null | head -n1 || true)"
-            if [ -z "${man_src:-}" ] || [ ! -f "$man_src" ]; then
+            shopt -s nullglob
+            candidates=(dist/${{ env.REPO_NAME }}-*/*-*.1)
+            count="${#candidates[@]}"
+            if [ "$count" -eq 0 ]; then
               echo "::error title=Manpage missing::No prebuilt man page found under dist/${{ env.REPO_NAME }}-*/"
               exit 1
+            elif [ "$count" -gt 1 ]; then
+              printf 'Found multiple manpages:\n%s\n' "${candidates[@]}"
+              echo "::error title=Ambiguous manpage::Multiple candidates found. Produce a single canonical manpage or set MANPAGE_SRC."
+              exit 1
             fi
-            cp "$man_src" dist/netsuke.1
+            cp "${candidates[0]}" dist/netsuke.1
             printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
               mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
               src="dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,28 +235,28 @@ PY
           path: dist
       - name: Set up Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
-      - name: Generate man page
-        run: cargo build -q --features manpage --no-default-features
       - name: Setup jq
         uses: vegardit/gha-setup-jq@491c577e0d5e6512cf02b06cf439b1fc4165aad1
-      - name: Verify man page exists
+      - name: Export BIN_NAME
         run: |
           set -euo pipefail
-          host=$(rustc -Vv | awk '/^host:/ {print $2}')
           BIN_NAME="$(cargo metadata --no-deps --format-version 1 \
             | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' \
             | head -n 1)"
-          man_src="target/generated-man/${host}/debug/${BIN_NAME}.1"
-          test -f "$man_src" || {
-            echo "::error title=Manpage missing::${man_src} not found"; exit 1; }
+          if [ -z "${BIN_NAME:-}" ]; then
+            echo "::error title=Binary name not found::No binary target in Cargo.toml"; exit 1; fi
+          echo "BIN_NAME=$BIN_NAME" >> "$GITHUB_ENV"
+      - name: Stage man page
+        run: |
+          set -euo pipefail
+          man_src=$(find dist -name "${BIN_NAME}-*.1" | head -n 1)
+          if [ -z "${man_src:-}" ]; then
+            echo "::error title=Manpage missing::${BIN_NAME}-*.1 not found in dist"; exit 1; fi
           mkdir -p target/generated-man
           cp "$man_src" "target/generated-man/${BIN_NAME}.1"
       - name: Prepare GoReleaser dist
         run: |
           set -euo pipefail
-          BIN_NAME="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' \
-            | head -n 1)"
           printf '%s\n' "$PACKAGE_PLATFORMS" | while read -r src_os src_arch dst_os dst_arch; do
             mkdir -p "dist/netsuke_${dst_os}_${dst_arch}"
             mv "dist/${{ env.REPO_NAME }}-${src_os}-${src_arch}/${BIN_NAME}-${src_os}-${src_arch}" \

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,7 +56,7 @@ nfpms:
     license: ISC
     formats: [deb, rpm]
     builds: [netsuke]
-    bindir: /usr/local/bin
+    bindir: /usr/bin
     contents:
       - src: ./dist/netsuke.1
         dst: /usr/share/man/man1/netsuke.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,7 +96,7 @@ hooks:
             continue
           fi
 
-          if [ -f "${MANPAGE}" ]; then
+          if [ -s "${MANPAGE}" ]; then
             install -m 0644 "${MANPAGE}" "$STAGE/usr/local/share/man/man1/${BIN}.1.gz"
           fi
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ project_name: netsuke
 before:
   hooks:
     - |
-        test -f dist/netsuke.1 || {
+        test -s dist/netsuke.1 || {
           echo "::error title=Manpage missing::dist/netsuke.1 not found. Ensure package job staged it before packaging.";
           exit 1;
         }
@@ -59,7 +59,7 @@ nfpms:
     bindir: /usr/local/bin
     contents:
       - src: ./dist/netsuke.1
-        dst: /usr/local/share/man/man1/netsuke.1
+        dst: /usr/share/man/man1/netsuke.1
 
 
 # FreeBSD native .pkg via a post hook that runs only on FreeBSD.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,10 +5,10 @@ project_name: netsuke
 before:
   hooks:
     - |
-      test -f target/generated-man/netsuke.1 || {
-        echo "::error title=Manpage missing::target/generated-man/netsuke.1 not found. Ensure build.rs or a dedicated step generates it before packaging.";
-        exit 1;
-      }
+        test -f dist/netsuke.1 || {
+          echo "::error title=Manpage missing::dist/netsuke.1 not found. Ensure package job staged it before packaging.";
+          exit 1;
+        }
 
 builds:
   # GoReleaser packages prebuilt Rust binaries. `skip_build: true` avoids
@@ -43,7 +43,7 @@ archives:
     files:
       - LICENSE
       - README.md
-      - target/generated-man/netsuke.1
+      - dist/netsuke.1
 
 nfpms:
   # Linux packages (deb/rpm) for netsuke
@@ -58,7 +58,7 @@ nfpms:
     builds: [netsuke]
     bindir: /usr/local/bin
     contents:
-      - src: ./target/generated-man/netsuke.1
+      - src: ./dist/netsuke.1
         dst: /usr/local/share/man/man1/netsuke.1
 
 
@@ -80,7 +80,7 @@ hooks:
 
         for BIN in netsuke; do
           STAGE="$(mktemp -d -t "netsuke-${BIN}-stage.XXXXXXXX")"
-          MANPAGE="target/generated-man/${BIN}.1"
+          MANPAGE="dist/${BIN}.1"
           # Scope cleanup to each BIN
           trap 'rc=$?; rm -rf "$STAGE" manifest.ucl 2>/dev/null || true; exit $rc' EXIT
           install -d "$STAGE/usr/local/bin" "$STAGE/usr/local/share/man/man1"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,8 +5,8 @@ project_name: netsuke
 before:
   hooks:
     - |
-        test -s dist/netsuke.1 || {
-          echo "::error title=Manpage missing::dist/netsuke.1 not found. Ensure package job staged it before packaging.";
+        test -s dist/netsuke.1.gz || {
+          echo "::error title=Manpage missing::dist/netsuke.1.gz not found. Ensure package job staged it before packaging.";
           exit 1;
         }
 
@@ -43,7 +43,7 @@ archives:
     files:
       - LICENSE
       - README.md
-      - dist/netsuke.1
+      - dist/netsuke.1.gz
 
 nfpms:
   # Linux packages (deb/rpm) for netsuke
@@ -58,8 +58,8 @@ nfpms:
     builds: [netsuke]
     bindir: /usr/bin
     contents:
-      - src: ./dist/netsuke.1
-        dst: /usr/share/man/man1/netsuke.1
+      - src: ./dist/netsuke.1.gz
+        dst: /usr/share/man/man1/netsuke.1.gz
 
 
 # FreeBSD native .pkg via a post hook that runs only on FreeBSD.
@@ -80,7 +80,7 @@ hooks:
 
         for BIN in netsuke; do
           STAGE="$(mktemp -d -t "netsuke-${BIN}-stage.XXXXXXXX")"
-          MANPAGE="dist/${BIN}.1"
+          MANPAGE="dist/${BIN}.1.gz"
           # Scope cleanup to each BIN
           trap 'rc=$?; rm -rf "$STAGE" manifest.ucl 2>/dev/null || true; exit $rc' EXIT
           install -d "$STAGE/usr/local/bin" "$STAGE/usr/local/share/man/man1"
@@ -97,7 +97,7 @@ hooks:
           fi
 
           if [ -f "${MANPAGE}" ]; then
-            install -m 0644 "${MANPAGE}" "$STAGE/usr/local/share/man/man1/${BIN}.1"
+            install -m 0644 "${MANPAGE}" "$STAGE/usr/local/share/man/man1/${BIN}.1.gz"
           fi
 
           cat > manifest.ucl <<UCL

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,6 +96,7 @@ hooks:
             continue
           fi
 
+          # Guard against packaging a zero-length man page
           if [ -s "${MANPAGE}" ]; then
             install -m 0644 "${MANPAGE}" "$STAGE/usr/local/share/man/man1/${BIN}.1.gz"
           fi


### PR DESCRIPTION
## Summary
- stage man pages from cross-built artifacts instead of regenerating them
- package release binaries and man page via GoReleaser

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b825af7f80832291d4db927b3a6d90

## Summary by Sourcery

Streamline the GitHub Actions release workflow to use prebuilt man pages from cross-built artifacts and integrate with GoReleaser

Enhancements:
- Leverage prebuilt man pages from the dist directory instead of regenerating them via cargo
- Export the binary name (BIN_NAME) as an environment variable for reuse across workflow steps

CI:
- Remove the cargo-based man page generation step
- Stage and validate the prebuilt man page in target/generated-man before GoReleaser dist preparation