### PR TITLE
Avoid clobbering manifests in test helper

### DIFF
--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -152,7 +152,8 @@ pub fn ensure_manifest_exists(temp_dir: &Path, cli_file: &Path) -> PathBuf {
             "Failed to write manifest content to {}",
             manifest_path.display()
         ));
-        file.persist(&manifest_path).expect(&format!(
+        // Avoid clobbering an existing manifest if concurrently created.
+        file.persist_noclobber(&manifest_path).expect(&format!(
             "Failed to persist manifest file to {}",
             manifest_path.display()
         ));


### PR DESCRIPTION
## Summary
- avoid overwriting manifests during tests by using `persist_noclobber`

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`

closes #58

------
https://chatgpt.com/codex/tasks/task_e_68c6158d7d648322b540014697a08b5d