### PR TITLE
Propagate manifest write errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +144,12 @@ checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -168,9 +185,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "camino"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
 
 [[package]]
 name = "cap-primitives"
@@ -325,11 +342,12 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.21.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
+checksum = "8e5063d8cf24f4998ad01cac265da468a15ca682a8f4f826d50e661964e8d9b8"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "console",
  "cucumber-codegen",
@@ -342,7 +360,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
@@ -354,13 +372,13 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.21.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
+checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -657,11 +675,11 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.9.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -765,7 +783,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -802,15 +820,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1015,7 +1024,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "camino",
- "cap-std",
  "clap",
  "clap_mangen",
  "cucumber",
@@ -1029,7 +1037,6 @@ dependencies = [
  "mockall",
  "ninja_env",
  "rstest",
- "rustix",
  "semver",
  "serde",
  "serde_json",
@@ -1297,7 +1304,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1397,7 +1404,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1757,6 +1764,8 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 name = "test_support"
 version = "0.1.0"
 dependencies = [
+ "camino",
+ "cap-std",
  "mockable",
  "ninja_env",
  "tempfile",
@@ -2209,7 +2218,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "windows-sys 0.59.0",
 ]
 
@@ -2219,5 +2228,5 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,17 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,12 +133,6 @@ checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
 dependencies = [
  "backtrace",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -342,12 +325,11 @@ dependencies = [
 
 [[package]]
 name = "cucumber"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5063d8cf24f4998ad01cac265da468a15ca682a8f4f826d50e661964e8d9b8"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "console",
  "cucumber-codegen",
@@ -360,7 +342,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
@@ -372,13 +354,13 @@ dependencies = [
 
 [[package]]
 name = "cucumber-codegen"
-version = "0.20.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01091e28d1f566c8b31b67948399d2efd6c0a8f6228a9785519ed7b73f7f0aef"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -675,11 +657,11 @@ dependencies = [
 
 [[package]]
 name = "globwalk"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "ignore",
  "walkdir",
 ]
@@ -783,7 +765,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -820,6 +802,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1024,6 +1015,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "camino",
+ "cap-std",
  "clap",
  "clap_mangen",
  "cucumber",
@@ -1037,6 +1029,7 @@ dependencies = [
  "mockall",
  "ninja_env",
  "rstest",
+ "rustix",
  "semver",
  "serde",
  "serde_json",
@@ -1304,7 +1297,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1404,7 +1397,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2218,7 +2211,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "windows-sys 0.59.0",
 ]
 
@@ -2228,5 +2221,5 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ assert_cmd = "2.0.17"
 mockable = { version = "0.3", features = ["mock"] }
 serial_test = "3"
 mockall = "0.11"
+camino = "1.2.0"
 test_support = { path = "test_support" }
 strip-ansi-escapes = "0.2"
 

--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -859,10 +859,11 @@ Test code should be organized in the same way as application code.
 
   `tests/features/authentication/`, `tests/features/product_catalog/`, etc.
 
-- **Step Definitions:** Mirror the feature file structure in your `tests/steps/
-  ` directory. Create a Rust module for each feature area (e.g., `tests/steps/
-  authentication_steps.rs`, `tests/steps/catalog_steps.rs
-  `).Thispreventshavingasingle,massivestepdefinitionfileandmakesiteasiertofindthecodecorrespondingtoaGherkinstep.
+- **Step Definitions:** Mirror the feature file structure in your
+  `tests/steps/` directory. Create a Rust module for each feature area (e.g.,
+  `tests/steps/authentication_steps.rs`, `tests/steps/catalog_steps.rs`). This
+  prevents having a single, massive step definition file and makes it easier to
+  find the code corresponding to a Gherkin step.
 
 ## Part 7: Common Pitfalls and Troubleshooting
 

--- a/docs/behavioural-testing-in-rust-with-cucumber.md
+++ b/docs/behavioural-testing-in-rust-with-cucumber.md
@@ -861,9 +861,8 @@ Test code should be organized in the same way as application code.
 
 - **Step Definitions:** Mirror the feature file structure in your `tests/steps/
   ` directory. Create a Rust module for each feature area (e.g., `tests/steps/
-  authentication_steps.rs`, `tests/steps/catalog_steps.rs`). This prevents
-  having a single, massive step definition file and makes it easier to find the
-  code corresponding to a Gherkin step.
+  authentication_steps.rs`, `tests/steps/catalog_steps.rs
+  `).Thispreventshavingasingle,massivestepdefinitionfileandmakesiteasiertofindthecodecorrespondingtoaGherkinstep.
 
 ## Part 7: Common Pitfalls and Troubleshooting
 

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -22,7 +22,7 @@ dependencies are provided as arguments. The `mockable` crate offers a
 convenient set of traits (`Env`, `Clock`, etc.) to implement this pattern for
 common system interactions in Rust.
 
----
+______________________________________________________________________
 
 ## ✨ Mocking Environment Variables
 
@@ -121,7 +121,7 @@ fn main() {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 🔩 Handling Other Non-Deterministic Dependencies
 
@@ -187,7 +187,7 @@ mod tests {
 
 In production, an instance of `RealClock::new()` would be used.
 
----
+______________________________________________________________________
 
 ## 📌 Key Takeaways
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -227,9 +227,10 @@ behaviour.
 ## Advanced Doctest Control and Attributes
 
 Beyond basic pass/fail checks, `rustdoc` provides a suite of attributes to
-control doctest behaviour with fine-grained precision. These attributes, placed
-in the header of a code block (e.g.,
-\`\`\`\`ignore\`), allow developers to handle expected failures, non-executable examples, and other complex scenarios.
+control doctest behaviour with fine-grained precision. These attributes are
+placed in the header of a code block (for example, by annotating the code fence
+with 'ignore'), and allow developers to handle expected failures,
+non-executable examples, and other complex scenarios.
 
 ### 3.1 A Comparative Analysis of Doctest Attributes
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -228,8 +228,8 @@ behaviour.
 
 Beyond basic pass/fail checks, `rustdoc` provides a suite of attributes to
 control doctest behaviour with fine-grained precision. These attributes, placed
-in the header of a code block (e.g., \`\`\`\`ignore\`), allow developers to
-handle expected failures, non-executable examples, and other complex scenarios.
+in the header of a code block (e.g.,
+\`\`\`\`ignore\`), allow developers to handle expected failures, non-executable examples, and other complex scenarios.
 
 ### 3.1 A Comparative Analysis of Doctest Attributes
 
@@ -629,8 +629,10 @@ mastering doctests:
 [^4]: Documentation tests - - GitHub Pages, accessed on July 15, 2025,
    <https://ebarnard.github.io/2019-06-03-rust-smaller-trait-implementers-docs/rustdoc/documentation-tests.html>
    <!-- mdformat off -->
-[^5]: Documentation tests — Massachusetts Institute of Technology, accessed on July 15, 2025, <http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/rustdoc/documentation-tests.html>
-<!-- mdformat on -->
+[^5]: Documentation tests — Massachusetts Institute of Technology, accessed on
+      July 15, 2025,
+      <http://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/rustdoc/documentation-tests.html>
+       <!-- mdformat on -->
 [^6]: How to organize your Rust tests - LogRocket Blog, accessed on July 15,
    2025, <https://blog.logrocket.com/how-to-organize-rust-tests/>
    <https://www.reddit.com/r/rust/comments/qk77iu/best_way_to_organise_tests_in_rust/>

--- a/src/ninja_gen.rs
+++ b/src/ninja_gen.rs
@@ -40,8 +40,8 @@ macro_rules! write_flag {
 ///
 /// # Examples
 /// ```
-/// use crate::ast::Recipe;
-/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use netsuke::ast::Recipe;
+/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -55,7 +55,7 @@ macro_rules! write_flag {
 ///     implicit_outputs: Vec::new(), order_only_deps: Vec::new(),
 ///     phony: false, always: false
 /// });
-/// let text = crate::ninja_gen::generate(&graph).expect("generate ninja");
+/// let text = netsuke::ninja_gen::generate(&graph).expect("generate ninja");
 /// assert!(text.contains("rule a"));
 /// ```
 ///
@@ -73,8 +73,8 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///
 /// # Examples
 /// ```
-/// use crate::ast::Recipe;
-/// use crate::ir::{Action, BuildEdge, BuildGraph};
+/// use netsuke::ast::Recipe;
+/// use netsuke::ir::{Action, BuildEdge, BuildGraph};
 /// use std::path::PathBuf;
 /// let mut graph = BuildGraph::default();
 /// graph.actions.insert("a".into(), Action {
@@ -89,7 +89,7 @@ pub fn generate(graph: &BuildGraph) -> Result<String, NinjaGenError> {
 ///     phony: false, always: false
 /// });
 /// let mut out = String::new();
-/// crate::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
+/// netsuke::ninja_gen::generate_into(&graph, &mut out).expect("format ninja");
 /// assert!(out.contains("build out: a"));
 /// ```
 ///

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -20,7 +20,6 @@ pub const NINJA_PROGRAM: &str = "ninja";
 pub use ninja_env::NINJA_ENV;
 
 mod process;
-#[cfg(doctest)]
 #[doc(hidden)]
 pub use process::doc;
 pub use process::run_ninja;

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -24,7 +24,6 @@ impl CommandArg {
 
 // Public helpers for doctests only. This exposes internal helpers as a stable
 // testing surface without exporting them in release builds.
-#[cfg(doctest)]
 #[doc(hidden)]
 pub mod doc {
     pub use super::CommandArg;

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -52,10 +52,12 @@ type FileTest = (&'static str, fn(fs::FileType) -> bool);
 ///
 /// let mut env = Environment::new();
 /// stdlib::register(&mut env);
-/// let tmpl = env
-///     .compile("{% if path is dir %}yes{% endif %}")
+/// env.add_template("t", "{% if path is dir %}yes{% endif %}").unwrap();
+/// let tmpl = env.get_template("t").unwrap();
+/// let cwd = std::env::current_dir().unwrap();
+/// let rendered = tmpl
+///     .render(context!(path => cwd.to_string_lossy()))
 ///     .unwrap();
-/// let rendered = tmpl.render(context!(path => ".")).unwrap();
 /// assert_eq!(rendered, "yes");
 /// ```
 pub fn register(env: &mut Environment<'_>) {

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 tempfile = "3.8.0"
 mockable = { version = "0.3", features = ["mock"] }
 ninja_env = { path = "../ninja_env" }
+camino = "1.2.0"
+cap-std = { version = "3.4.4", features = ["fs_utf8"] }
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -309,4 +309,33 @@ mod tests {
             "message: {msg}"
         );
     }
+
+    #[test]
+    fn creates_missing_parent_directory_and_manifest() {
+        let temp = TempDir::new().expect("temp dir");
+        let temp_path = Utf8Path::from_path(temp.path()).expect("utf-8 path");
+
+        // Parent directory does not exist beforehand.
+        let cli_file = Utf8Path::new("missing/subdir/manifest.yml");
+        let expected_path = temp_path.join(cli_file);
+        assert!(
+            !expected_path.exists(),
+            "precondition: path should not exist"
+        );
+
+        let manifest_path = ensure_manifest_exists(temp_path, cli_file).expect("create manifest");
+        assert_eq!(manifest_path, expected_path);
+        assert!(manifest_path.exists(), "manifest file should exist");
+        assert!(
+            manifest_path.parent().expect("has parent").exists(),
+            "parent directory should be created"
+        );
+
+        // Sanity check that content was written, not an empty file.
+        let contents = std::fs::read_to_string(manifest_path.as_std_path()).expect("read manifest");
+        assert!(
+            contents.contains("netsuke_version:"),
+            "unexpected manifest contents: {contents}"
+        );
+    }
 }

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -234,20 +234,7 @@ fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io:
         ));
     }
 
-    let mut ancestors = dest_dir.ancestors();
-    ancestors.next();
-
-    let base = ancestors
-        .find(|candidate| candidate.exists())
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "Failed to locate an existing ancestor for manifest directory {}",
-                    manifest_path,
-                ),
-            )
-        })?;
+    let base = find_existing_ancestor(dest_dir, manifest_path)?;
 
     let relative = dest_dir.strip_prefix(base).map_err(|_| {
         io::Error::new(
@@ -278,6 +265,26 @@ fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io:
             ),
         )
     })
+}
+
+fn find_existing_ancestor<'a>(
+    dest_dir: &'a Utf8Path,
+    manifest_path: &Utf8Path,
+) -> io::Result<&'a Utf8Path> {
+    let mut ancestors = dest_dir.ancestors();
+    ancestors.next(); // Skip self
+
+    ancestors
+        .find(|candidate| candidate.exists())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "Failed to locate an existing ancestor for manifest directory {}",
+                    manifest_path,
+                ),
+            )
+        })
 }
 
 // Additional helpers can be added here as the test suite evolves.

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -111,14 +111,14 @@ pub fn fake_ninja(exit_code: u8) -> (TempDir, PathBuf) {
 /// Resolve `cli_file` relative to `temp_dir` and ensure it exists.
 ///
 /// When `cli_file` is relative, it is joined with `temp_dir` and the returned
-/// [`PathBuf`] is absolute. If the resulting path does not exist, a minimal
+/// path is absolute and UTF‑8. If the resulting path does not exist, a minimal
 /// manifest is written to that location.
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if any I/O error occurs whilst creating parent
-/// directories, writing the temporary manifest, or persisting it to
-/// `manifest_path`.
+/// Returns an [`io::Error`] if any I/O error occurs whilst validating the
+/// target, creating parent directories, writing the temporary manifest, or
+/// persisting it to `manifest_path`.
 ///
 /// # Examples
 ///
@@ -172,69 +172,6 @@ fn resolve_manifest_path(temp_dir: &Utf8Path, cli_file: &Utf8Path) -> io::Result
     Ok(manifest_path)
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-fn resolve_manifest_path(temp_dir: &Path, cli_file: &Path) -> PathBuf {
-    if cli_file.is_absolute() {
-        cli_file.to_path_buf()
-    } else {
-        temp_dir.join(cli_file)
-    }
-}
-
-fn ensure_directory_exists(manifest_path: &Path, temp_dir: &Path) -> io::Result<PathBuf> {
-    let dest_dir = manifest_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| temp_dir.to_path_buf());
-
-    if dest_dir.exists() { return Ok(dest_dir); }
-
-    fs::create_dir_all(&dest_dir).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!(
-                "Failed to create manifest parent directory for {}: {e}",
-                manifest_path.display()
-            ),
-        )
-    })?;
-
-    Ok(dest_dir)
-}
-
-fn create_manifest_file(dest_dir: &Path, manifest_path: &Path) -> io::Result<NamedTempFile> {
-    let file = NamedTempFile::new_in(dest_dir).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!(
-                "Failed to create temporary manifest file for {}: {e}",
-                manifest_path.display()
-            ),
-        )
-    })?;
-    Ok(file)
-}
-
-fn persist_manifest_file(file: NamedTempFile, manifest_path: &Path) -> io::Result<()> {
-    // Avoid clobbering an existing manifest if concurrently created.
-    // Treat AlreadyExists as success when another process creates it.
-    match file.persist_noclobber(manifest_path) {
-        Ok(_) => Ok(()),
-        Err(err) if err.error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-        Err(err) => Err(io::Error::new(
-            err.error.kind(),
-            format!(
-                "Failed to persist manifest file to {}: {}",
-                manifest_path.display(),
-                err.error
-            ),
-        )),
-    }
-||||||| parent of f009f57 (Use camino paths and cap-std in manifest helper)
-=======
-||||||| parent of 36620a6 (Refactor manifest helper error handling)
-=======
 fn create_manifest_file(temp_dir: &Utf8Path, manifest_path: &Utf8Path) -> io::Result<()> {
     let dest_dir = manifest_path.parent().unwrap_or(temp_dir);
     ensure_parent_directory(manifest_path, dest_dir)?;
@@ -280,7 +217,6 @@ fn persist_manifest_file(file: NamedTempFile, manifest_path: &Utf8Path) -> io::R
     }
 }
 
->>>>>>> 36620a6 (Refactor manifest helper error handling)
 fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io::Result<()> {
     if dest_dir.exists() {
         return Ok(());
@@ -330,7 +266,6 @@ fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io:
             ),
         )
     })
->>>>>>> f009f57 (Use camino paths and cap-std in manifest helper)
 }
 
 // Additional helpers can be added here as the test suite evolves.
@@ -343,23 +278,6 @@ mod tests {
     use std::io;
     use tempfile::TempDir;
 
-fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io::Result<()> {
-    if dest_dir.exists() {
-        return Ok(());
-    }
-
-<<<<<<< HEAD
-    let mut ancestors = dest_dir.ancestors();
-    ancestors.next();
-||||||| parent of 36620a6 (Refactor manifest helper error handling)
-    #[test]
-    fn read_only_parent_reports_target_path() {
-        let temp = TempDir::new().expect("temp dir");
-        let temp_path = Utf8Path::from_path(temp.path()).expect("utf-8 path");
-        let parent = temp.path().join("parent");
-        fs::write(&parent, b"file").expect("parent file");
-        let manifest = parent.join("manifest.yml");
-=======
     #[test]
     fn existing_directory_manifest_path_is_rejected() {
         let temp = TempDir::new().expect("temp dir");
@@ -381,47 +299,14 @@ fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io:
         let parent = temp.path().join("parent");
         fs::write(&parent, b"file").expect("parent file");
         let manifest = parent.join("manifest.yml");
->>>>>>> 36620a6 (Refactor manifest helper error handling)
 
-    let base = ancestors
-        .find(|candidate| candidate.exists())
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "Failed to locate an existing ancestor for manifest directory {}",
-                    manifest_path,
-                ),
-            )
-        })?;
-
-    let relative = dest_dir.strip_prefix(base).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Failed to derive relative path for {} from ancestor {}",
-                dest_dir, base,
-            ),
-        )
-    })?;
-
-    let dir = fs_utf8::Dir::open_ambient_dir(base, ambient_authority()).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!(
-                "Failed to open ancestor directory {} for {}: {e}",
-                base, manifest_path,
-            ),
-        )
-    })?;
-
-    dir.create_dir_all(relative).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!(
-                "Failed to create manifest parent directory for {}: {e}",
-                manifest_path,
-            ),
-        )
-    })
+        let err = ensure_manifest_exists(temp_path, Utf8Path::new("parent/manifest.yml"))
+            .expect_err("non-dir parent");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        let msg = err.to_string();
+        assert!(
+            msg.contains(manifest.to_str().expect("utf-8")),
+            "message: {msg}"
+        );
+    }
 }

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -219,7 +219,19 @@ fn persist_manifest_file(file: NamedTempFile, manifest_path: &Utf8Path) -> io::R
 
 fn ensure_parent_directory(manifest_path: &Utf8Path, dest_dir: &Utf8Path) -> io::Result<()> {
     if dest_dir.exists() {
-        return Ok(());
+        // If the path exists but is not a directory, report a clear error that
+        // includes the final manifest path. Returning AlreadyExists mirrors the
+        // semantics that the desired directory “exists” but is unusable.
+        if dest_dir.is_dir() {
+            return Ok(());
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "Failed to create manifest parent directory for {}: parent path exists and is not a directory",
+                manifest_path,
+            ),
+        ));
     }
 
     let mut ancestors = dest_dir.ancestors();

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -133,6 +133,7 @@ pub fn fake_ninja(exit_code: u8) -> (TempDir, PathBuf) {
 pub fn ensure_manifest_exists(temp_dir: &Path, cli_file: &Path) -> io::Result<PathBuf> {
     let manifest_path = resolve_manifest_path(temp_dir, cli_file);
 
+<<<<<<< HEAD
     if manifest_path.exists() { return Ok(manifest_path); }
 
     let dest_dir = ensure_directory_exists(&manifest_path, temp_dir)?;
@@ -147,6 +148,102 @@ pub fn ensure_manifest_exists(temp_dir: &Path, cli_file: &Path) -> io::Result<Pa
         )
     })?;
     persist_manifest_file(file, &manifest_path)?;
+||||||| parent of f1ed148 (Validate manifest path and persist diagnostics)
+    if !manifest_path.exists() {
+        let dest_dir = manifest_path.parent().unwrap_or(temp_dir);
+        if !dest_dir.exists() {
+            fs::create_dir_all(dest_dir).map_err(|e| {
+                io::Error::new(
+                    e.kind(),
+                    format!(
+                        "Failed to create manifest parent directory for {}: {e}",
+                        manifest_path.display()
+                    ),
+                )
+            })?;
+        }
+        let mut file = NamedTempFile::new_in(dest_dir).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to create temporary manifest file for {}: {e}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+        crate::env::write_manifest(&mut file).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to write manifest content to {}: {e}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+        file.persist(&manifest_path).map_err(|e| {
+            io::Error::new(
+                e.error.kind(),
+                format!(
+                    "Failed to persist manifest file to {}: {}",
+                    manifest_path.display(),
+                    e.error
+                ),
+            )
+        })?;
+    }
+=======
+    if !manifest_path.exists() {
+        if manifest_path.file_name().is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Manifest path must include a file name: {}",
+                    manifest_path.display()
+                ),
+            ));
+        }
+
+        let dest_dir = manifest_path.parent().unwrap_or(temp_dir);
+        fs::create_dir_all(dest_dir).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to create manifest parent directory for {}: {e}",
+                    manifest_path.display(),
+                ),
+            )
+        })?;
+        let mut file = NamedTempFile::new_in(dest_dir).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to create temporary manifest file for {}: {e}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+        crate::env::write_manifest(&mut file).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to write manifest content to {}: {e}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+        file.persist(&manifest_path).map_err(|e| {
+            io::Error::new(
+                e.error.kind(),
+                format!(
+                    "Failed to persist manifest file to {} from {}: {}",
+                    manifest_path.display(),
+                    e.file.path().display(),
+                    e.error
+                ),
+            )
+        })?;
+    }
+>>>>>>> f1ed148 (Validate manifest path and persist diagnostics)
 
     Ok(manifest_path)
 }

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -82,7 +82,7 @@ fn run(world: &mut CliWorld) {
     let dir = world.temp.as_ref().expect("temp dir");
     {
         let cli = world.cli.as_mut().expect("cli");
-        cli.file = ensure_manifest_exists(dir.path(), &cli.file);
+        cli.file = ensure_manifest_exists(dir.path(), &cli.file).expect("manifest");
     }
     let program = if let Some(ninja) = &world.ninja {
         Path::new(ninja)

--- a/tests/steps/process_steps.rs
+++ b/tests/steps/process_steps.rs
@@ -1,6 +1,7 @@
 //! Step definitions for Ninja process execution.
 
 use crate::CliWorld;
+use camino::Utf8Path;
 use cucumber::{given, then, when};
 use netsuke::runner::{self, BuildTargets, NINJA_PROGRAM};
 use std::fs;
@@ -82,7 +83,13 @@ fn run(world: &mut CliWorld) {
     let dir = world.temp.as_ref().expect("temp dir");
     {
         let cli = world.cli.as_mut().expect("cli");
-        cli.file = ensure_manifest_exists(dir.path(), &cli.file).expect("manifest");
+        let temp_path = Utf8Path::from_path(dir.path()).expect("utf-8 temp dir");
+        let manifest = ensure_manifest_exists(
+            temp_path,
+            Utf8Path::from_path(&cli.file).expect("utf-8 manifest path"),
+        )
+        .expect("manifest");
+        cli.file = manifest.into_std_path_buf();
     }
     let program = if let Some(ninja) = &world.ninja {
         Path::new(ninja)


### PR DESCRIPTION
## Summary
- return `io::Result` from `ensure_manifest_exists`
- map file system errors to add manifest path context
- adjust process step to handle manifest helper failure

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #62

------
https://chatgpt.com/codex/tasks/task_e_68c615a741a08322937728e45293fdd6

## Summary by Sourcery

Implement error propagation in manifest creation by converting ensure_manifest_exists to return io::Result, refactor supporting helpers to use UTF-8 paths with enriched context errors, update tests and process step usage accordingly, adjust documentation formatting, and add necessary dependencies.

New Features:
- Return io::Result from ensure_manifest_exists and propagate manifest write errors
- Switch manifest handling functions to UTF-8 path types (Utf8Path/Utf8PathBuf)

Enhancements:
- Map filesystem errors to include manifest path context and invalid input checks
- Refactor manifest creation workflow into discrete helpers with detailed error mapping
- Use cap-std fs_utf8 ambient-authority logic for parent directory creation

Build:
- Add camino and cap-std dependencies to support UTF-8 path and fs_utf8 operations

Documentation:
- Correct formatting in markdown docs for doctest, behavioural testing, and reliability guides

Tests:
- Add unit tests for rejecting directory targets and read-only parent errors
- Update process_steps test to handle UTF-8 paths and result propagation