### PR TITLE
Adopt structured errors for Ninja generation

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1181,17 +1181,17 @@ The command construction will follow this pattern:
 1. A new `Command` is created via `Command::new("ninja")`. Netsuke will assume
    `ninja` is available in the system's `PATH`.
 
-1. Arguments passed to Netsuke's own CLI will be translated and forwarded to
+2. Arguments passed to Netsuke's own CLI will be translated and forwarded to
    Ninja. For example, a `Netsuke build my_target` command would result in
    `Command::new("ninja").arg("my_target")`. Flags like `-j` for parallelism
    will also be passed through.[^8]
 
-1. The working directory for the Ninja process will be set using
+3. The working directory for the Ninja process will be set using
    `.current_dir()`. When the user supplies a `-C` flag, Netsuke canonicalises
    the path and applies it via `current_dir` rather than forwarding the flag to
    Ninja.
 
-1. Standard I/O streams (`stdin`, `stdout`, `stderr`) will be configured using
+4. Standard I/O streams (`stdin`, `stdout`, `stderr`) will be configured using
    `.stdout(Stdio::piped())` and `.stderr(Stdio::piped())`.[^24] This allows
    Netsuke to capture the real-time output from Ninja, which can then be
    streamed to the user's console, potentially with additional formatting or
@@ -1279,11 +1279,11 @@ three fundamental questions:
 1. **What** went wrong? A concise summary of the failure (e.g., "YAML parsing
    failed," "Build configuration is invalid").
 
-1. **Where** did it go wrong? Precise location information, including the file,
+2. **Where** did it go wrong? Precise location information, including the file,
    line number, and column where applicable (e.g., "in `Netsukefile` at line
    15, column 3").
 
-1. **Why** did it go wrong, and what can be done about it? The underlying cause
+3. **Why** did it go wrong, and what can be done about it? The underlying cause
    of the error and a concrete suggestion for how to fix it (e.g., "Cause:
    Found a tab character, which is not allowed. Hint: Use spaces for
    indentation instead.").
@@ -1346,23 +1346,26 @@ enrichment:
 
 1. A specific, low-level error occurs within a module. For instance, the IR
    generator detects a missing rule and creates an `IrGenError::RuleNotFound`.
+   Likewise, the Ninja generator returns `NinjaGenError::MissingAction` when a
+   build edge references an undefined action, preventing panics during file
+   generation.
 
-1. The function where the error occurred returns
+2. The function where the error occurred returns
    `Err(IrGenError::RuleNotFound {... }.into())`. The `.into()` call converts
    the specific `thiserror` enum variant into a generic `anyhow::Error` object,
    preserving the original error as its source.
 
-1. A higher-level function in the call stack, which called the failing function,
+3. A higher-level function in the call stack, which called the failing function,
    receives this `Err` value. It uses the `.with_context()` method to wrap the
    error with more application-level context. For example:
    `ir::from_manifest(ast)`
    `.with_context(|| "Failed to build the internal build graph from the manifest")?`
     .
 
-1. This process of propagation and contextualization repeats as the error
+4. This process of propagation and contextualization repeats as the error
    bubbles up towards `main`.
 
-1. Finally, the `main` function receives the `Err` result. It prints the entire
+5. Finally, the `main` function receives the `Err` result. It prints the entire
    error chain provided by `anyhow`, which displays the highest-level context
    first, followed by a list of underlying "Caused by:" messages. This provides
    the user with a rich, layered explanation of the failure, from the general
@@ -1530,15 +1533,15 @@ goal.
 
     1. Implement the initial `clap` CLI structure for the `build` command.
 
-    1. Implement the YAML parser using `serde_yml` and the AST data structures
+    2. Implement the YAML parser using `serde_yml` and the AST data structures
        (`ast.rs`).
 
-    1. Implement the AST-to-IR transformation logic, including basic validation
+    3. Implement the AST-to-IR transformation logic, including basic validation
        like checking for rule existence.
 
-    1. Implement the IR-to-Ninja file generator (`ninja_gen.rs`).
+    4. Implement the IR-to-Ninja file generator (`ninja_gen.rs`).
 
-    1. Implement the `std::process::Command` logic to invoke `ninja`.
+    5. Implement the `std::process::Command` logic to invoke `ninja`.
 
   - **Success Criterion:** Netsuke can successfully take a `Netsukefile` file
     *without any Jinja syntax* and compile it to a `build.ninja` file, then
@@ -1554,13 +1557,13 @@ goal.
 
     1. Integrate the `minijinja` crate into the build pipeline.
 
-    1. Implement the two-pass parsing mechanism: first render the manifest with
+    2. Implement the two-pass parsing mechanism: first render the manifest with
        `minijinja`, then parse the result with `serde_yml`.
 
-    1. Populate the initial Jinja context with the global `vars` from the
+    3. Populate the initial Jinja context with the global `vars` from the
        manifest.
 
-    1. Implement basic Jinja control flow (`{% if... %}`, `{% for... %}`) and
+    4. Implement basic Jinja control flow (`{% if... %}`, `{% for... %}`) and
        variable substitution.
 
   - **Success Criterion:** Netsuke can successfully build a manifest that uses
@@ -1577,15 +1580,15 @@ goal.
     1. Implement the full suite of custom Jinja functions (`glob`, `env`, etc.)
        and filters (`shell_escape`).
 
-    1. Mandate the use of `shell-quote` for all command variable substitutions.
+    2. Mandate the use of `shell-quote` for all command variable substitutions.
 
-    1. Refactor the error handling to fully adopt the `anyhow`/`thiserror`
+    3. Refactor the error handling to fully adopt the `anyhow`/`thiserror`
        strategy, ensuring all user-facing errors are contextual and actionable
        as specified in Section 7.
 
-    1. Implement the `clean` and `graph` subcommands.
+    4. Implement the `clean` and `graph` subcommands.
 
-    1. Refine the CLI output for clarity and readability.
+    5. Refine the CLI output for clarity and readability.
 
   - **Success Criterion:** Netsuke is a feature-complete, secure, and
     user-friendly build tool that meets all the initial design goals.
@@ -1652,7 +1655,8 @@ projects.
 ### **Works cited**
 
 [^1]: Ninja, a small build system with a focus on speed. Accessed on 12 July
-      2025. <https://ninja-build.org/>
+
+      1. <https://ninja-build.org/>
 
 [^2]: "Ninja (build system)." Wikipedia. Accessed on 12 July 2025.
       <https://en.wikipedia.org/wiki/Ninja_(build_system)>

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1370,14 +1370,14 @@ pub enum ManifestError {
     Parse {
         #[source]
         #[diagnostic_source]
-        source: YamlDiagnostic,
+        source: Box<dyn Diagnostic + Send + Sync + 'static>,
     },
 }
 ```
 
-`ManifestError::Parse` preserves the rich diagnostic, allowing `miette` to show
-the offending YAML snippet. All new user-facing errors with source context must
-follow this model.
+`ManifestError::Parse` boxes the diagnostic to preserve the rich error so
+`miette` can show the offending YAML snippet. All new user-facing errors with
+source context must follow this model.
 
 Common use cases requiring `miette` diagnostics include:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,6 +148,8 @@ library, and CLI ergonomics.
 
   - [x] Use anyhow in the application logic to add human-readable context to
     errors as they propagate (e.g., using .with_context()).
+  - [x] Use `miette` to render diagnostics with source spans and helpful
+    messages.
 
   - [x] Refactor all error-producing code to provide the clear, contextual, and
     actionable error messages specified in the design document.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,18 +138,18 @@ library, and CLI ergonomics.
   - [x] After interpolation, validate the final command string is parsable using
     the shlex crate.
 
-- [ ] **Actionable Error Reporting:**
+- [x] **Actionable Error Reporting:**
 
-  - [ ] Adopt the `anyhow` and `thiserror` error handling strategy.
+  - [x] Adopt the `anyhow` and `thiserror` error handling strategy.
 
-  - [ ] Use thiserror to define specific, structured error types within library
+  - [x] Use thiserror to define specific, structured error types within library
 
     modules (e.g., IrGenError::RuleNotFound, IrGenError::CircularDependency).
 
-  - [ ] Use anyhow in the application logic to add human-readable context to
+  - [x] Use anyhow in the application logic to add human-readable context to
     errors as they propagate (e.g., using .with_context()).
 
-  - [ ] Refactor all error-producing code to provide the clear, contextual, and
+  - [x] Refactor all error-producing code to provide the clear, contextual, and
     actionable error messages specified in the design document.
 
 - [ ] **Template Standard Library:**

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -176,9 +176,11 @@ fn simple_manifest_ninja_snapshot() {
     let build_graph = BuildGraph::from_manifest(&manifest).expect("IR generation succeeded");
 
     // Generate Ninja file content from the IR
-    // The function returns `Result<String, NinjaGenError>`
-    let ninja_file = ninja_gen::generate(&build_graph)
-        .expect("Ninja file generation succeeded");
+    // `generate` returns `Result<String, NinjaGenError>`; handle errors
+    let ninja_file = match ninja_gen::generate(&build_graph) {
+        Ok(ninja) => ninja,
+        Err(e) => panic!("Ninja file generation failed: {e}"),
+    };
 
     // The output is a multi-line Ninja build script (as a String)
     // Ensure the output is deterministic
@@ -190,6 +192,10 @@ fn simple_manifest_ninja_snapshot() {
         });
 }
 ```
+
+The match explicitly handles the `Result` from `generate` so any formatting or
+missing action errors surface during tests. Production code should propagate
+the error and report it with `miette` rather than panicking.
 
 Key points for Ninja snapshot tests:
 

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -176,6 +176,7 @@ fn simple_manifest_ninja_snapshot() {
     let build_graph = BuildGraph::from_manifest(&manifest).expect("IR generation succeeded");
 
     // Generate Ninja file content from the IR
+    // The function returns Result
     let ninja_file = ninja_gen::generate(&build_graph)
         .expect("Ninja file generation succeeded");
 
@@ -196,9 +197,10 @@ Key points for Ninja snapshot tests:
   constructed directly for tests, but using the manifest→IR pipeline ensures
   realistic coverage.
 
-- Call the Ninja generation function (e.g. `ninja_gen::generate`), which
-  produces the Ninja file contents as a `String`. This function traverses the
-  IR and outputs rules and build statements in Ninja syntax.
+- Call the Ninja generation function (`ninja_gen::generate`), which
+  produces the Ninja file contents as a `Result`. This function traverses the
+  IR and outputs rules and build statements in Ninja syntax, returning an error
+  if any build edge references an undefined action.
 
 - As with IR, **determinism is crucial**. The Ninja output should list rules,
   targets, and dependencies in a consistent order. For example, if the IR does

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -176,7 +176,7 @@ fn simple_manifest_ninja_snapshot() {
     let build_graph = BuildGraph::from_manifest(&manifest).expect("IR generation succeeded");
 
     // Generate Ninja file content from the IR
-    // The function returns Result
+    // The function returns `Result<String, NinjaGenError>`
     let ninja_file = ninja_gen::generate(&build_graph)
         .expect("Ninja file generation succeeded");
 
@@ -198,9 +198,9 @@ Key points for Ninja snapshot tests:
   realistic coverage.
 
 - Call the Ninja generation function (`ninja_gen::generate`), which
-  produces the Ninja file contents as a `Result`. This function traverses the
-  IR and outputs rules and build statements in Ninja syntax, returning an error
-  if any build edge references an undefined action.
+  yields a `Result<String, NinjaGenError>`. This function traverses the IR and
+  outputs rules and build statements in Ninja syntax, returning an error if any
+  build edge references an undefined action.
 
 - As with IR, **determinism is crucial**. The Ninja output should list rules,
   targets, and dependencies in a consistent order. For example, if the IR does

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -176,7 +176,7 @@ fn simple_manifest_ninja_snapshot() {
     let build_graph = BuildGraph::from_manifest(&manifest).expect("IR generation succeeded");
 
     // Generate Ninja file content from the IR
-    let ninja_file = ninja_gen::generate_ninja(&build_graph)
+    let ninja_file = ninja_gen::generate(&build_graph)
         .expect("Ninja file generation succeeded");
 
     // The output is a multi-line Ninja build script (as a String)
@@ -196,7 +196,7 @@ Key points for Ninja snapshot tests:
   constructed directly for tests, but using the manifest→IR pipeline ensures
   realistic coverage.
 
-- Call the Ninja generation function (e.g. `ninja_gen::generate_ninja`), which
+- Call the Ninja generation function (e.g. `ninja_gen::generate`), which
   produces the Ninja file contents as a `String`. This function traverses the
   IR and outputs rules and build statements in Ninja syntax.
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -29,7 +29,10 @@ use std::fmt::Display;
 ///     File::open(path).diag("open file")
 /// }
 /// ```
-#[expect(dead_code, reason = "unused after migration to anyhow")]
+#[expect(
+    dead_code,
+    reason = "temporarily retained during anyhow migration; remove when no call sites remain"
+)]
 pub(crate) trait ResultExt<T> {
     /// Attach a static context message to any error.
     ///

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -29,6 +29,7 @@ use std::fmt::Display;
 ///     File::open(path).diag("open file")
 /// }
 /// ```
+#[allow(dead_code, reason = "unused after migration to anyhow")]
 pub(crate) trait ResultExt<T> {
     /// Attach a static context message to any error.
     ///

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -29,7 +29,7 @@ use std::fmt::Display;
 ///     File::open(path).diag("open file")
 /// }
 /// ```
-#[allow(dead_code, reason = "unused after migration to anyhow")]
+#[expect(dead_code, reason = "unused after migration to anyhow")]
 pub(crate) trait ResultExt<T> {
     /// Attach a static context message to any error.
     ///

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -84,11 +84,15 @@ pub enum ManifestError {
     Parse {
         #[source]
         #[diagnostic_source]
-        source: YamlDiagnostic,
+        source: Box<dyn Diagnostic + Send + Sync + 'static>,
     },
 }
 
-fn map_yaml_error(err: YamlError, src: &str, name: &str) -> YamlDiagnostic {
+fn map_yaml_error(
+    err: YamlError,
+    src: &str,
+    name: &str,
+) -> Box<dyn Diagnostic + Send + Sync + 'static> {
     let loc = err.location();
     let (line, col, span) = loc.map_or((1, 1, None), |l| {
         (l.line(), l.column(), Some(to_span(src, l)))
@@ -101,13 +105,13 @@ fn map_yaml_error(err: YamlError, src: &str, name: &str) -> YamlDiagnostic {
         message.push_str(h);
     }
 
-    YamlDiagnostic {
+    Box::new(YamlDiagnostic {
         src: NamedSource::new(name, src.to_string()),
         span,
         help: hint,
         source: err,
         message,
-    }
+    })
 }
 
 /// Resolve the value of an environment variable for the `env()` Jinja helper.

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -36,7 +36,7 @@ fn to_span(src: &str, loc: Location) -> SourceSpan {
         }
     };
     let len = end.saturating_sub(start);
-    #[allow(clippy::useless_conversion, reason = "future-proof span length type")]
+    #[expect(clippy::useless_conversion, reason = "future-proof span length type")]
     SourceSpan::new(start.into(), len.into())
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -528,8 +528,9 @@ fn glob_paths(pattern: &str) -> std::result::Result<Vec<String>, Error> {
 ///
 /// Returns an error if YAML parsing or Jinja evaluation fails.
 fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
-    let mut doc: YamlValue =
-        serde_yml::from_str(yaml).map_err(|e| map_yaml_error(e, yaml, name))?;
+    let mut doc: YamlValue = serde_yml::from_str(yaml).map_err(|e| ManifestError::Parse {
+        source: map_yaml_error(e, yaml, name),
+    })?;
 
     let mut jinja = Environment::new();
     jinja.set_undefined_behavior(UndefinedBehavior::Strict);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -549,9 +549,10 @@ fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
 
     expand_foreach(&mut doc, &jinja)?;
 
-    let manifest: NetsukeManifest = serde_yml::from_value(doc).map_err(|e| ManifestError::Parse {
-        source: map_yaml_error(e, yaml, name),
-    })?;
+    let manifest: NetsukeManifest =
+        serde_yml::from_value(doc).map_err(|e| ManifestError::Parse {
+            source: map_yaml_error(e, yaml, name),
+        })?;
 
     render_manifest(manifest, &jinja)
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -7,11 +7,9 @@
 //! filesystem patterns during template evaluation. Both helpers fail fast when
 //! inputs are missing or patterns are invalid.
 
-use crate::{
-    ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars},
-    diagnostics::ResultExt,
-};
-use miette::{Diagnostic, NamedSource, Report, Result, SourceSpan};
+use crate::ast::{NetsukeManifest, Recipe, StringOrList, Target, Vars};
+use anyhow::{Context, Result};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use minijinja::{Environment, Error, ErrorKind, UndefinedBehavior, context, value::Value};
 use serde_yml::{Error as YamlError, Location};
 use serde_yml::{Mapping as YamlMapping, Value as YamlValue};
@@ -531,7 +529,7 @@ fn glob_paths(pattern: &str) -> std::result::Result<Vec<String>, Error> {
 /// Returns an error if YAML parsing or Jinja evaluation fails.
 fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
     let mut doc: YamlValue =
-        serde_yml::from_str(yaml).map_err(|e| Report::new(map_yaml_error(e, yaml, name)))?;
+        serde_yml::from_str(yaml).map_err(|e| map_yaml_error(e, yaml, name))?;
 
     let mut jinja = Environment::new();
     jinja.set_undefined_behavior(UndefinedBehavior::Strict);
@@ -543,7 +541,7 @@ fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
         for (k, v) in vars {
             let key = k
                 .as_str()
-                .ok_or_else(|| miette::miette!("non-string key in 'vars' mapping: {k:?}"))?
+                .ok_or_else(|| anyhow::anyhow!("non-string key in vars mapping: {k:?}"))?
                 .to_string();
             jinja.add_global(key, Value::from_serialize(v));
         }
@@ -551,10 +549,8 @@ fn from_str_named(yaml: &str, name: &str) -> Result<NetsukeManifest> {
 
     expand_foreach(&mut doc, &jinja)?;
 
-    let manifest: NetsukeManifest = serde_yml::from_value(doc).map_err(|e| {
-        Report::new(ManifestError::Parse {
-            source: map_yaml_error(e, yaml, name),
-        })
+    let manifest: NetsukeManifest = serde_yml::from_value(doc).map_err(|e| ManifestError::Parse {
+        source: map_yaml_error(e, yaml, name),
     })?;
 
     render_manifest(manifest, &jinja)
@@ -618,7 +614,7 @@ fn parse_foreach_values(expr_val: &YamlValue, env: &Environment) -> Result<Vec<V
     let seq = eval_expression(env, "foreach", expr, context! {})?;
     let iter = seq
         .try_iter()
-        .diag("foreach expression did not yield an iterable")?;
+        .context("foreach expression did not yield an iterable")?;
     Ok(iter.collect())
 }
 
@@ -644,14 +640,14 @@ fn inject_iteration_vars(map: &mut YamlMapping, item: &Value, index: usize) -> R
         None => YamlMapping::new(),
         Some(YamlValue::Mapping(m)) => m,
         Some(other) => {
-            return Err(miette::miette!(
+            return Err(anyhow::anyhow!(
                 "target.vars must be a mapping, got: {other:?}"
             ));
         }
     };
     vars.insert(
         YamlValue::String("item".into()),
-        serde_yml::to_value(item).diag("serialise item")?,
+        serde_yml::to_value(item).context("serialise item")?,
     );
     vars.insert(
         YamlValue::String("index".into()),
@@ -664,14 +660,14 @@ fn inject_iteration_vars(map: &mut YamlMapping, item: &Value, index: usize) -> R
 fn as_str<'a>(value: &'a YamlValue, field: &str) -> Result<&'a str> {
     value
         .as_str()
-        .ok_or_else(|| miette::miette!("{field} must be a string expression"))
+        .ok_or_else(|| anyhow::anyhow!("{field} must be a string expression"))
 }
 
 fn eval_expression(env: &Environment, name: &str, expr: &str, ctx: Value) -> Result<Value> {
     env.compile_expression(expr)
-        .diag_with(|| format!("{name} expression parse error"))?
+        .with_context(|| format!("{name} expression parse error"))?
         .eval(ctx)
-        .diag_with(|| format!("{name} evaluation error"))
+        .with_context(|| format!("{name} evaluation error"))
 }
 
 /// Render a Jinja template and label any error with the given context.
@@ -681,7 +677,7 @@ fn render_str_with(
     ctx: &impl serde::Serialize,
     what: impl FnOnce() -> String,
 ) -> Result<String> {
-    env.render_str(tpl, ctx).diag_with(what)
+    env.render_str(tpl, ctx).with_context(what)
 }
 
 /// Render all templated strings in the manifest.
@@ -769,7 +765,7 @@ fn render_string_or_list(value: &mut StringOrList, env: &Environment, ctx: &Vars
 pub fn from_path(path: impl AsRef<Path>) -> Result<NetsukeManifest> {
     let path_ref = path.as_ref();
     let data = fs::read_to_string(path_ref)
-        .diag_with(|| format!("failed to read {}", path_ref.display()))?;
+        .with_context(|| format!("failed to read {}", path_ref.display()))?;
     from_str_named(&data, &path_ref.display().to_string())
 }
 

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -40,8 +40,8 @@ macro_rules! write_flag {
 ///
 /// # Examples
 /// ```
-/// use crate::ast::Recipe;
-/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use netsuke::ast::Recipe;
+/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -55,7 +55,7 @@ macro_rules! write_flag {
 ///     implicit_outputs: Vec::new(), order_only_deps: Vec::new(),
 ///     phony: false, always: false
 /// });
-/// let text = crate::ninja_gen::generate(&graph).expect("generate ninja");
+/// let text = netsuke::ninja_gen::generate(&graph).expect("generate ninja");
 /// assert!(text.contains("rule a"));
 /// ```
 ///
@@ -73,8 +73,8 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///
 /// # Examples
 /// ```
-/// use crate::ast::Recipe;
-/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use netsuke::ast::Recipe;
+/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -89,7 +89,7 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///     phony: false, always: false
 /// });
 /// let mut out = String::new();
-/// crate::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
+/// netsuke::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
 /// assert!(out.contains("build out: a"));
 /// ```
 ///

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -44,7 +44,16 @@ macro_rules! write_flag {
 /// writing to the output fails.
 pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
     let mut out = String::new();
+    generate_into(graph, &mut out)?;
+    Ok(out)
+}
 
+/// Write a Ninja build file to the provided writer.
+///
+/// # Errors
+///
+/// Returns [`NinjaGenError`] if a build edge references an unknown action or writing to the output fails.
+pub fn generate_into<W: Write>(graph: &BuildGraph, out: &mut W) -> Result<(), NinjaGenError> {
     let mut actions: Vec<_> = graph.actions.iter().collect();
     actions.sort_by_key(|(id, _)| *id);
     for (id, action) in actions {
@@ -82,7 +91,7 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
         writeln!(out, "default {}", join(&defs))?;
     }
 
-    Ok(out)
+    Ok(())
 }
 
 /// Convert a slice of paths into a space-separated string.

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -38,6 +38,27 @@ macro_rules! write_flag {
 
 /// Generate a Ninja build file as a string.
 ///
+/// # Examples
+/// ```
+/// use crate::ast::Recipe;
+/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use std::path::PathBuf;
+/// let mut graph = BuildGraph::default();
+/// graph.actions.insert("a".into(), Action {
+///     recipe: Recipe::Command { command: "true".into() },
+///     description: None, depfile: None, deps_format: None,
+///     pool: None, restat: false
+/// });
+/// graph.targets.insert(PathBuf::from("out"), BuildEdge {
+///     action_id: "a".into(), inputs: Vec::new(),
+///     explicit_outputs: vec![PathBuf::from("out")],
+///     implicit_outputs: Vec::new(), order_only_deps: Vec::new(),
+///     phony: false, always: false
+/// });
+/// let text = crate::ninja_gen::generate(&graph).expect("generate ninja");
+/// assert!(text.contains("rule a"));
+/// ```
+///
 /// # Errors
 ///
 /// Returns [`NinjaGenError`] if a build edge references an unknown action or
@@ -49,6 +70,28 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 }
 
 /// Write a Ninja build file to the provided writer.
+///
+/// # Examples
+/// ```
+/// use crate::ast::Recipe;
+/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use std::path::PathBuf;
+/// let mut graph = BuildGraph::default();
+/// graph.actions.insert("a".into(), Action {
+///     recipe: Recipe::Command { command: "true".into() },
+///     description: None, depfile: None, deps_format: None,
+///     pool: None, restat: false
+/// });
+/// graph.targets.insert(PathBuf::from("out"), BuildEdge {
+///     action_id: "a".into(), inputs: Vec::new(),
+///     explicit_outputs: vec![PathBuf::from("out")],
+///     implicit_outputs: Vec::new(), order_only_deps: Vec::new(),
+///     phony: false, always: false
+/// });
+/// let mut out = String::new();
+/// crate::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
+/// assert!(out.contains("build out: a"));
+/// ```
 ///
 /// # Errors
 ///

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -10,6 +10,15 @@ use itertools::Itertools;
 use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
 use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NinjaGenError {
+    #[error("action '{id}' referenced by build edge was not found")]
+    MissingAction { id: String },
+    #[error("failed to format Ninja output")]
+    Format(#[from] fmt::Error),
+}
 
 macro_rules! write_kv {
     ($f:expr, $key:expr, $opt:expr) => {
@@ -29,18 +38,17 @@ macro_rules! write_flag {
 
 /// Generate a Ninja build file as a string.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if a build edge references an unknown action or if writing to the
-/// output string fails (which is unexpected under normal conditions).
-#[must_use]
-pub fn generate(graph: &BuildGraph) -> String {
+/// Returns [`NinjaGenError`] if a build edge references an unknown action or
+/// writing to the output fails.
+pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
     let mut out = String::new();
 
     let mut actions: Vec<_> = graph.actions.iter().collect();
     actions.sort_by_key(|(id, _)| *id);
     for (id, action) in actions {
-        write!(out, "{}", NamedAction { id, action }).expect("write Ninja rule");
+        write!(out, "{}", NamedAction { id, action })?;
     }
 
     let mut edges: Vec<_> = graph.targets.values().collect();
@@ -51,7 +59,13 @@ pub fn generate(graph: &BuildGraph) -> String {
         if !seen.insert(key.clone()) {
             continue;
         }
-        let action = graph.actions.get(&edge.action_id).expect("action");
+        let action =
+            graph
+                .actions
+                .get(&edge.action_id)
+                .ok_or_else(|| NinjaGenError::MissingAction {
+                    id: edge.action_id.clone(),
+                })?;
         write!(
             out,
             "{}",
@@ -59,17 +73,16 @@ pub fn generate(graph: &BuildGraph) -> String {
                 edge,
                 action_restat: action.restat,
             }
-        )
-        .expect("write Ninja edge");
+        )?;
     }
 
     if !graph.default_targets.is_empty() {
         let mut defs = graph.default_targets.clone();
         defs.sort();
-        writeln!(out, "default {}", join(&defs)).expect("write defaults");
+        writeln!(out, "default {}", join(&defs))?;
     }
 
-    out
+    Ok(out)
 }
 
 /// Convert a slice of paths into a space-separated string.
@@ -195,7 +208,7 @@ mod tests {
         graph.targets.insert(PathBuf::from("out"), edge);
         graph.default_targets.push(PathBuf::from("out"));
 
-        let ninja = generate(&graph);
+        let ninja = generate(&graph).expect("generate ninja");
         let expected = concat!(
             "rule a\n",
             "  command = echo hi\n\n",

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -40,8 +40,8 @@ macro_rules! write_flag {
 ///
 /// # Examples
 /// ```
-/// use netsuke::ast::Recipe;
-/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
+/// use crate::ast::Recipe;
+/// use crate::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -55,7 +55,7 @@ macro_rules! write_flag {
 ///     implicit_outputs: Vec::new(), order_only_deps: Vec::new(),
 ///     phony: false, always: false
 /// });
-/// let text = netsuke::ninja_gen::generate(&graph).expect("generate ninja");
+/// let text = crate::ninja_gen::generate(&graph).expect("generate ninja");
 /// assert!(text.contains("rule a"));
 /// ```
 ///
@@ -73,8 +73,8 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///
 /// # Examples
 /// ```
-/// use netsuke::ast::Recipe;
-/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
+/// use crate::ast::Recipe;
+/// use crate::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -89,7 +89,7 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///     phony: false, always: false
 /// });
 /// let mut out = String::new();
-/// netsuke::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
+/// crate::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
 /// assert!(out.contains("build out: a"));
 /// ```
 ///

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,10 +10,7 @@ use anyhow::{Context, Result};
 use serde_json;
 use std::borrow::Cow;
 use std::fs;
-use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::thread;
 use tempfile::{Builder, NamedTempFile};
 use tracing::{debug, info};
 
@@ -22,31 +19,11 @@ pub const NINJA_PROGRAM: &str = "ninja";
 /// Environment variable override for the Ninja executable.
 pub use ninja_env::NINJA_ENV;
 
-// Public helpers for doctests only. This exposes internal helpers as a stable
-// testing surface without exporting them in release builds.
+mod process;
 #[cfg(doctest)]
 #[doc(hidden)]
-pub mod doc {
-    pub use super::CommandArg;
-
-    // Public wrappers to expose crate-private helpers to doctests.
-    #[must_use]
-    pub fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
-        super::contains_sensitive_keyword(arg)
-    }
-    #[must_use]
-    pub fn is_sensitive_arg(arg: &CommandArg) -> bool {
-        super::is_sensitive_arg(arg)
-    }
-    #[must_use]
-    pub fn redact_argument(arg: &CommandArg) -> CommandArg {
-        super::redact_argument(arg)
-    }
-    #[must_use]
-    pub fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
-        super::redact_sensitive_args(args)
-    }
-}
+pub use process::doc;
+pub use process::run_ninja;
 
 #[derive(Debug, Clone)]
 pub struct NinjaContent(String);
@@ -62,19 +39,6 @@ impl NinjaContent {
     #[must_use]
     pub fn into_string(self) -> String {
         self.0
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct CommandArg(String);
-impl CommandArg {
-    #[must_use]
-    pub fn new(arg: String) -> Self {
-        Self(arg)
-    }
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
     }
 }
 
@@ -276,158 +240,4 @@ fn resolve_manifest_path(cli: &Cli) -> std::path::PathBuf {
 #[must_use]
 fn resolve_ninja_program() -> PathBuf {
     std::env::var_os(NINJA_ENV).map_or_else(|| PathBuf::from(NINJA_PROGRAM), PathBuf::from)
-}
-
-/// Check if `arg` contains a sensitive keyword.
-///
-/// # Examples
-/// ```
-/// # use netsuke::runner::doc::{CommandArg, contains_sensitive_keyword};
-/// assert!(contains_sensitive_keyword(&CommandArg::new("token=abc".into())));
-/// assert!(!contains_sensitive_keyword(&CommandArg::new("path=/tmp".into())));
-/// ```
-pub(crate) fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
-    let lower = arg.as_str().to_lowercase();
-    lower.contains("password") || lower.contains("token") || lower.contains("secret")
-}
-
-/// Determine whether the argument should be redacted.
-///
-/// # Examples
-/// ```
-/// # use netsuke::runner::doc::{CommandArg, is_sensitive_arg};
-/// assert!(is_sensitive_arg(&CommandArg::new("password=123".into())));
-/// assert!(!is_sensitive_arg(&CommandArg::new("file=readme".into())));
-/// ```
-pub(crate) fn is_sensitive_arg(arg: &CommandArg) -> bool {
-    contains_sensitive_keyword(arg)
-}
-
-/// Redact sensitive information in a single argument.
-///
-/// Sensitive values are replaced with `***REDACTED***`, preserving keys.
-///
-/// # Examples
-/// ```
-/// # use netsuke::runner::doc::{CommandArg, redact_argument};
-/// let arg = CommandArg::new("token=abc".into());
-/// assert_eq!(redact_argument(&arg).as_str(), "token=***REDACTED***");
-/// let arg = CommandArg::new("path=/tmp".into());
-/// assert_eq!(redact_argument(&arg).as_str(), "path=/tmp");
-/// ```
-pub(crate) fn redact_argument(arg: &CommandArg) -> CommandArg {
-    if is_sensitive_arg(arg) {
-        let redacted = arg.as_str().split_once('=').map_or_else(
-            || "***REDACTED***".to_string(),
-            |(key, _)| format!("{key}=***REDACTED***"),
-        );
-        CommandArg::new(redacted)
-    } else {
-        arg.clone()
-    }
-}
-
-/// Redact sensitive information from all `args`.
-///
-/// # Examples
-/// ```
-/// # use netsuke::runner::doc::{CommandArg, redact_sensitive_args};
-/// let args = vec![
-///     CommandArg::new("ninja".into()),
-///     CommandArg::new("token=abc".into()),
-/// ];
-/// let redacted = redact_sensitive_args(&args);
-/// assert_eq!(redacted[1].as_str(), "token=***REDACTED***");
-/// ```
-pub(crate) fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
-    args.iter().map(redact_argument).collect()
-}
-
-/// Invoke the Ninja executable with the provided CLI settings.
-///
-/// The function forwards the job count and working directory to Ninja,
-/// specifies the temporary build file, and streams its standard output and
-/// error back to the user.
-///
-/// # Errors
-///
-/// Returns an [`io::Error`] if the Ninja process fails to spawn or reports a
-/// non-zero exit status.
-///
-/// # Panics
-///
-/// Panics if the child's output streams cannot be captured.
-pub fn run_ninja(
-    program: &Path,
-    cli: &Cli,
-    build_file: &Path,
-    targets: &BuildTargets<'_>,
-) -> io::Result<()> {
-    let mut cmd = Command::new(program);
-    if let Some(dir) = &cli.directory {
-        // Resolve and canonicalise the directory so Ninja receives a stable
-        // absolute path. Using only `current_dir` avoids combining it with
-        // Ninja's own `-C` flag which would otherwise double-apply the
-        // directory and break relative paths.
-        let dir = fs::canonicalize(dir)?;
-        cmd.current_dir(dir);
-    }
-    if let Some(jobs) = cli.jobs {
-        cmd.arg("-j").arg(jobs.to_string());
-    }
-    // Canonicalise the build file path so Ninja resolves it correctly from the
-    // working directory. Fall back to the original on failure so Ninja can
-    // surface a meaningful error.
-    let build_file_path = build_file
-        .canonicalize()
-        .unwrap_or_else(|_| build_file.to_path_buf());
-    cmd.arg("-f").arg(&build_file_path);
-    cmd.args(targets.as_slice());
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-
-    let program = cmd.get_program().to_string_lossy().into_owned();
-    let args: Vec<CommandArg> = cmd
-        .get_args()
-        .map(|a| CommandArg::new(a.to_string_lossy().into_owned()))
-        .collect();
-    let redacted_args = redact_sensitive_args(&args);
-    let arg_strings: Vec<&str> = redacted_args.iter().map(CommandArg::as_str).collect();
-    info!("Running command: {} {}", program, arg_strings.join(" "));
-
-    let mut child = cmd.spawn()?;
-    let stdout = child.stdout.take().expect("child stdout");
-    let stderr = child.stderr.take().expect("child stderr");
-
-    let out_handle = thread::spawn(move || {
-        let reader = BufReader::new(stdout);
-        let mut handle = io::stdout();
-        for line in reader.lines().map_while(Result::ok) {
-            let _ = writeln!(handle, "{line}");
-        }
-    });
-    let err_handle = thread::spawn(move || {
-        let reader = BufReader::new(stderr);
-        let mut handle = io::stderr();
-        for line in reader.lines().map_while(Result::ok) {
-            let _ = writeln!(handle, "{line}");
-        }
-    });
-
-    let status = child.wait()?;
-    let _ = out_handle.join();
-    let _ = err_handle.join();
-
-    if status.success() {
-        Ok(())
-    } else {
-        #[expect(
-            clippy::io_other_error,
-            reason = "use explicit error kind for compatibility with older Rust"
-        )]
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!("ninja exited with {status}"),
-        ))
-    }
 }

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -1,0 +1,196 @@
+use super::BuildTargets;
+use crate::cli::Cli;
+use std::{
+    fs,
+    io::{self, BufRead, BufReader, Write},
+    path::Path,
+    process::{Command, Stdio},
+    thread,
+};
+use tracing::info;
+
+#[derive(Debug, Clone)]
+pub struct CommandArg(String);
+impl CommandArg {
+    #[must_use]
+    pub fn new(arg: String) -> Self {
+        Self(arg)
+    }
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// Public helpers for doctests only. This exposes internal helpers as a stable
+// testing surface without exporting them in release builds.
+#[cfg(doctest)]
+#[doc(hidden)]
+pub mod doc {
+    pub use super::CommandArg;
+
+    #[must_use]
+    pub fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
+        super::contains_sensitive_keyword(arg)
+    }
+    #[must_use]
+    pub fn is_sensitive_arg(arg: &CommandArg) -> bool {
+        super::is_sensitive_arg(arg)
+    }
+    #[must_use]
+    pub fn redact_argument(arg: &CommandArg) -> CommandArg {
+        super::redact_argument(arg)
+    }
+    #[must_use]
+    pub fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
+        super::redact_sensitive_args(args)
+    }
+}
+
+/// Check if `arg` contains a sensitive keyword.
+///
+/// # Examples
+/// ```
+/// # use netsuke::runner::doc::{CommandArg, contains_sensitive_keyword};
+/// assert!(contains_sensitive_keyword(&CommandArg::new("token=abc".into())));
+/// assert!(!contains_sensitive_keyword(&CommandArg::new("path=/tmp".into())));
+/// ```
+pub(crate) fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
+    let lower = arg.as_str().to_lowercase();
+    lower.contains("password") || lower.contains("token") || lower.contains("secret")
+}
+
+/// Determine whether the argument should be redacted.
+/// Determine whether the argument should be redacted.
+///
+/// # Examples
+/// ```
+/// # use netsuke::runner::doc::{CommandArg, is_sensitive_arg};
+/// assert!(is_sensitive_arg(&CommandArg::new("password=123".into())));
+/// assert!(!is_sensitive_arg(&CommandArg::new("file=readme".into())));
+/// ```
+pub(crate) fn is_sensitive_arg(arg: &CommandArg) -> bool {
+    contains_sensitive_keyword(arg)
+}
+
+/// Redact sensitive information in a single argument.
+///
+/// Sensitive values are replaced with `***REDACTED***`, preserving keys.
+///
+/// # Examples
+/// ```
+/// # use netsuke::runner::doc::{CommandArg, redact_argument};
+/// let arg = CommandArg::new("token=abc".into());
+/// assert_eq!(redact_argument(&arg).as_str(), "token=***REDACTED***");
+/// let arg = CommandArg::new("path=/tmp".into());
+/// assert_eq!(redact_argument(&arg).as_str(), "path=/tmp");
+/// ```
+pub(crate) fn redact_argument(arg: &CommandArg) -> CommandArg {
+    if is_sensitive_arg(arg) {
+        let redacted = arg.as_str().split_once('=').map_or_else(
+            || "***REDACTED***".to_string(),
+            |(key, _)| format!("{key}=***REDACTED***"),
+        );
+        CommandArg::new(redacted)
+    } else {
+        arg.clone()
+    }
+}
+
+/// Redact sensitive information from all `args`.
+///
+/// # Examples
+/// ```
+/// # use netsuke::runner::doc::{CommandArg, redact_sensitive_args};
+/// let args = vec![
+///     CommandArg::new("ninja".into()),
+///     CommandArg::new("token=abc".into()),
+/// ];
+/// let redacted = redact_sensitive_args(&args);
+/// assert_eq!(redacted[1].as_str(), "token=***REDACTED***");
+/// ```
+pub(crate) fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
+    args.iter().map(redact_argument).collect()
+}
+
+/// Invoke the Ninja executable with the provided CLI settings.
+///
+/// The function forwards the job count and working directory to Ninja,
+/// specifies the temporary build file, and streams its standard output and
+/// error back to the user.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the Ninja process fails to spawn or reports a
+/// non-zero exit status.
+///
+/// # Panics
+///
+/// Panics if the child's output streams cannot be captured.
+pub fn run_ninja(
+    program: &Path,
+    cli: &Cli,
+    build_file: &Path,
+    targets: &BuildTargets<'_>,
+) -> io::Result<()> {
+    let mut cmd = Command::new(program);
+    if let Some(dir) = &cli.directory {
+        let dir = fs::canonicalize(dir)?;
+        cmd.current_dir(dir);
+    }
+    if let Some(jobs) = cli.jobs {
+        cmd.arg("-j").arg(jobs.to_string());
+    }
+    let build_file_path = build_file
+        .canonicalize()
+        .unwrap_or_else(|_| build_file.to_path_buf());
+    cmd.arg("-f").arg(&build_file_path);
+    cmd.args(targets.as_slice());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let program = cmd.get_program().to_string_lossy().into_owned();
+    let args: Vec<CommandArg> = cmd
+        .get_args()
+        .map(|a| CommandArg::new(a.to_string_lossy().into_owned()))
+        .collect();
+    let redacted_args = redact_sensitive_args(&args);
+    let arg_strings: Vec<&str> = redacted_args.iter().map(CommandArg::as_str).collect();
+    info!("Running command: {} {}", program, arg_strings.join(" "));
+
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().expect("child stdout");
+    let stderr = child.stderr.take().expect("child stderr");
+
+    let out_handle = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let mut handle = io::stdout();
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = writeln!(handle, "{line}");
+        }
+    });
+    let err_handle = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        let mut handle = io::stderr();
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = writeln!(handle, "{line}");
+        }
+    });
+
+    let status = child.wait()?;
+    let _ = out_handle.join();
+    let _ = err_handle.join();
+
+    if status.success() {
+        Ok(())
+    } else {
+        #[expect(
+            clippy::io_other_error,
+            reason = "use explicit error kind for compatibility with older Rust"
+        )]
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("ninja exited with {status}"),
+        ))
+    }
+}

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for Netsuke manifest AST deserialisation.
 
-use miette::Result;
+use anyhow::Result;
 use netsuke::{ast::*, manifest};
 use rstest::rstest;
 use semver::Version;

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -291,7 +291,7 @@ fn phony_and_always_flags() {
     true,
     true
 )]
-fn actions_behavior(
+fn actions_behaviour(
     #[case] yaml: &str,
     #[case] expected_phony: bool,
     #[case] expected_always: bool,

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -14,6 +14,7 @@ pub struct CliWorld {
     pub build_graph: Option<netsuke::ir::BuildGraph>,
     /// Generated Ninja file content.
     pub ninja: Option<String>,
+    pub ninja_error: Option<String>,
     /// Status of the last process execution (true for success, false for
     /// failure).
     pub run_status: Option<bool>,

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -14,7 +14,10 @@ pub struct CliWorld {
     pub build_graph: Option<netsuke::ir::BuildGraph>,
     /// Generated Ninja file content.
     pub ninja: Option<String>,
+    /// Error message from Ninja generation.
     pub ninja_error: Option<String>,
+    /// Identifier of the action removed for negative tests.
+    pub removed_action_id: Option<String>,
     /// Status of the last process execution (true for success, false for
     /// failure).
     pub run_status: Option<bool>,

--- a/tests/features/ninja.feature
+++ b/tests/features/ninja.feature
@@ -22,3 +22,9 @@ Feature: Ninja file generation
     And the ninja file is generated
     Then shlex splitting command 3 yields "printf, %s, -in file, >, o'utfile"
 
+  Scenario: Missing action is reported
+    When the manifest file "tests/data/rules.yml" is compiled to IR
+    And an action is removed from the graph
+    And the ninja file is generated
+    Then ninja generation fails with "referenced by build edge was not found"
+

--- a/tests/features/ninja.feature
+++ b/tests/features/ninja.feature
@@ -26,5 +26,5 @@ Feature: Ninja file generation
     When the manifest file "tests/data/rules.yml" is compiled to IR
     And an action is removed from the graph
     And the ninja file is generated
-    Then ninja generation fails with "referenced by build edge was not found"
+    Then ninja generation fails mentioning the removed action id
 

--- a/tests/ninja_gen_tests.rs
+++ b/tests/ninja_gen_tests.rs
@@ -8,7 +8,7 @@
 use insta::{Settings, assert_snapshot};
 use netsuke::ast::Recipe;
 use netsuke::ir::{Action, BuildEdge, BuildGraph};
-use netsuke::ninja_gen::{NinjaGenError, generate};
+use netsuke::ninja_gen::{NinjaGenError, generate, generate_into};
 use rstest::{fixture, rstest};
 use std::{fs, path::PathBuf, process::Command};
 use tempfile::{TempDir, tempdir};
@@ -337,4 +337,43 @@ fn errors_when_action_missing() {
     graph.targets.insert(PathBuf::from("out"), edge);
     let err = generate(&graph).expect_err("missing action");
     assert!(matches!(err, NinjaGenError::MissingAction { id } if id == "missing"));
+}
+
+#[rstest]
+fn generate_format_error() {
+    use std::fmt::{self, Write};
+
+    struct FailWriter;
+    impl Write for FailWriter {
+        fn write_str(&mut self, _: &str) -> fmt::Result {
+            Err(fmt::Error)
+        }
+    }
+
+    let action = Action {
+        recipe: Recipe::Command {
+            command: "true".into(),
+        },
+        description: None,
+        depfile: None,
+        deps_format: None,
+        pool: None,
+        restat: false,
+    };
+    let edge = BuildEdge {
+        action_id: "a".into(),
+        inputs: Vec::new(),
+        explicit_outputs: vec![PathBuf::from("out")],
+        implicit_outputs: Vec::new(),
+        order_only_deps: Vec::new(),
+        phony: false,
+        always: false,
+    };
+    let mut graph = BuildGraph::default();
+    graph.actions.insert("a".into(), action);
+    graph.targets.insert(PathBuf::from("out"), edge);
+
+    let mut writer = FailWriter;
+    let err = generate_into(&graph, &mut writer).expect_err("format error");
+    assert!(matches!(err, NinjaGenError::Format(_)));
 }

--- a/tests/ninja_snapshot_tests.rs
+++ b/tests/ninja_snapshot_tests.rs
@@ -40,7 +40,7 @@ fn touch_manifest_ninja_validation() {
 
     let manifest = manifest::from_str(manifest_yaml).expect("parse manifest");
     let ir = BuildGraph::from_manifest(&manifest).expect("ir generation");
-    let ninja_content = ninja_gen::generate(&ir);
+    let ninja_content = ninja_gen::generate(&ir).expect("generate ninja");
 
     let mut settings = Settings::new();
     settings.set_snapshot_path(concat!(

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -91,7 +91,8 @@ fn ir_generation_fails(world: &mut CliWorld) {
 #[when("an action is removed from the graph")]
 fn remove_action(world: &mut CliWorld) {
     let graph = world.build_graph.as_mut().expect("graph");
-    if let Some(id) = graph.actions.keys().next().cloned() {
+    let first_edge_action = graph.targets.values().next().map(|e| e.action_id.clone());
+    if let Some(id) = first_edge_action {
         graph.actions.remove(&id);
         world.removed_action_id = Some(id);
     }

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -1,8 +1,8 @@
 //! Step definitions for `BuildGraph` scenarios.
 
 use crate::CliWorld;
-use cucumber::{given, then, when};
 use anyhow::Context;
+use cucumber::{given, then, when};
 use netsuke::ir::BuildGraph;
 
 fn assert_graph(world: &CliWorld) {
@@ -51,9 +51,7 @@ fn graph_defaults(world: &mut CliWorld, count: usize) {
 #[when(expr = "the manifest file {string} is compiled to IR")]
 fn compile_manifest(world: &mut CliWorld, path: String) {
     match netsuke::manifest::from_path(&path)
-        .and_then(|m| {
-            BuildGraph::from_manifest(&m).context("building IR from manifest")
-        })
+        .and_then(|m| BuildGraph::from_manifest(&m).context("building IR from manifest"))
         .with_context(|| format!("IR generation failed for {path}"))
     {
         Ok(graph) => {

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -91,8 +91,8 @@ fn ir_generation_fails(world: &mut CliWorld) {
 #[when("an action is removed from the graph")]
 fn remove_action(world: &mut CliWorld) {
     let graph = world.build_graph.as_mut().expect("graph");
-    let first_edge_action = graph.targets.values().next().map(|e| e.action_id.clone());
-    if let Some(id) = first_edge_action {
+    let first_action = graph.targets.values().next().map(|e| e.action_id.clone());
+    if let Some(id) = first_action {
         graph.actions.remove(&id);
         world.removed_action_id = Some(id);
     }

--- a/tests/steps/ir_steps.rs
+++ b/tests/steps/ir_steps.rs
@@ -93,5 +93,6 @@ fn remove_action(world: &mut CliWorld) {
     let graph = world.build_graph.as_mut().expect("graph");
     if let Some(id) = graph.actions.keys().next().cloned() {
         graph.actions.remove(&id);
+        world.removed_action_id = Some(id);
     }
 }

--- a/tests/steps/ninja_steps.rs
+++ b/tests/steps/ninja_steps.rs
@@ -22,11 +22,11 @@ fn generate_ninja(world: &mut CliWorld) {
     }
 }
 
-#[allow(
+#[then(expr = "the ninja file contains {string}")]
+#[expect(
     clippy::needless_pass_by_value,
     reason = "Cucumber requires owned String arguments"
 )]
-#[then(expr = "the ninja file contains {string}")]
 fn ninja_contains(world: &mut CliWorld, text: String) {
     let ninja = world
         .ninja
@@ -35,11 +35,11 @@ fn ninja_contains(world: &mut CliWorld, text: String) {
     assert!(ninja.contains(&text));
 }
 
-#[allow(
+#[then(expr = "shlex splitting command {int} yields {string}")]
+#[expect(
     clippy::needless_pass_by_value,
     reason = "Cucumber requires owned String arguments"
 )]
-#[then(expr = "shlex splitting command {int} yields {string}")]
 fn ninja_command_tokens(world: &mut CliWorld, index: usize, expected: String) {
     let ninja = world
         .ninja
@@ -59,20 +59,16 @@ fn ninja_command_tokens(world: &mut CliWorld, index: usize, expected: String) {
     assert_eq!(words, expected);
 }
 
-#[allow(
-    clippy::needless_pass_by_value,
-    reason = "Cucumber requires owned String arguments"
-)]
 #[then(expr = "shlex splitting the command yields {string}")]
 fn ninja_first_command_tokens(world: &mut CliWorld, expected: String) {
     ninja_command_tokens(world, 2, expected);
 }
 
-#[allow(
+#[then(expr = "ninja generation fails with {string}")]
+#[expect(
     clippy::needless_pass_by_value,
     reason = "Cucumber requires owned String arguments"
 )]
-#[then(expr = "ninja generation fails with {string}")]
 fn ninja_generation_fails(world: &mut CliWorld, text: String) {
     let err = world
         .ninja_error

--- a/tests/steps/ninja_steps.rs
+++ b/tests/steps/ninja_steps.rs
@@ -80,3 +80,16 @@ fn ninja_generation_fails(world: &mut CliWorld, text: String) {
         .expect("ninja error should be available");
     assert!(err.contains(&text));
 }
+
+#[then("ninja generation fails mentioning the removed action id")]
+fn ninja_generation_fails_with_removed_action_id(world: &mut CliWorld) {
+    let err = world
+        .ninja_error
+        .as_ref()
+        .expect("ninja error should be available");
+    let id = world
+        .removed_action_id
+        .as_ref()
+        .expect("removed action id should be available");
+    assert!(err.contains(id));
+}

--- a/tests/steps/ninja_steps.rs
+++ b/tests/steps/ninja_steps.rs
@@ -10,7 +10,16 @@ fn generate_ninja(world: &mut CliWorld) {
         .build_graph
         .as_ref()
         .expect("build graph should be available");
-    world.ninja = Some(ninja_gen::generate(graph));
+    match ninja_gen::generate(graph) {
+        Ok(n) => {
+            world.ninja = Some(n);
+            world.ninja_error = None;
+        }
+        Err(e) => {
+            world.ninja = None;
+            world.ninja_error = Some(e.to_string());
+        }
+    }
 }
 
 #[allow(
@@ -57,4 +66,17 @@ fn ninja_command_tokens(world: &mut CliWorld, index: usize, expected: String) {
 #[then(expr = "shlex splitting the command yields {string}")]
 fn ninja_first_command_tokens(world: &mut CliWorld, expected: String) {
     ninja_command_tokens(world, 2, expected);
+}
+
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "Cucumber requires owned String arguments"
+)]
+#[then(expr = "ninja generation fails with {string}")]
+fn ninja_generation_fails(world: &mut CliWorld, text: String) {
+    let err = world
+        .ninja_error
+        .as_ref()
+        .expect("ninja error should be available");
+    assert!(err.contains(&text));
 }

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -68,7 +68,12 @@ fn normalise_report(report: &str) -> String {
 )]
 fn yaml_diagnostics_are_actionable(#[case] yaml: &str, #[case] needles: &[&str]) {
     let err = manifest::from_str(yaml).expect_err("parse should fail");
-    let msg = normalise_report(&format!("{err:?}"));
+    let msg = normalise_report(
+        &err.chain()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
     for needle in needles {
         assert!(msg.contains(needle), "missing: {needle}\nmessage: {msg}");
     }

--- a/tests/yaml_error_tests.rs
+++ b/tests/yaml_error_tests.rs
@@ -3,7 +3,6 @@
 //! These tests ensure diagnostics include line numbers and optional hints, and
 //! that rendering is stable across terminals.
 
-use miette::GraphicalReportHandler;
 use netsuke::manifest;
 use rstest::rstest;
 use strip_ansi_escapes::strip;
@@ -69,11 +68,7 @@ fn normalise_report(report: &str) -> String {
 )]
 fn yaml_diagnostics_are_actionable(#[case] yaml: &str, #[case] needles: &[&str]) {
     let err = manifest::from_str(yaml).expect_err("parse should fail");
-    let mut msg = String::new();
-    GraphicalReportHandler::new()
-        .render_report(&mut msg, err.as_ref())
-        .expect("render yaml error");
-    let msg = normalise_report(&msg);
+    let msg = normalise_report(&format!("{err:?}"));
     for needle in needles {
         assert!(msg.contains(needle), "missing: {needle}\nmessage: {msg}");
     }


### PR DESCRIPTION
## Summary
- use `anyhow` for contextual error propagation in runner and manifest
- add `NinjaGenError` for actionable Ninja generation failures
- exercise missing-action paths in unit and behavioural tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68c0a537c8648322b451b857125d22df

## Summary by Sourcery

Adopt structured error handling for Ninja generation and manifest parsing by introducing NinjaGenError, propagating errors with anyhow’s context methods, standardizing diagnostics with thiserror and miette, restructuring runner logic into a process module, and updating tests and documentation to cover and reflect these changes

New Features:
- Introduce NinjaGenError enum for actionable ninja generation errors
- Change ninja_gen::generate signature to return Result<String, NinjaGenError> and add generate_into for streaming output

Enhancements:
- Replace custom diag extensions with anyhow’s context for error propagation in runner and manifest modules
- Extract ninja invocation logic into a dedicated runner::process module
- Adopt thiserror and miette patterns for structured diagnostics in manifest parsing

Documentation:
- Update design and user documentation to reflect the structured error handling strategy and Result-based ninja API

Tests:
- Add unit tests for missing-action and format-error scenarios in ninja_gen
- Update Cucumber and rstest scenarios to verify ninja generation failure paths

Chores:
- Remove deprecated diag-based helpers and migrate to anyhow context methods