### PR TITLE
Refactor cycle detection traversal

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -758,6 +758,41 @@ whitespace-only `when` values, or type mismatches in the iterable.
 
 **Cross-references:** `docs/netsuke-design.md` §2.5 and roadmap task 3.14.2.
 
+## IR cycle detection
+
+
+### Module: `ir::cycle`
+
+`src/ir/cycle.rs` provides cycle detection for the IR target graph.
+
+**Entry point:**
+`analyse(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetectionReport`
+
+Accepts the target map produced by IR lowering and returns a
+`CycleDetectionReport` containing:
+
+- `cycle: Option<Vec<Utf8PathBuf>>` — the first dependency cycle found, in
+  canonical order (smallest node first, first node repeated last), or `None`
+  for acyclic graphs.
+- `missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>` — every
+  `(dependent, missing_dep)` pair encountered during traversal.
+
+**`CycleDetector`**
+
+Traversal state is managed by the private `CycleDetector` struct, which owns
+the DFS recursion stack and per-node `VisitState` map. The API surface for
+callers within the `ir` module is:
+
+- `CycleDetector::new(targets)` — borrows the target map for the lifetime of
+  the traversal.
+- `CycleDetector::detect()` — iterates over all nodes in sorted order and
+  returns the first detected cycle, or `None`.
+
+Detected cycles are normalised by `canonicalize_cycle` so that error messages
+are deterministic regardless of hash-map iteration order.
+
+**Cross-references:** `docs/netsuke-design.md` §5.3.
+
 ## Documentation upkeep
 
 When test strategy or behavioural test usage changes, update this file in the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -773,8 +773,8 @@ Accepts the target map produced by IR lowering and returns a
 - `cycle: Option<Vec<Utf8PathBuf>>` — the first dependency cycle found, in
   canonical order (smallest node first, first node repeated last), or `None`
   for acyclic graphs.
-- `missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>` — every
-  `(dependent, missing_dep)` pair encountered during traversal.
+- `missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>` —
+  `(dependent, missing_dep)` pairs encountered before the first detected cycle.
 
 **`CycleDetector`**
 
@@ -787,7 +787,7 @@ callers within the `ir` module is:
 - `CycleDetector::detect()` — iterates over all nodes in sorted order and
   returns the first detected cycle, or `None`.
 
-Detected cycles are normalised by `canonicalize_cycle` so that error messages
+Detected cycles are normalized by `canonicalize_cycle` so that error messages
 are deterministic regardless of hash-map iteration order.
 
 **Cross-references:** `docs/netsuke-design.md` §5.3.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -760,7 +760,6 @@ whitespace-only `when` values, or type mismatches in the iterable.
 
 ## IR cycle detection
 
-
 ### Module: `ir::cycle`
 
 `src/ir/cycle.rs` provides cycle detection for the IR target graph.

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -400,6 +400,7 @@ The cleaner model is:
 - `always`: When set to `true`, the target runs on every invocation regardless
   of timestamps or dependencies. The default value is `false`.
 
+
 ### 2.5 Generated Targets and Actions with `foreach`
 
 Large sets of similar outputs or setup actions can clutter a manifest when
@@ -1882,10 +1883,11 @@ This transformation involves several steps:
    deterministic error messages.
 
    Traversal state is implemented in the dedicated `ir::cycle` module. Its
-   `CycleDetector` helper owns the recursion stack and visitation map. Keys are
-   cloned from the `targets` map so traversal leaves the input graph untouched.
-   Missing dependencies encountered during traversal are logged, collected, and
-   returned alongside any cycle to aid diagnostics.
+   `CycleDetector` helper exposes a `detect` API and owns the recursion stack
+   and visitation map. Keys are cloned from the `targets` map so traversal
+   leaves the input graph untouched. Missing dependencies encountered during
+   traversal are logged, collected, and returned alongside any cycle to aid
+   diagnostics.
 
 ### 5.4 Ninja File Synthesis (`ninja_gen.rs`)
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -887,7 +887,7 @@ presenting a stable public API surface. The `serde_json` library is built with
 the `preserve_order` feature so the backing `ManifestMap` retains the insertion
 order observed in the YAML manifest. This guarantees that downstream consumers
 see keys in a stable sequence after foreach expansion, matching the authoring
-intent and keeping diagnostics and serialised output predictable. Targets also
+intent and keeping diagnostics and serialized output predictable. Targets also
 accept optional `phony` and `always` booleans. They default to `false`, making
 it explicit when an action should run regardless of file timestamps. Targets
 listed in the `actions` section are deserialized using a custom helper so they
@@ -2152,7 +2152,7 @@ pub enum IrGenError {
         missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>,
     },
 
-    #[error("failed to serialise action: {0}")]
+    #[error("failed to serialize action: {0}")]
     ActionSerialisation(#[from] serde_json::Error), }
 ```
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1218,9 +1218,9 @@ logic in Rust.
 The filter accepts four keyword arguments:
 
 - `all` *(bool, default `false`)* — emit every match, similar to `which -a`.
-- `canonical` *(bool, default `false`)* — resolve symlinks with
-  `std::fs::canonicalize` after discovery, deduplicating on canonical paths
-  while preserving discovery order.
+- `canonical` *(bool, default `false`)* — resolve symlinks through a
+  capability-bearing `cap_std::fs::Dir` handle after discovery, deduplicating
+  on canonical paths while preserving discovery order.
 - `fresh` *(bool, default `false`)* — bypass the per-process cache for this
   lookup without flushing previous entries.
 - `cwd_mode` *("auto" | "never" | "always", default `"auto"`)* — control how

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -400,7 +400,6 @@ The cleaner model is:
 - `always`: When set to `true`, the target runs on every invocation regardless
   of timestamps or dependencies. The default value is `false`.
 
-
 ### 2.5 Generated Targets and Actions with `foreach`
 
 Large sets of similar outputs or setup actions can clutter a manifest when
@@ -625,7 +624,7 @@ data structures are crucial for the robustness and maintainability of Netsuke.
 
 ### 3.1 Crate Selection: `serde_saphyr`
 
-Netsuke now relies on `serde_saphyr` for YAML parsing and serialisation. The
+Netsuke now relies on `serde_saphyr` for YAML parsing and serialization. The
 crate wraps the actively maintained `saphyr` parser while preserving the
 familiar `serde_yaml`-style API: helpers such as `from_str`, `from_reader`, and
 `to_string` integrate cleanly with `serde` derives, and the error type exposes
@@ -1234,11 +1233,11 @@ Semantics honour platform conventions while enforcing predictable behaviour:
   bit. Empty `PATH` segments (leading, trailing, or `::`) map to the working
   directory when `cwd_mode` is `"auto"` or `"always"`.
 - On Windows, the lookup respects `PATHEXT` when the command lacks an
-  extension. Comparisons are case-insensitive, results normalise both slash
+  extension. Comparisons are case-insensitive, results normalize both slash
   styles, and `cwd_mode` defaults to skipping the working directory to avoid
   the platform’s surprise "search CWD first" rule. Opting in via `"always"`
   restores that behaviour.
-- Canonicalisation happens after discovery and only when requested so that
+- Canonicalization happens after discovery and only when requested so that
   manifests can balance reproducibility against host-specific absolute paths.
 
 The resolver keeps a small LRU cache keyed by the command, a fingerprint of
@@ -1707,7 +1706,7 @@ use camino::Utf8PathBuf;
 /// The complete, static build graph.
 pub struct BuildGraph {
     /// A map of all unique actions (rules) in the build.
-    /// The key is a hash of a canonical JSON serialisation of the action's
+    /// The key is a hash of a canonical JSON serialization of the action's
     /// properties to enable deduplication.
     pub actions: HashMap<String, Action>,
 
@@ -1969,7 +1968,7 @@ manifest. No Ninja specific placeholders are stored in the IR to keep the
 representation portable.
 
 - Actions are deduplicated using a SHA-256 hash of a canonical JSON
-  serialisation of their recipe, inputs, and outputs. Because commands embed
+  serialization of their recipe, inputs, and outputs. Because commands embed
   shell-quoted file paths, two targets share an identifier only when both the
   command text and file sets match exactly.
 - Multiple rule references in a single target are not yet supported. The IR
@@ -2239,7 +2238,7 @@ enrichment:
    `.with_context(|| "Failed to build the internal build graph from the manifest")?`
     .
 
-4. This process of propagation and contextualisation repeats as the error
+4. This process of propagation and contextualization repeats as the error
    bubbles up towards `main`. Use `anyhow::Context` to add detail, but never
    convert a `miette::Diagnostic` into a plain `anyhow::Error`--doing so would
    discard spans and help text.
@@ -2339,7 +2338,7 @@ given). /// This is the default subcommand. Build(BuildArgs),
 
     /// Remove build artefacts and intermediate files. Clean,
 
-    /// Display the build dependency graph in DOT format for visualisation.
+    /// Display the build dependency graph in DOT format for visualization.
     Graph,
 
     /// Write the Ninja manifest to `FILE` without invoking Ninja.

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -259,6 +259,20 @@ mod tests {
         assert_eq!(cycle, vec![path("a"), path("b"), path("a")]);
     }
 
+    #[test]
+    fn cycle_detector_stack_is_empty_after_cycle_detected() {
+        let mut targets = HashMap::new();
+        targets.insert(path("a"), build_edge(&["b"], "a"));
+        targets.insert(path("b"), build_edge(&["a"], "b"));
+
+        let mut detector = CycleDetector::new(&targets);
+        assert!(detector.detect().is_some(), "expected a cycle");
+        assert!(
+            detector.stack.is_empty(),
+            "stack must be empty after cycle detection",
+        );
+    }
+
     fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
         let cycle: Vec<Utf8PathBuf> = input.iter().map(|&s| path(s)).collect();
         let canonical = canonicalize_cycle(cycle);

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -177,11 +177,7 @@ impl CycleDetector<'_> {
     ///
     /// Returns early with `None` when the dependency is absent from the target
     /// map.
-    fn visit_dependency(
-        &mut self,
-        node: &Utf8Path,
-        dep: &Utf8Path,
-    ) -> Option<Vec<Utf8PathBuf>> {
+    fn visit_dependency(&mut self, node: &Utf8Path, dep: &Utf8Path) -> Option<Vec<Utf8PathBuf>> {
         if self.record_missing_dependency(node, dep) {
             return None;
         }
@@ -217,9 +213,6 @@ fn canonicalize_cycle(mut cycle: Vec<Utf8PathBuf>) -> Vec<Utf8PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use rstest::rstest;
-
     fn path(name: &str) -> Utf8PathBuf {
         Utf8PathBuf::from(name)
     }
@@ -322,19 +315,6 @@ mod tests {
         );
     }
 
-    #[rstest]
-    #[case::explicit_dependency(MissingDepsCase {
-        primary_inputs: &["b"],
-        primary_implicit_deps: &[],
-        extra_targets: &[],
-        expected: &[("a", "b")],
-    })]
-    #[case::implicit_dependency(MissingDepsCase {
-        primary_inputs: &["b"],
-        primary_implicit_deps: &["missing"],
-        extra_targets: &[("b", &[], &[])],
-        expected: &[("a", "missing")],
-    })]
     fn cycle_detector_records_missing_dependencies(#[case] case: MissingDepsCase<'_>) {
         assert_missing_deps(&case);
     }
@@ -419,19 +399,20 @@ mod tests {
 
         /// Generate a non-empty list of distinct single-character node names.
         fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
-            proptest::collection::vec("[a-z]", min..=max).prop_filter(
-                "nodes must be unique",
-                |v| {
-                    let set: std::collections::HashSet<_> = v.iter().collect();
-                    set.len() == v.len()
-                },
-            )
+            proptest::collection::vec("[a-z]", min..=max).prop_filter("nodes must be unique", |v| {
+                let set: std::collections::HashSet<_> = v.iter().collect();
+                set.len() == v.len()
+            })
         }
 
         /// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
         fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
             let mut cycle: Vec<_> = nodes.iter().map(|s| path(s)).collect();
-            cycle.push(path(&nodes[0]));
+            cycle.push(path(
+                nodes
+                    .first()
+                    .expect("node_names generates at least two nodes"),
+            ));
             cycle
         }
 
@@ -463,8 +444,12 @@ mod tests {
             #[test]
             fn canonical_first_node_is_smallest(nodes in node_names(2, 10)) {
                 let canonical = canonicalize_cycle(make_cycle(&nodes));
-                let interior = &canonical[..canonical.len() - 1];
-                let first = &canonical[0];
+                let interior = canonical
+                    .get(..canonical.len().saturating_sub(1))
+                    .expect("canonicalize_cycle produces at least two nodes");
+                let first = canonical
+                    .first()
+                    .expect("canonicalize_cycle produces at least one node");
                 for node in interior {
                     prop_assert!(first <= node);
                 }
@@ -491,12 +476,11 @@ mod tests {
         let first = CycleDetector::find_cycle(&targets).expect("cycle");
         for _ in 1..100 {
             let cycle = CycleDetector::find_cycle(&targets).expect("cycle");
-            if cycle != first {
-                panic!(
-                    "find_cycle returned inconsistent results across runs: \
-                     first={first:?}, got={cycle:?}",
-                );
-            }
+            assert!(
+                cycle == first,
+                "find_cycle returned inconsistent results across runs: \
+                 first={first:?}, got={cycle:?}",
+            );
         }
         // Probabilistic guard: 100 runs; `detect` sorts keys for stable traversal.
         tracing::info!("find_cycle returned the same cycle across 100 runs");

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 
 use super::BuildEdge;
 
@@ -71,14 +71,105 @@ struct CycleDetector<'targets> {
 }
 
 impl CycleDetector<'_> {
+    /// Create a new detector borrowing `targets` for the duration of the
+    /// traversal.
+    fn new(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetector<'_> {
+        CycleDetector {
+            targets,
+            stack: Vec::new(),
+            states: HashMap::new(),
+            missing_dependencies: Vec::new(),
+        }
+    }
+
+    /// Walk every node in the target map and return the first cycle found,
+    /// or `None` if the graph is acyclic.
+    fn detect(&mut self) -> Option<Vec<Utf8PathBuf>> {
+        let mut nodes: Vec<Utf8PathBuf> = self.targets.keys().cloned().collect();
+        nodes.sort();
+        for node in nodes {
+            if self.is_visited(node.as_path()) {
+                continue;
+            }
+            if let Some(cycle) = self.visit(node.as_path()) {
+                return Some(cycle);
+            }
+        }
+        None
+    }
+
+    /// Return `true` if `node` has been fully visited.
+    fn is_visited(&self, node: &Utf8Path) -> bool {
+        matches!(self.states.get(node), Some(VisitState::Visited))
+    }
+
+    /// Visit `node` depth-first.
+    ///
+    /// Returns `Some(cycle)` if a back-edge to an in-progress node is
+    /// discovered, `None` otherwise.
+    fn visit(&mut self, node: &Utf8Path) -> Option<Vec<Utf8PathBuf>> {
+        match self.states.get(node) {
+            Some(VisitState::Visited) => return None,
+            Some(VisitState::Visiting) => {
+                let idx = self
+                    .stack
+                    .iter()
+                    .position(|n| n.as_path() == node)
+                    .unwrap_or_else(|| {
+                        debug_assert!(false, "visiting node must be on the stack");
+                        0
+                    });
+                let mut cycle: Vec<Utf8PathBuf> = self.stack.iter().skip(idx).cloned().collect();
+                cycle.push(node.to_path_buf());
+                return Some(canonicalize_cycle(cycle));
+            }
+            None => {
+                self.states.insert(node.to_path_buf(), VisitState::Visiting);
+            }
+        }
+
+        self.stack.push(node.to_path_buf());
+
+        let cycle = self
+            .targets
+            .get(node)
+            .into_iter()
+            .flat_map(|edge| edge.inputs.iter().chain(&edge.implicit_deps))
+            .find_map(|dep| self.visit_dependency(node, dep));
+
+        self.stack.pop();
+
+        if cycle.is_none() {
+            self.states.insert(node.to_path_buf(), VisitState::Visited);
+        }
+
+        cycle
+    }
+
+    #[cfg(test)]
+    fn missing_dependencies(&self) -> &[(Utf8PathBuf, Utf8PathBuf)] {
+        &self.missing_dependencies
+    }
+
+    #[cfg(test)]
+    fn find_cycle(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> Option<Vec<Utf8PathBuf>> {
+        analyse(targets).cycle
+    }
+
     /// Record `dep` as missing and return `true` if `dep` is absent from the
     /// target map; return `false` if it is present.
-    fn record_missing_dependency(&mut self, node: &Utf8PathBuf, dep: &Utf8PathBuf) -> bool {
+    fn record_missing_dependency(&mut self, node: &Utf8Path, dep: &Utf8Path) -> bool {
         if self.targets.contains_key(dep) {
             return false;
         }
 
-        self.missing_dependencies.push((node.clone(), dep.clone()));
+        tracing::debug!(
+            missing = %dep,
+            dependent = %node,
+            "skipping dependency missing from targets during cycle detection",
+        );
+        self.missing_dependencies
+            .push((node.to_path_buf(), dep.to_path_buf()));
         true
     }
 
@@ -88,43 +179,14 @@ impl CycleDetector<'_> {
     /// map.
     fn visit_dependency(
         &mut self,
-        node: &Utf8PathBuf,
-        dep: &Utf8PathBuf,
+        node: &Utf8Path,
+        dep: &Utf8Path,
     ) -> Option<Vec<Utf8PathBuf>> {
         if self.record_missing_dependency(node, dep) {
             return None;
         }
 
-        self.visit(dep.clone())
-    }
-}
-
-impl CycleDetector<'_> {
-    /// Record `dep` as missing and return `true` if `dep` is absent from the
-    /// target map; return `false` if it is present.
-    fn record_missing_dependency(&mut self, node: &Utf8PathBuf, dep: &Utf8PathBuf) -> bool {
-        if self.targets.contains_key(dep) {
-            return false;
-        }
-
-        self.missing_dependencies.push((node.clone(), dep.clone()));
-        true
-    }
-
-    /// Optionally record `dep` as missing, then visit it.
-    ///
-    /// Returns early with `None` when the dependency is absent from the target
-    /// map.
-    fn visit_dependency(
-        &mut self,
-        node: &Utf8PathBuf,
-        dep: &Utf8PathBuf,
-    ) -> Option<Vec<Utf8PathBuf>> {
-        if self.record_missing_dependency(node, dep) {
-            return None;
-        }
-
-        self.visit(dep.clone())
+        self.visit(dep)
     }
 }
 
@@ -197,7 +259,7 @@ mod tests {
             .map(|(dependent, missing)| (path(dependent), path(missing)))
             .collect();
         let mut detector = CycleDetector::new(&targets);
-        assert!(detector.visit(path("a")).is_none());
+        assert!(detector.visit(path("a").as_path()).is_none());
         assert_eq!(detector.missing_dependencies(), expected.as_slice());
     }
 
@@ -252,8 +314,8 @@ mod tests {
 
         let mut detector = CycleDetector::new(&targets);
         assert!(detector.detect().is_none());
-        assert!(detector.is_visited(&a));
-        assert!(detector.is_visited(&b));
+        assert!(detector.is_visited(a.as_path()));
+        assert!(detector.is_visited(b.as_path()));
         assert!(
             detector.stack.is_empty(),
             "stack should be empty after complete traversal",
@@ -300,8 +362,8 @@ mod tests {
     #[test]
     fn cycle_detector_stack_is_empty_after_cycle_detected() {
         let mut targets = HashMap::new();
-        targets.insert(path("a"), build_edge(&["b"], "a"));
-        targets.insert(path("b"), build_edge(&["a"], "b"));
+        targets.insert(path("a"), build_edge(&["b"], &[], "a"));
+        targets.insert(path("b"), build_edge(&["a"], &[], "b"));
 
         let mut detector = CycleDetector::new(&targets);
         assert!(detector.detect().is_some(), "expected a cycle");
@@ -416,5 +478,38 @@ mod tests {
                 prop_assert_eq!(canonical.first(), canonical.last());
             }
         }
+    }
+
+    #[test]
+    fn find_cycle_is_deterministic() {
+        let mut targets = HashMap::new();
+        targets.insert(path("p"), build_edge(&["q"], &[], "p"));
+        targets.insert(path("q"), build_edge(&["p"], &[], "q"));
+        targets.insert(path("x"), build_edge(&["y"], &[], "x"));
+        targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+
+        let first = CycleDetector::find_cycle(&targets).expect("cycle");
+        for _ in 1..100 {
+            let cycle = CycleDetector::find_cycle(&targets).expect("cycle");
+            if cycle != first {
+                panic!(
+                    "find_cycle returned inconsistent results across runs: \
+                     first={first:?}, got={cycle:?}",
+                );
+            }
+        }
+        // Probabilistic guard: 100 runs; `detect` sorts keys for stable traversal.
+        tracing::info!("find_cycle returned the same cycle across 100 runs");
+    }
+
+    #[test]
+    fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
+        let mut targets = HashMap::new();
+        targets.insert(path("p"), build_edge(&["q"], &[], "p"));
+        targets.insert(path("q"), build_edge(&["p"], &[], "q"));
+        targets.insert(path("x"), build_edge(&["y"], &[], "x"));
+        targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+
+        assert!(CycleDetector::find_cycle(&targets).is_some());
     }
 }

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -213,6 +213,9 @@ fn canonicalize_cycle(mut cycle: Vec<Utf8PathBuf>) -> Vec<Utf8PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use rstest::rstest;
+
     fn path(name: &str) -> Utf8PathBuf {
         Utf8PathBuf::from(name)
     }
@@ -315,6 +318,19 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::explicit_dependency(MissingDepsCase {
+        primary_inputs: &["b"],
+        primary_implicit_deps: &[],
+        extra_targets: &[],
+        expected: &[("a", "b")],
+    })]
+    #[case::implicit_dependency(MissingDepsCase {
+        primary_inputs: &["b"],
+        primary_implicit_deps: &["missing"],
+        extra_targets: &[("b", &[], &[])],
+        expected: &[("a", "missing")],
+    })]
     fn cycle_detector_records_missing_dependencies(#[case] case: MissingDepsCase<'_>) {
         assert_missing_deps(&case);
     }
@@ -353,13 +369,6 @@ mod tests {
         );
     }
 
-    fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
-        let cycle: Vec<Utf8PathBuf> = input.iter().map(|&s| path(s)).collect();
-        let canonical = canonicalize_cycle(cycle);
-        let want: Vec<Utf8PathBuf> = expected.iter().map(|&s| path(s)).collect();
-        assert_eq!(canonical, want);
-    }
-
     #[test]
     fn find_cycle_identifies_mixed_input_and_implicit_dependency_cycle() {
         let mut targets = HashMap::new();
@@ -381,49 +390,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn canonicalize_cycle_rotates_smallest_node() {
-        check_canonicalize_cycle(&["c", "a", "b", "c"], &["a", "b", "c", "a"]);
-    }
-
-    #[test]
-    fn canonicalize_cycle_handles_reverse_direction() {
-        check_canonicalize_cycle(&["c", "b", "a", "c"], &["a", "c", "b", "a"]);
-    }
-
     mod property_tests {
         include!("cycle_property_tests.rs");
-    }
-
-    #[test]
-    fn find_cycle_is_deterministic() {
-        let mut targets = HashMap::new();
-        targets.insert(path("p"), build_edge(&["q"], &[], "p"));
-        targets.insert(path("q"), build_edge(&["p"], &[], "q"));
-        targets.insert(path("x"), build_edge(&["y"], &[], "x"));
-        targets.insert(path("y"), build_edge(&["x"], &[], "y"));
-
-        let first = CycleDetector::find_cycle(&targets).expect("cycle");
-        for _ in 1..100 {
-            let cycle = CycleDetector::find_cycle(&targets).expect("cycle");
-            assert!(
-                cycle == first,
-                "find_cycle returned inconsistent results across runs: \
-                 first={first:?}, got={cycle:?}",
-            );
-        }
-        // Probabilistic guard: 100 runs; `detect` sorts keys for stable traversal.
-        tracing::info!("find_cycle returned the same cycle across 100 runs");
-    }
-
-    #[test]
-    fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
-        let mut targets = HashMap::new();
-        targets.insert(path("p"), build_edge(&["q"], &[], "p"));
-        targets.insert(path("q"), build_edge(&["p"], &[], "q"));
-        targets.insert(path("x"), build_edge(&["y"], &[], "x"));
-        targets.insert(path("y"), build_edge(&["x"], &[], "y"));
-
-        assert!(CycleDetector::find_cycle(&targets).is_some());
     }
 }

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -3,7 +3,7 @@
 //! The public entry point is [`analyse`], which accepts the target map
 //! (`HashMap<Utf8PathBuf, BuildEdge>`) produced by IR lowering and
 //! returns a [`CycleDetectionReport`].  The report carries an optional
-//! detected cycle — an ordered, canonicalised list of paths — together
+//! detected cycle — an ordered, canonicalized list of paths — together
 //! with any dependencies referenced by a target but absent from the map.
 //! `order_only_deps` are intentionally excluded from traversal.
 //!
@@ -12,7 +12,7 @@
 //! Callers drive detection through [`CycleDetector::detect`], which
 //! iterates over every node in the target map and delegates depth-first
 //! visiting to `visit` and `visit_dependency`.  Detected cycles are
-//! normalised by [`canonicalize_cycle`] to produce deterministic error
+//! normalized by [`canonicalize_cycle`] to produce deterministic error
 //! messages regardless of traversal order.
 //! Consumed by [`super::from_manifest`] after the full target map is
 //! constructed.
@@ -22,6 +22,10 @@ use std::collections::HashMap;
 use camino::{Utf8Path, Utf8PathBuf};
 
 use super::BuildEdge;
+
+#[cfg(test)]
+#[path = "cycle_property_tests.rs"]
+mod cycle_property_tests;
 
 /// Tracks the visitation state of a node during cycle detection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -34,8 +38,8 @@ enum VisitState {
 ///
 /// `cycle` is `Some` when a dependency cycle was found; the vec holds the
 /// cycle's nodes in canonical order, with the first node repeated as the
-/// last element.  `missing_dependencies` lists every `(dependent, dep)`
-/// pair where `dep` is referenced but absent from the target map.
+/// last element.  `missing_dependencies` lists unresolved dependencies
+/// encountered before the first detected cycle.
 pub(crate) struct CycleDetectionReport {
     pub(crate) cycle: Option<Vec<Utf8PathBuf>>,
     pub(crate) missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>,
@@ -46,10 +50,8 @@ pub(crate) struct CycleDetectionReport {
 /// Performs a depth-first traversal of each [`BuildEdge`]'s `inputs` and
 /// `implicit_deps`.  `order_only_deps` are intentionally excluded.
 ///
-/// Returns a [`CycleDetectionReport`] containing any detected cycle path and
-/// all dependency references that could not be resolved to a build target.
-/// This function does **not** emit any log events; the caller is responsible
-/// for logging the reported data.
+/// Returns any detected cycle path and missing dependencies encountered
+/// before that cycle.  Missing dependencies emit debug-level tracing events.
 pub(crate) fn analyse(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetectionReport {
     let mut detector = CycleDetector::new(targets);
     let cycle = detector.detect();
@@ -86,10 +88,9 @@ impl CycleDetector<'_> {
     /// or `None` if the graph is acyclic.
     fn detect(&mut self) -> Option<Vec<Utf8PathBuf>> {
         let mut nodes: Vec<Utf8PathBuf> = self.targets.keys().cloned().collect();
-        // Sort keys to guarantee deterministic traversal order.  The
-        // O(n log n) cost is negligible for typical build graphs
-        // (100–10 000 targets) and is outweighed by the benefit of
-        // stable, reproducible error messages.
+        // Sort keys for deterministic traversal order.  The O(n log n) cost is
+        // negligible for typical build graphs (100–10 000 targets) and is
+        // outweighed by the benefit of stable, reproducible error messages.
         nodes.sort();
         for node in nodes {
             if self.is_visited(node.as_path()) {
@@ -162,6 +163,8 @@ impl CycleDetector<'_> {
 
     /// Record `dep` as missing and return `true` if `dep` is absent from the
     /// target map; return `false` if it is present.
+    ///
+    /// Missing dependencies are also emitted as debug-level tracing events.
     fn record_missing_dependency(&mut self, node: &Utf8Path, dep: &Utf8Path) -> bool {
         if self.targets.contains_key(dep) {
             return false;
@@ -392,9 +395,5 @@ mod tests {
         for (cycle_len, implicit_index) in cases {
             assert_bounded_cycle_detected(cycle_len, implicit_index);
         }
-    }
-
-    mod property_tests {
-        include!("cycle_property_tests.rs");
     }
 }

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -35,16 +35,7 @@ pub(crate) struct CycleDetectionReport {
 /// for logging the reported data.
 pub(crate) fn analyse(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetectionReport {
     let mut detector = CycleDetector::new(targets);
-    let mut cycle = None;
-    for node in targets.keys() {
-        if detector.is_visited(node) {
-            continue;
-        }
-        if let Some(found) = detector.visit(node.clone()) {
-            cycle = Some(found);
-            break;
-        }
-    }
+    let cycle = detector.detect();
     CycleDetectionReport {
         cycle,
         missing_dependencies: detector.missing_dependencies,
@@ -59,65 +50,25 @@ struct CycleDetector<'targets> {
 }
 
 impl CycleDetector<'_> {
-    fn new(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetector<'_> {
-        CycleDetector {
-            targets,
-            stack: Vec::new(),
-            states: HashMap::new(),
-            missing_dependencies: Vec::new(),
-        }
-    }
-
-    fn is_visited(&self, node: &Utf8PathBuf) -> bool {
-        matches!(self.states.get(node), Some(VisitState::Visited))
-    }
-
-    fn visit(&mut self, node: Utf8PathBuf) -> Option<Vec<Utf8PathBuf>> {
-        match self.states.get(&node) {
-            Some(VisitState::Visited) => return None,
-            Some(VisitState::Visiting) => {
-                let idx = self
-                    .stack
-                    .iter()
-                    .position(|n| n == &node)
-                    .unwrap_or_else(|| {
-                        debug_assert!(false, "visiting node must be on the stack");
-                        0
-                    });
-                let mut cycle: Vec<Utf8PathBuf> = self.stack.iter().skip(idx).cloned().collect();
-                cycle.push(node);
-                return Some(canonicalize_cycle(cycle));
-            }
-            None => {
-                self.states.insert(node.clone(), VisitState::Visiting);
-            }
+    fn record_missing_dependency(&mut self, node: &Utf8PathBuf, dep: &Utf8PathBuf) -> bool {
+        if self.targets.contains_key(dep) {
+            return false;
         }
 
-        self.stack.push(node.clone());
+        self.missing_dependencies.push((node.clone(), dep.clone()));
+        true
+    }
 
-        if let Some(cycle) = self
-            .targets
-            .get(&node)
-            .into_iter()
-            .flat_map(|edge| edge.inputs.iter().chain(&edge.implicit_deps))
-            .find_map(|dep| self.visit_dependency(&node, dep))
-        {
-            return Some(cycle);
+    fn visit_dependency(
+        &mut self,
+        node: &Utf8PathBuf,
+        dep: &Utf8PathBuf,
+    ) -> Option<Vec<Utf8PathBuf>> {
+        if self.record_missing_dependency(node, dep) {
+            return None;
         }
 
-        self.stack.pop();
-        self.states.insert(node, VisitState::Visited);
-        None
-    }
-
-    #[cfg(test)]
-    fn missing_dependencies(&self) -> &[(Utf8PathBuf, Utf8PathBuf)] {
-        &self.missing_dependencies
-    }
-
-    #[cfg(test)]
-    fn find_cycle(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> Option<Vec<Utf8PathBuf>> {
-        analyse(targets).cycle
+        self.visit(dep.clone())
     }
 }
 
@@ -156,10 +107,10 @@ fn canonicalize_cycle(mut cycle: Vec<Utf8PathBuf>) -> Vec<Utf8PathBuf> {
         .enumerate()
         .min_by(|(_, a), (_, b)| a.cmp(b))
         .map_or(0, |(idx, _)| idx);
-    let (prefix, suffix) = cycle.split_at_mut(len);
-    prefix.rotate_left(start);
-    if let (Some(first), Some(last)) = (prefix.first().cloned(), suffix.first_mut()) {
-        *last = first;
+    cycle.pop();
+    cycle.rotate_left(start);
+    if let Some(first) = cycle.first().cloned() {
+        cycle.push(first);
     }
     cycle
 }
@@ -262,7 +213,7 @@ mod tests {
         targets.insert(b.clone(), build_edge(&[], &[], "b"));
 
         let mut detector = CycleDetector::new(&targets);
-        assert!(detector.visit(a.clone()).is_none());
+        assert!(detector.detect().is_none());
         assert!(detector.is_visited(&a));
         assert!(detector.is_visited(&b));
         assert!(

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -348,4 +348,73 @@ mod tests {
     fn canonicalize_cycle_handles_reverse_direction() {
         check_canonicalize_cycle(&["c", "b", "a", "c"], &["a", "c", "b", "a"]);
     }
+
+    mod property_tests {
+        use proptest::prelude::*;
+
+        use super::super::canonicalize_cycle;
+        use super::path;
+
+        /// Generate a non-empty list of distinct single-character node names.
+        fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
+            proptest::collection::vec("[a-z]", min..=max).prop_filter(
+                "nodes must be unique",
+                |v| {
+                    let set: std::collections::HashSet<_> = v.iter().collect();
+                    set.len() == v.len()
+                },
+            )
+        }
+
+        /// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
+        fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
+            let mut cycle: Vec<_> = nodes.iter().map(|s| path(s)).collect();
+            cycle.push(path(&nodes[0]));
+            cycle
+        }
+
+        proptest! {
+            /// Canonicalisation is idempotent: applying it twice yields the
+            /// same result as applying it once.
+            #[test]
+            fn canonicalize_is_idempotent(nodes in node_names(2, 10)) {
+                let cycle = make_cycle(&nodes);
+                let once = canonicalize_cycle(cycle.clone());
+                let twice = canonicalize_cycle(once.clone());
+                prop_assert_eq!(once, twice);
+            }
+
+            /// All rotations of a cycle canonicalise to the same sequence.
+            #[test]
+            fn all_rotations_canonicalise_identically(nodes in node_names(2, 8)) {
+                let base = canonicalize_cycle(make_cycle(&nodes));
+                for i in 1..nodes.len() {
+                    let mut rotated = nodes.clone();
+                    rotated.rotate_left(i);
+                    let result = canonicalize_cycle(make_cycle(&rotated));
+                    prop_assert_eq!(&base, &result);
+                }
+            }
+
+            /// The first node in the canonical form is lexicographically <=
+            /// every other non-terminal node.
+            #[test]
+            fn canonical_first_node_is_smallest(nodes in node_names(2, 10)) {
+                let canonical = canonicalize_cycle(make_cycle(&nodes));
+                let interior = &canonical[..canonical.len() - 1];
+                let first = &canonical[0];
+                for node in interior {
+                    prop_assert!(first <= node);
+                }
+            }
+
+            /// The canonical form is closed: first and last elements are
+            /// equal.
+            #[test]
+            fn canonical_cycle_is_closed(nodes in node_names(2, 10)) {
+                let canonical = canonicalize_cycle(make_cycle(&nodes));
+                prop_assert_eq!(canonical.first(), canonical.last());
+            }
+        }
+    }
 }

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -392,77 +392,7 @@ mod tests {
     }
 
     mod property_tests {
-        use proptest::prelude::*;
-
-        use super::super::canonicalize_cycle;
-        use super::path;
-
-        /// Generate a non-empty list of distinct single-character node names.
-        fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
-            proptest::collection::vec("[a-z]", min..=max).prop_filter("nodes must be unique", |v| {
-                let set: std::collections::HashSet<_> = v.iter().collect();
-                set.len() == v.len()
-            })
-        }
-
-        /// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
-        fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
-            let mut cycle: Vec<_> = nodes.iter().map(|s| path(s)).collect();
-            cycle.push(path(
-                nodes
-                    .first()
-                    .expect("node_names generates at least two nodes"),
-            ));
-            cycle
-        }
-
-        proptest! {
-            /// Canonicalisation is idempotent: applying it twice yields the
-            /// same result as applying it once.
-            #[test]
-            fn canonicalize_is_idempotent(nodes in node_names(2, 10)) {
-                let cycle = make_cycle(&nodes);
-                let once = canonicalize_cycle(cycle.clone());
-                let twice = canonicalize_cycle(once.clone());
-                prop_assert_eq!(once, twice);
-            }
-
-            /// All rotations of a cycle canonicalise to the same sequence.
-            #[test]
-            fn all_rotations_canonicalise_identically(nodes in node_names(2, 8)) {
-                let base = canonicalize_cycle(make_cycle(&nodes));
-                for i in 1..nodes.len() {
-                    let mut rotated = nodes.clone();
-                    rotated.rotate_left(i);
-                    let result = canonicalize_cycle(make_cycle(&rotated));
-                    prop_assert_eq!(&base, &result);
-                }
-            }
-
-            /// The first node in the canonical form is lexicographically <=
-            /// every other non-terminal node.
-            #[test]
-            fn canonical_first_node_is_smallest(nodes in node_names(2, 10)) {
-                let canonical = canonicalize_cycle(make_cycle(&nodes));
-                let interior = canonical
-                    .get(..canonical.len().saturating_sub(1))
-                    .expect("canonicalize_cycle produces at least two nodes");
-                let first = canonical
-                    .first()
-                    .expect("canonicalize_cycle produces at least one node");
-                for node in interior {
-                    prop_assert!(first <= node);
-                }
-            }
-
-            /// The canonical form is closed: first and last elements are
-            /// equal.
-            #[test]
-            fn canonical_cycle_is_closed(nodes in node_names(2, 10)) {
-                let canonical = canonicalize_cycle(make_cycle(&nodes));
-                prop_assert_eq!(canonical.first(), canonical.last());
-            }
-        }
+        include!("cycle_property_tests.rs");
     }
 
     #[test]

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -1,10 +1,21 @@
 //! Cycle detection utilities for the IR target graph.
 //!
-//! Implements [`CycleDetector`], which performs a depth-first traversal of
-//! [`BuildEdge`] `inputs` and `implicit_deps` to detect circular dependencies
-//! and record missing dependency references.  `order_only_deps` are
-//! intentionally excluded from traversal.  Consumed by
-//! [`super::from_manifest`] after the full target map is constructed.
+//! The public entry point is [`analyse`], which accepts the target map
+//! (`HashMap<Utf8PathBuf, BuildEdge>`) produced by IR lowering and
+//! returns a [`CycleDetectionReport`].  The report carries an optional
+//! detected cycle — an ordered, canonicalised list of paths — together
+//! with any dependencies referenced by a target but absent from the map.
+//! `order_only_deps` are intentionally excluded from traversal.
+//!
+//! Traversal state is managed by the private [`CycleDetector`] struct,
+//! which owns the DFS recursion stack and per-node visitation map.
+//! Callers drive detection through [`CycleDetector::detect`], which
+//! iterates over every node in the target map and delegates depth-first
+//! visiting to `visit` and `visit_dependency`.  Detected cycles are
+//! normalised by [`canonicalize_cycle`] to produce deterministic error
+//! messages regardless of traversal order.
+//! Consumed by [`super::from_manifest`] after the full target map is
+//! constructed.
 
 use std::collections::HashMap;
 

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -30,6 +30,12 @@ enum VisitState {
     Visited,
 }
 
+/// The result of a cycle-detection pass over the target graph.
+///
+/// `cycle` is `Some` when a dependency cycle was found; the vec holds the
+/// cycle's nodes in canonical order, with the first node repeated as the
+/// last element.  `missing_dependencies` lists every `(dependent, dep)`
+/// pair where `dep` is referenced but absent from the target map.
 pub(crate) struct CycleDetectionReport {
     pub(crate) cycle: Option<Vec<Utf8PathBuf>>,
     pub(crate) missing_dependencies: Vec<(Utf8PathBuf, Utf8PathBuf)>,
@@ -53,6 +59,10 @@ pub(crate) fn analyse(targets: &HashMap<Utf8PathBuf, BuildEdge>) -> CycleDetecti
     }
 }
 
+/// Depth-first cycle detector that owns its traversal state.
+///
+/// Create with [`CycleDetector::new`] and drive detection with
+/// [`CycleDetector::detect`].
 struct CycleDetector<'targets> {
     targets: &'targets HashMap<Utf8PathBuf, BuildEdge>,
     stack: Vec<Utf8PathBuf>,
@@ -61,6 +71,8 @@ struct CycleDetector<'targets> {
 }
 
 impl CycleDetector<'_> {
+    /// Record `dep` as missing and return `true` if `dep` is absent from the
+    /// target map; return `false` if it is present.
     fn record_missing_dependency(&mut self, node: &Utf8PathBuf, dep: &Utf8PathBuf) -> bool {
         if self.targets.contains_key(dep) {
             return false;
@@ -70,6 +82,10 @@ impl CycleDetector<'_> {
         true
     }
 
+    /// Optionally record `dep` as missing, then visit it.
+    ///
+    /// Returns early with `None` when the dependency is absent from the target
+    /// map.
     fn visit_dependency(
         &mut self,
         node: &Utf8PathBuf,
@@ -84,6 +100,8 @@ impl CycleDetector<'_> {
 }
 
 impl CycleDetector<'_> {
+    /// Record `dep` as missing and return `true` if `dep` is absent from the
+    /// target map; return `false` if it is present.
     fn record_missing_dependency(&mut self, node: &Utf8PathBuf, dep: &Utf8PathBuf) -> bool {
         if self.targets.contains_key(dep) {
             return false;
@@ -93,6 +111,10 @@ impl CycleDetector<'_> {
         true
     }
 
+    /// Optionally record `dep` as missing, then visit it.
+    ///
+    /// Returns early with `None` when the dependency is absent from the target
+    /// map.
     fn visit_dependency(
         &mut self,
         node: &Utf8PathBuf,
@@ -106,6 +128,11 @@ impl CycleDetector<'_> {
     }
 }
 
+/// Rotate `cycle` so that the lexicographically smallest node appears
+/// first, then re-close it by appending the first node.
+///
+/// The input must contain at least two nodes; the first and last node are
+/// expected to be identical (the standard DFS cycle representation).
 fn canonicalize_cycle(mut cycle: Vec<Utf8PathBuf>) -> Vec<Utf8PathBuf> {
     debug_assert!(
         cycle.len() >= 2,

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -259,6 +259,13 @@ mod tests {
         assert_eq!(cycle, vec![path("a"), path("b"), path("a")]);
     }
 
+    fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
+        let cycle: Vec<Utf8PathBuf> = input.iter().map(|&s| path(s)).collect();
+        let canonical = canonicalize_cycle(cycle);
+        let want: Vec<Utf8PathBuf> = expected.iter().map(|&s| path(s)).collect();
+        assert_eq!(canonical, want);
+    }
+
     #[test]
     fn find_cycle_identifies_mixed_input_and_implicit_dependency_cycle() {
         let mut targets = HashMap::new();
@@ -282,17 +289,11 @@ mod tests {
 
     #[test]
     fn canonicalize_cycle_rotates_smallest_node() {
-        let cycle = vec![path("c"), path("a"), path("b"), path("c")];
-        let canonical = canonicalize_cycle(cycle);
-        let expected = vec![path("a"), path("b"), path("c"), path("a")];
-        assert_eq!(canonical, expected);
+        check_canonicalize_cycle(&["c", "a", "b", "c"], &["a", "b", "c", "a"]);
     }
 
     #[test]
     fn canonicalize_cycle_handles_reverse_direction() {
-        let cycle = vec![path("c"), path("b"), path("a"), path("c")];
-        let canonical = canonicalize_cycle(cycle);
-        let expected = vec![path("a"), path("c"), path("b"), path("a")];
-        assert_eq!(canonical, expected);
+        check_canonicalize_cycle(&["c", "b", "a", "c"], &["a", "c", "b", "a"]);
     }
 }

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -86,6 +86,10 @@ impl CycleDetector<'_> {
     /// or `None` if the graph is acyclic.
     fn detect(&mut self) -> Option<Vec<Utf8PathBuf>> {
         let mut nodes: Vec<Utf8PathBuf> = self.targets.keys().cloned().collect();
+        // Sort keys to guarantee deterministic traversal order.  The
+        // O(n log n) cost is negligible for typical build graphs
+        // (100–10 000 targets) and is outweighed by the benefit of
+        // stable, reproducible error messages.
         nodes.sort();
         for node in nodes {
             if self.is_visited(node.as_path()) {

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -84,9 +84,12 @@ impl CycleDetector<'_> {
         }
     }
 
-    /// Walk every node in the target map and return the first cycle found,
-    /// or `None` if the graph is acyclic.
+    /// Walk every node in the target map and return the first cycle found.
     fn detect(&mut self) -> Option<Vec<Utf8PathBuf>> {
+        self.states.clear();
+        self.stack.clear();
+        self.missing_dependencies.clear();
+
         let mut nodes: Vec<Utf8PathBuf> = self.targets.keys().cloned().collect();
         // Sort keys for deterministic traversal order.  The O(n log n) cost is
         // negligible for typical build graphs (100–10 000 targets) and is
@@ -149,11 +152,6 @@ impl CycleDetector<'_> {
         }
 
         cycle
-    }
-
-    #[cfg(test)]
-    fn missing_dependencies(&self) -> &[(Utf8PathBuf, Utf8PathBuf)] {
-        &self.missing_dependencies
     }
 
     #[cfg(test)]
@@ -263,7 +261,10 @@ mod tests {
             .collect();
         let mut detector = CycleDetector::new(&targets);
         assert!(detector.visit(path("a").as_path()).is_none());
-        assert_eq!(detector.missing_dependencies(), expected.as_slice());
+        assert_eq!(
+            detector.missing_dependencies.as_slice(),
+            expected.as_slice()
+        );
     }
 
     fn next_cycle_index(index: usize, cycle_len: usize) -> usize {

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -73,9 +73,33 @@ fn make_cycle(nodes: &[camino::Utf8PathBuf]) -> Vec<camino::Utf8PathBuf> {
     cycle
 }
 
+/// Assert that `canonicalize_cycle` converts `input` to `expected`.
 fn check_canonicalize_cycle(input: &[camino::Utf8PathBuf], expected: &[camino::Utf8PathBuf]) {
     let canonical = canonicalize_cycle(input.to_vec());
     assert_eq!(canonical, expected);
+}
+
+/// Build a target graph containing two disjoint two-node cycles:
+/// p ↔ q and x ↔ y.
+fn two_disjoint_cycles() -> HashMap<camino::Utf8PathBuf, BuildEdge> {
+    let mut targets = HashMap::new();
+    targets.insert(
+        path("p"),
+        EdgeBuilder::new(path("p")).input(path("q")).build(),
+    );
+    targets.insert(
+        path("q"),
+        EdgeBuilder::new(path("q")).input(path("p")).build(),
+    );
+    targets.insert(
+        path("x"),
+        EdgeBuilder::new(path("x")).input(path("y")).build(),
+    );
+    targets.insert(
+        path("y"),
+        EdgeBuilder::new(path("y")).input(path("x")).build(),
+    );
+    targets
 }
 
 proptest! {
@@ -127,23 +151,7 @@ proptest! {
 
 #[test]
 fn find_cycle_is_deterministic() {
-    let mut targets = HashMap::new();
-    targets.insert(
-        path("p"),
-        EdgeBuilder::new(path("p")).input(path("q")).build(),
-    );
-    targets.insert(
-        path("q"),
-        EdgeBuilder::new(path("q")).input(path("p")).build(),
-    );
-    targets.insert(
-        path("x"),
-        EdgeBuilder::new(path("x")).input(path("y")).build(),
-    );
-    targets.insert(
-        path("y"),
-        EdgeBuilder::new(path("y")).input(path("x")).build(),
-    );
+    let targets = two_disjoint_cycles();
 
     let first = CycleDetector::find_cycle(&targets).expect("cycle");
     for _ in 1..100 {
@@ -154,8 +162,8 @@ fn find_cycle_is_deterministic() {
              first={first:?}, got={cycle:?}",
         );
     }
-    // Probabilistic guard: 100 runs; `detect` sorts keys for stable traversal.
-    tracing::info!("find_cycle returned the same cycle across 100 runs");
+    // Run 100 times; `detect` sorts keys deterministically, so the result must
+    // be identical on every invocation.
 }
 
 #[test]
@@ -176,25 +184,19 @@ fn canonicalize_cycle_handles_reverse_direction() {
 
 #[test]
 fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
-    let mut targets = HashMap::new();
-    targets.insert(
-        path("p"),
-        EdgeBuilder::new(path("p")).input(path("q")).build(),
-    );
-    targets.insert(
-        path("q"),
-        EdgeBuilder::new(path("q")).input(path("p")).build(),
-    );
-    targets.insert(
-        path("x"),
-        EdgeBuilder::new(path("x")).input(path("y")).build(),
-    );
-    targets.insert(
-        path("y"),
-        EdgeBuilder::new(path("y")).input(path("x")).build(),
-    );
+    let targets = two_disjoint_cycles();
 
-    assert!(CycleDetector::find_cycle(&targets).is_some());
+    let cycle = CycleDetector::find_cycle(&targets).expect("should detect a cycle");
+    let valid_cycles = [
+        vec![path("p"), path("q"), path("p")],
+        vec![path("q"), path("p"), path("q")],
+        vec![path("x"), path("y"), path("x")],
+        vec![path("y"), path("x"), path("y")],
+    ];
+    assert!(
+        valid_cycles.contains(&cycle),
+        "expected one of the two disjoint canonical cycles, got {cycle:?}",
+    );
 }
 
 #[test]

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -73,7 +73,11 @@ fn make_cycle(nodes: &[camino::Utf8PathBuf]) -> Vec<camino::Utf8PathBuf> {
     cycle
 }
 
-/// Assert that `canonicalize_cycle` converts `input` to `expected`.
+/// Assert that `canonicalize_cycle` transforms `input` into `expected`.
+///
+/// Converts the provided `Utf8PathBuf` slices to an owned `Vec`, calls
+/// `canonicalize_cycle`, and asserts the result equals `expected` to verify
+/// correct canonicalisation of cycle rotation.
 fn check_canonicalize_cycle(input: &[camino::Utf8PathBuf], expected: &[camino::Utf8PathBuf]) {
     let canonical = canonicalize_cycle(input.to_vec());
     assert_eq!(canonical, expected);

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -6,7 +6,7 @@
 use proptest::prelude::*;
 use std::collections::HashMap;
 
-use super::{BuildEdge, CycleDetector, canonicalize_cycle};
+use super::{BuildEdge, CycleDetector, analyse, canonicalize_cycle};
 
 fn path(name: &str) -> camino::Utf8PathBuf {
     camino::Utf8PathBuf::from(name)
@@ -138,6 +138,35 @@ fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
     targets.insert(path("y"), build_edge(&["x"], &[], "y"));
 
     assert!(CycleDetector::find_cycle(&targets).is_some());
+}
+
+#[test]
+fn cycle_detector_repeated_detect_resets_traversal_state() {
+    let mut targets = HashMap::new();
+    targets.insert(path("a"), build_edge(&["b"], &[], "a"));
+    targets.insert(path("b"), build_edge(&["a"], &[], "b"));
+
+    let expected = vec![path("a"), path("b"), path("a")];
+    let mut detector = CycleDetector::new(&targets);
+
+    assert_eq!(detector.detect(), Some(expected.clone()));
+    assert_eq!(detector.detect(), Some(expected));
+}
+
+#[test]
+fn analyse_reports_missing_dependencies_before_detected_cycle() {
+    let mut targets = HashMap::new();
+    targets.insert(path("a"), build_edge(&["missing"], &[], "a"));
+    targets.insert(path("b"), build_edge(&["c"], &[], "b"));
+    targets.insert(path("c"), build_edge(&["b"], &[], "c"));
+
+    let report = analyse(&targets);
+
+    assert_eq!(report.cycle, Some(vec![path("b"), path("c"), path("b")]));
+    assert_eq!(
+        report.missing_dependencies,
+        vec![(path("a"), path("missing"))],
+    );
 }
 
 /// Generate a list of `count` distinct node names "n0", "n1", …

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -127,12 +127,9 @@ fn sequential_nodes(count: usize) -> Vec<String> {
 /// Build an acyclic chain: n0 → n1 → … → n(count-1) (no back-edges).
 fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
     let mut targets = HashMap::new();
-    for (i, name) in nodes.iter().enumerate() {
-        let inputs: Vec<&str> = if i + 1 < nodes.len() {
-            vec![nodes[i + 1].as_str()]
-        } else {
-            vec![]
-        };
+    let mut iter = nodes.iter().peekable();
+    while let Some(name) = iter.next() {
+        let inputs: Vec<&str> = iter.peek().map(|n| n.as_str()).into_iter().collect();
         targets.insert(path(name), build_edge(&inputs, &[], name));
     }
     targets
@@ -140,10 +137,9 @@ fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::s
 
 /// Build a cycle of length `cycle_len` starting at node index 0.
 fn make_cycle_graph(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
-    let len = nodes.len();
     let mut targets = HashMap::new();
-    for (i, name) in nodes.iter().enumerate() {
-        let dep = &nodes[(i + 1) % len];
+    let deps = nodes.iter().cycle().skip(1).take(nodes.len());
+    for (name, dep) in nodes.iter().zip(deps) {
         targets.insert(path(name), build_edge(&[dep.as_str()], &[], name));
     }
     targets

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -190,16 +190,16 @@ fn canonicalize_cycle_handles_reverse_direction() {
 fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
     let targets = two_disjoint_cycles();
 
-    let cycle = CycleDetector::find_cycle(&targets).expect("should detect a cycle");
-    let valid_cycles = [
+    let cycle = CycleDetector::find_cycle(&targets)
+        .expect("should detect a cycle in a graph with two disjoint cycles");
+    // Must be exactly one of the two canonical closed cycles.
+    let expected_cycles = vec![
         vec![path("p"), path("q"), path("p")],
-        vec![path("q"), path("p"), path("q")],
         vec![path("x"), path("y"), path("x")],
-        vec![path("y"), path("x"), path("y")],
     ];
     assert!(
-        valid_cycles.contains(&cycle),
-        "expected one of the two disjoint canonical cycles, got {cycle:?}",
+        expected_cycles.contains(&cycle),
+        "Expected one of {expected_cycles:?}, got {cycle:?}",
     );
 }
 

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -12,16 +12,42 @@ fn path(name: &str) -> camino::Utf8PathBuf {
     camino::Utf8PathBuf::from(name)
 }
 
-fn build_edge(inputs: &[&str], implicit_deps: &[&str], output: &str) -> BuildEdge {
-    BuildEdge {
-        action_id: "id".into(),
-        inputs: inputs.iter().map(|name| path(name)).collect(),
-        implicit_deps: implicit_deps.iter().map(|name| path(name)).collect(),
-        explicit_outputs: vec![path(output)],
-        implicit_outputs: Vec::new(),
-        order_only_deps: Vec::new(),
-        phony: false,
-        always: false,
+struct EdgeBuilder {
+    output: String,
+    inputs: Vec<String>,
+    implicit_deps: Vec<String>,
+}
+
+impl EdgeBuilder {
+    fn new(output: &str) -> Self {
+        Self {
+            output: output.into(),
+            inputs: Vec::new(),
+            implicit_deps: Vec::new(),
+        }
+    }
+
+    fn input(mut self, node: &str) -> Self {
+        self.inputs.push(node.into());
+        self
+    }
+
+    fn implicit_dep(mut self, node: &str) -> Self {
+        self.implicit_deps.push(node.into());
+        self
+    }
+
+    fn build(self) -> BuildEdge {
+        BuildEdge {
+            action_id: "id".into(),
+            inputs: self.inputs.iter().map(|name| path(name)).collect(),
+            implicit_deps: self.implicit_deps.iter().map(|name| path(name)).collect(),
+            explicit_outputs: vec![path(&self.output)],
+            implicit_outputs: Vec::new(),
+            order_only_deps: Vec::new(),
+            phony: false,
+            always: false,
+        }
     }
 }
 
@@ -101,10 +127,10 @@ proptest! {
 #[test]
 fn find_cycle_is_deterministic() {
     let mut targets = HashMap::new();
-    targets.insert(path("p"), build_edge(&["q"], &[], "p"));
-    targets.insert(path("q"), build_edge(&["p"], &[], "q"));
-    targets.insert(path("x"), build_edge(&["y"], &[], "x"));
-    targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+    targets.insert(path("p"), EdgeBuilder::new("p").input("q").build());
+    targets.insert(path("q"), EdgeBuilder::new("q").input("p").build());
+    targets.insert(path("x"), EdgeBuilder::new("x").input("y").build());
+    targets.insert(path("y"), EdgeBuilder::new("y").input("x").build());
 
     let first = CycleDetector::find_cycle(&targets).expect("cycle");
     for _ in 1..100 {
@@ -132,10 +158,10 @@ fn canonicalize_cycle_handles_reverse_direction() {
 #[test]
 fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
     let mut targets = HashMap::new();
-    targets.insert(path("p"), build_edge(&["q"], &[], "p"));
-    targets.insert(path("q"), build_edge(&["p"], &[], "q"));
-    targets.insert(path("x"), build_edge(&["y"], &[], "x"));
-    targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+    targets.insert(path("p"), EdgeBuilder::new("p").input("q").build());
+    targets.insert(path("q"), EdgeBuilder::new("q").input("p").build());
+    targets.insert(path("x"), EdgeBuilder::new("x").input("y").build());
+    targets.insert(path("y"), EdgeBuilder::new("y").input("x").build());
 
     assert!(CycleDetector::find_cycle(&targets).is_some());
 }
@@ -143,8 +169,8 @@ fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
 #[test]
 fn cycle_detector_repeated_detect_resets_traversal_state() {
     let mut targets = HashMap::new();
-    targets.insert(path("a"), build_edge(&["b"], &[], "a"));
-    targets.insert(path("b"), build_edge(&["a"], &[], "b"));
+    targets.insert(path("a"), EdgeBuilder::new("a").input("b").build());
+    targets.insert(path("b"), EdgeBuilder::new("b").input("a").build());
 
     let expected = vec![path("a"), path("b"), path("a")];
     let mut detector = CycleDetector::new(&targets);
@@ -156,16 +182,25 @@ fn cycle_detector_repeated_detect_resets_traversal_state() {
 #[test]
 fn analyse_reports_missing_dependencies_before_detected_cycle() {
     let mut targets = HashMap::new();
-    targets.insert(path("a"), build_edge(&["missing"], &[], "a"));
-    targets.insert(path("b"), build_edge(&["c"], &[], "b"));
-    targets.insert(path("c"), build_edge(&["b"], &[], "c"));
+    targets.insert(
+        path("a"),
+        EdgeBuilder::new("a")
+            .input("missing")
+            .implicit_dep("also_missing")
+            .build(),
+    );
+    targets.insert(path("b"), EdgeBuilder::new("b").input("c").build());
+    targets.insert(path("c"), EdgeBuilder::new("c").input("b").build());
 
     let report = analyse(&targets);
 
     assert_eq!(report.cycle, Some(vec![path("b"), path("c"), path("b")]));
     assert_eq!(
         report.missing_dependencies,
-        vec![(path("a"), path("missing"))],
+        vec![
+            (path("a"), path("missing")),
+            (path("a"), path("also_missing")),
+        ],
     );
 }
 
@@ -179,8 +214,11 @@ fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::s
     let mut targets = HashMap::new();
     let mut iter = nodes.iter().peekable();
     while let Some(name) = iter.next() {
-        let inputs: Vec<&str> = iter.peek().map(|n| n.as_str()).into_iter().collect();
-        targets.insert(path(name), build_edge(&inputs, &[], name));
+        let mut builder = EdgeBuilder::new(name);
+        if let Some(next) = iter.peek() {
+            builder = builder.input(next);
+        }
+        targets.insert(path(name), builder.build());
     }
     targets
 }
@@ -193,7 +231,7 @@ fn make_cycle_graph(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::sup
     let mut targets = HashMap::new();
     let deps = nodes.iter().cycle().skip(1).take(nodes.len());
     for (name, dep) in nodes.iter().zip(deps) {
-        targets.insert(path(name), build_edge(&[dep.as_str()], &[], name));
+        targets.insert(path(name), EdgeBuilder::new(name).input(dep).build());
     }
     targets
 }

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -1,0 +1,70 @@
+use proptest::prelude::*;
+
+use super::super::canonicalize_cycle;
+use super::path;
+
+/// Generate a non-empty list of distinct single-character node names.
+fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
+    proptest::collection::vec("[a-z]", min..=max).prop_filter("nodes must be unique", |v| {
+        let set: std::collections::HashSet<_> = v.iter().collect();
+        set.len() == v.len()
+    })
+}
+
+/// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
+fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
+    let mut cycle: Vec<_> = nodes.iter().map(|s| path(s)).collect();
+    cycle.push(path(
+        nodes
+            .first()
+            .expect("node_names generates at least two nodes"),
+    ));
+    cycle
+}
+
+proptest! {
+    /// Canonicalisation is idempotent: applying it twice yields the same
+    /// result as applying it once.
+    #[test]
+    fn canonicalize_is_idempotent(nodes in node_names(2, 10)) {
+        let cycle = make_cycle(&nodes);
+        let once = canonicalize_cycle(cycle.clone());
+        let twice = canonicalize_cycle(once.clone());
+        prop_assert_eq!(once, twice);
+    }
+
+    /// All rotations of a cycle canonicalise to the same sequence.
+    #[test]
+    fn all_rotations_canonicalise_identically(nodes in node_names(2, 8)) {
+        let base = canonicalize_cycle(make_cycle(&nodes));
+        for i in 1..nodes.len() {
+            let mut rotated = nodes.clone();
+            rotated.rotate_left(i);
+            let result = canonicalize_cycle(make_cycle(&rotated));
+            prop_assert_eq!(&base, &result);
+        }
+    }
+
+    /// The first node in the canonical form is lexicographically <= every
+    /// other non-terminal node.
+    #[test]
+    fn canonical_first_node_is_smallest(nodes in node_names(2, 10)) {
+        let canonical = canonicalize_cycle(make_cycle(&nodes));
+        let interior = canonical
+            .get(..canonical.len().saturating_sub(1))
+            .expect("canonicalize_cycle produces at least two nodes");
+        let first = canonical
+            .first()
+            .expect("canonicalize_cycle produces at least one node");
+        for node in interior {
+            prop_assert!(first <= node);
+        }
+    }
+
+    /// The canonical form is closed: first and last elements are equal.
+    #[test]
+    fn canonical_cycle_is_closed(nodes in node_names(2, 10)) {
+        let canonical = canonicalize_cycle(make_cycle(&nodes));
+        prop_assert_eq!(canonical.first(), canonical.last());
+    }
+}

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -13,36 +13,36 @@ fn path(name: &str) -> camino::Utf8PathBuf {
 }
 
 struct EdgeBuilder {
-    output: String,
-    inputs: Vec<String>,
-    implicit_deps: Vec<String>,
+    output: camino::Utf8PathBuf,
+    inputs: Vec<camino::Utf8PathBuf>,
+    implicit_deps: Vec<camino::Utf8PathBuf>,
 }
 
 impl EdgeBuilder {
-    fn new(output: &str) -> Self {
+    fn new(output: camino::Utf8PathBuf) -> Self {
         Self {
-            output: output.into(),
+            output,
             inputs: Vec::new(),
             implicit_deps: Vec::new(),
         }
     }
 
-    fn input(mut self, node: &str) -> Self {
-        self.inputs.push(node.into());
+    fn input(mut self, node: camino::Utf8PathBuf) -> Self {
+        self.inputs.push(node);
         self
     }
 
-    fn implicit_dep(mut self, node: &str) -> Self {
-        self.implicit_deps.push(node.into());
+    fn implicit_dep(mut self, node: camino::Utf8PathBuf) -> Self {
+        self.implicit_deps.push(node);
         self
     }
 
     fn build(self) -> BuildEdge {
         BuildEdge {
             action_id: "id".into(),
-            inputs: self.inputs.iter().map(|name| path(name)).collect(),
-            implicit_deps: self.implicit_deps.iter().map(|name| path(name)).collect(),
-            explicit_outputs: vec![path(&self.output)],
+            inputs: self.inputs,
+            implicit_deps: self.implicit_deps,
+            explicit_outputs: vec![self.output],
             implicit_outputs: Vec::new(),
             order_only_deps: Vec::new(),
             phony: false,
@@ -52,29 +52,30 @@ impl EdgeBuilder {
 }
 
 /// Generate a non-empty list of distinct single-character node names.
-fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
-    proptest::collection::vec("[a-z]", min..=max).prop_filter("nodes must be unique", |v| {
-        let set: std::collections::HashSet<_> = v.iter().collect();
-        set.len() == v.len()
-    })
+fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<camino::Utf8PathBuf>> {
+    proptest::collection::vec("[a-z]", min..=max)
+        .prop_filter("nodes must be unique", |v| {
+            let set: std::collections::HashSet<_> = v.iter().collect();
+            set.len() == v.len()
+        })
+        .prop_map(|v| v.iter().map(|s| path(s)).collect())
 }
 
 /// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
-fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
-    let mut cycle: Vec<_> = nodes.iter().map(|s| path(s)).collect();
-    cycle.push(path(
+fn make_cycle(nodes: &[camino::Utf8PathBuf]) -> Vec<camino::Utf8PathBuf> {
+    let mut cycle = nodes.to_vec();
+    cycle.push(
         nodes
             .first()
-            .expect("node_names generates at least two nodes"),
-    ));
+            .expect("node_names generates at least two nodes")
+            .clone(),
+    );
     cycle
 }
 
-fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
-    let cycle: Vec<camino::Utf8PathBuf> = input.iter().map(|&s| path(s)).collect();
-    let canonical = canonicalize_cycle(cycle);
-    let want: Vec<camino::Utf8PathBuf> = expected.iter().map(|&s| path(s)).collect();
-    assert_eq!(canonical, want);
+fn check_canonicalize_cycle(input: &[camino::Utf8PathBuf], expected: &[camino::Utf8PathBuf]) {
+    let canonical = canonicalize_cycle(input.to_vec());
+    assert_eq!(canonical, expected);
 }
 
 proptest! {
@@ -127,10 +128,22 @@ proptest! {
 #[test]
 fn find_cycle_is_deterministic() {
     let mut targets = HashMap::new();
-    targets.insert(path("p"), EdgeBuilder::new("p").input("q").build());
-    targets.insert(path("q"), EdgeBuilder::new("q").input("p").build());
-    targets.insert(path("x"), EdgeBuilder::new("x").input("y").build());
-    targets.insert(path("y"), EdgeBuilder::new("y").input("x").build());
+    targets.insert(
+        path("p"),
+        EdgeBuilder::new(path("p")).input(path("q")).build(),
+    );
+    targets.insert(
+        path("q"),
+        EdgeBuilder::new(path("q")).input(path("p")).build(),
+    );
+    targets.insert(
+        path("x"),
+        EdgeBuilder::new(path("x")).input(path("y")).build(),
+    );
+    targets.insert(
+        path("y"),
+        EdgeBuilder::new(path("y")).input(path("x")).build(),
+    );
 
     let first = CycleDetector::find_cycle(&targets).expect("cycle");
     for _ in 1..100 {
@@ -147,21 +160,39 @@ fn find_cycle_is_deterministic() {
 
 #[test]
 fn canonicalize_cycle_rotates_smallest_node() {
-    check_canonicalize_cycle(&["c", "a", "b", "c"], &["a", "b", "c", "a"]);
+    check_canonicalize_cycle(
+        &[path("c"), path("a"), path("b"), path("c")],
+        &[path("a"), path("b"), path("c"), path("a")],
+    );
 }
 
 #[test]
 fn canonicalize_cycle_handles_reverse_direction() {
-    check_canonicalize_cycle(&["c", "b", "a", "c"], &["a", "c", "b", "a"]);
+    check_canonicalize_cycle(
+        &[path("c"), path("b"), path("a"), path("c")],
+        &[path("a"), path("c"), path("b"), path("a")],
+    );
 }
 
 #[test]
 fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
     let mut targets = HashMap::new();
-    targets.insert(path("p"), EdgeBuilder::new("p").input("q").build());
-    targets.insert(path("q"), EdgeBuilder::new("q").input("p").build());
-    targets.insert(path("x"), EdgeBuilder::new("x").input("y").build());
-    targets.insert(path("y"), EdgeBuilder::new("y").input("x").build());
+    targets.insert(
+        path("p"),
+        EdgeBuilder::new(path("p")).input(path("q")).build(),
+    );
+    targets.insert(
+        path("q"),
+        EdgeBuilder::new(path("q")).input(path("p")).build(),
+    );
+    targets.insert(
+        path("x"),
+        EdgeBuilder::new(path("x")).input(path("y")).build(),
+    );
+    targets.insert(
+        path("y"),
+        EdgeBuilder::new(path("y")).input(path("x")).build(),
+    );
 
     assert!(CycleDetector::find_cycle(&targets).is_some());
 }
@@ -169,8 +200,14 @@ fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
 #[test]
 fn cycle_detector_repeated_detect_resets_traversal_state() {
     let mut targets = HashMap::new();
-    targets.insert(path("a"), EdgeBuilder::new("a").input("b").build());
-    targets.insert(path("b"), EdgeBuilder::new("b").input("a").build());
+    targets.insert(
+        path("a"),
+        EdgeBuilder::new(path("a")).input(path("b")).build(),
+    );
+    targets.insert(
+        path("b"),
+        EdgeBuilder::new(path("b")).input(path("a")).build(),
+    );
 
     let expected = vec![path("a"), path("b"), path("a")];
     let mut detector = CycleDetector::new(&targets);
@@ -184,13 +221,19 @@ fn analyse_reports_missing_dependencies_before_detected_cycle() {
     let mut targets = HashMap::new();
     targets.insert(
         path("a"),
-        EdgeBuilder::new("a")
-            .input("missing")
-            .implicit_dep("also_missing")
+        EdgeBuilder::new(path("a"))
+            .input(path("missing"))
+            .implicit_dep(path("also_missing"))
             .build(),
     );
-    targets.insert(path("b"), EdgeBuilder::new("b").input("c").build());
-    targets.insert(path("c"), EdgeBuilder::new("c").input("b").build());
+    targets.insert(
+        path("b"),
+        EdgeBuilder::new(path("b")).input(path("c")).build(),
+    );
+    targets.insert(
+        path("c"),
+        EdgeBuilder::new(path("c")).input(path("b")).build(),
+    );
 
     let report = analyse(&targets);
 
@@ -205,20 +248,22 @@ fn analyse_reports_missing_dependencies_before_detected_cycle() {
 }
 
 /// Generate a list of `count` distinct node names "n0", "n1", …
-fn sequential_nodes(count: usize) -> Vec<String> {
-    (0..count).map(|i| format!("n{i}")).collect()
+fn sequential_nodes(count: usize) -> Vec<camino::Utf8PathBuf> {
+    (0..count).map(|i| path(&format!("n{i}"))).collect()
 }
 
 /// Build an acyclic chain: n0 → n1 → … → n(count-1) (no back-edges).
-fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
+fn make_acyclic_chain(
+    nodes: &[camino::Utf8PathBuf],
+) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
     let mut targets = HashMap::new();
     let mut iter = nodes.iter().peekable();
     while let Some(name) = iter.next() {
-        let mut builder = EdgeBuilder::new(name);
+        let mut builder = EdgeBuilder::new(name.clone());
         if let Some(next) = iter.peek() {
-            builder = builder.input(next);
+            builder = builder.input((*next).clone());
         }
-        targets.insert(path(name), builder.build());
+        targets.insert(name.clone(), builder.build());
     }
     targets
 }
@@ -227,11 +272,16 @@ fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::s
 ///
 /// Each node depends on the next name in the slice, and the last node depends
 /// on the first, preserving the input order as the cycle order.
-fn make_cycle_graph(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
+fn make_cycle_graph(
+    nodes: &[camino::Utf8PathBuf],
+) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
     let mut targets = HashMap::new();
     let deps = nodes.iter().cycle().skip(1).take(nodes.len());
     for (name, dep) in nodes.iter().zip(deps) {
-        targets.insert(path(name), EdgeBuilder::new(name).input(dep).build());
+        targets.insert(
+            name.clone(),
+            EdgeBuilder::new(name.clone()).input(dep.clone()).build(),
+        );
     }
     targets
 }

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -1,7 +1,8 @@
 use proptest::prelude::*;
+use std::collections::HashMap;
 
-use super::super::canonicalize_cycle;
-use super::path;
+use super::super::{canonicalize_cycle, CycleDetector};
+use super::{build_edge, path};
 
 /// Generate a non-empty list of distinct single-character node names.
 fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
@@ -20,6 +21,13 @@ fn make_cycle(nodes: &[String]) -> Vec<camino::Utf8PathBuf> {
             .expect("node_names generates at least two nodes"),
     ));
     cycle
+}
+
+fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
+    let cycle: Vec<camino::Utf8PathBuf> = input.iter().map(|&s| path(s)).collect();
+    let canonical = canonicalize_cycle(cycle);
+    let want: Vec<camino::Utf8PathBuf> = expected.iter().map(|&s| path(s)).collect();
+    assert_eq!(canonical, want);
 }
 
 proptest! {
@@ -67,4 +75,46 @@ proptest! {
         let canonical = canonicalize_cycle(make_cycle(&nodes));
         prop_assert_eq!(canonical.first(), canonical.last());
     }
+}
+
+#[test]
+fn find_cycle_is_deterministic() {
+    let mut targets = HashMap::new();
+    targets.insert(path("p"), build_edge(&["q"], &[], "p"));
+    targets.insert(path("q"), build_edge(&["p"], &[], "q"));
+    targets.insert(path("x"), build_edge(&["y"], &[], "x"));
+    targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+
+    let first = CycleDetector::find_cycle(&targets).expect("cycle");
+    for _ in 1..100 {
+        let cycle = CycleDetector::find_cycle(&targets).expect("cycle");
+        assert!(
+            cycle == first,
+            "find_cycle returned inconsistent results across runs: \
+             first={first:?}, got={cycle:?}",
+        );
+    }
+    // Probabilistic guard: 100 runs; `detect` sorts keys for stable traversal.
+    tracing::info!("find_cycle returned the same cycle across 100 runs");
+}
+
+#[test]
+fn canonicalize_cycle_rotates_smallest_node() {
+    check_canonicalize_cycle(&["c", "a", "b", "c"], &["a", "b", "c", "a"]);
+}
+
+#[test]
+fn canonicalize_cycle_handles_reverse_direction() {
+    check_canonicalize_cycle(&["c", "b", "a", "c"], &["a", "c", "b", "a"]);
+}
+
+#[test]
+fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
+    let mut targets = HashMap::new();
+    targets.insert(path("p"), build_edge(&["q"], &[], "p"));
+    targets.insert(path("q"), build_edge(&["p"], &[], "q"));
+    targets.insert(path("x"), build_edge(&["y"], &[], "x"));
+    targets.insert(path("y"), build_edge(&["x"], &[], "y"));
+
+    assert!(CycleDetector::find_cycle(&targets).is_some());
 }

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -64,12 +64,9 @@ fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<camino::Utf8P
 /// Build a closed cycle from `nodes`: [...nodes, nodes[0]].
 fn make_cycle(nodes: &[camino::Utf8PathBuf]) -> Vec<camino::Utf8PathBuf> {
     let mut cycle = nodes.to_vec();
-    cycle.push(
-        nodes
-            .first()
-            .expect("node_names generates at least two nodes")
-            .clone(),
-    );
+    if let Some(first) = nodes.first() {
+        cycle.push(first.clone());
+    }
     cycle
 }
 
@@ -134,12 +131,14 @@ proptest! {
     #[test]
     fn canonical_first_node_is_smallest(nodes in node_names(2, 10)) {
         let canonical = canonicalize_cycle(make_cycle(&nodes));
-        let interior = canonical
-            .get(..canonical.len().saturating_sub(1))
-            .expect("canonicalize_cycle produces at least two nodes");
-        let first = canonical
-            .first()
-            .expect("canonicalize_cycle produces at least one node");
+        let Some(interior) = canonical.get(..canonical.len().saturating_sub(1)) else {
+            prop_assert!(false, "canonicalize_cycle produces a valid cycle slice");
+            return Ok(());
+        };
+        let Some(first) = canonical.first() else {
+            prop_assert!(false, "canonicalize_cycle produces at least one node");
+            return Ok(());
+        };
         for node in interior {
             prop_assert!(first <= node);
         }
@@ -154,20 +153,26 @@ proptest! {
 }
 
 #[test]
-fn find_cycle_is_deterministic() {
+fn find_cycle_is_deterministic() -> Result<(), String> {
     let targets = two_disjoint_cycles();
 
-    let first = CycleDetector::find_cycle(&targets).expect("cycle");
+    let Some(first) = CycleDetector::find_cycle(&targets) else {
+        return Err("expected an initial cycle".into());
+    };
     for _ in 1..100 {
-        let cycle = CycleDetector::find_cycle(&targets).expect("cycle");
-        assert!(
-            cycle == first,
-            "find_cycle returned inconsistent results across runs: \
-             first={first:?}, got={cycle:?}",
-        );
+        let Some(cycle) = CycleDetector::find_cycle(&targets) else {
+            return Err("expected a cycle on every deterministic run".into());
+        };
+        if cycle != first {
+            return Err(format!(
+                "find_cycle returned inconsistent results across runs: \
+                 first={first:?}, got={cycle:?}",
+            ));
+        }
     }
     // Run 100 times; `detect` sorts keys deterministically, so the result must
     // be identical on every invocation.
+    Ok(())
 }
 
 #[test]
@@ -187,20 +192,23 @@ fn canonicalize_cycle_handles_reverse_direction() {
 }
 
 #[test]
-fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
+fn find_cycle_detects_one_of_multiple_disjoint_cycles() -> Result<(), String> {
     let targets = two_disjoint_cycles();
 
-    let cycle = CycleDetector::find_cycle(&targets)
-        .expect("should detect a cycle in a graph with two disjoint cycles");
+    let Some(cycle) = CycleDetector::find_cycle(&targets) else {
+        return Err("should detect a cycle in a graph with two disjoint cycles".into());
+    };
     // Must be exactly one of the two canonical closed cycles.
     let expected_cycles = vec![
         vec![path("p"), path("q"), path("p")],
         vec![path("x"), path("y"), path("x")],
     ];
-    assert!(
-        expected_cycles.contains(&cycle),
-        "Expected one of {expected_cycles:?}, got {cycle:?}",
-    );
+    if !expected_cycles.contains(&cycle) {
+        return Err(format!(
+            "Expected one of {expected_cycles:?}, got {cycle:?}"
+        ));
+    }
+    Ok(())
 }
 
 #[test]

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -1,8 +1,29 @@
+//! Property tests for IR cycle detection.
+//!
+//! Exercises `canonicalize_cycle` normalization and `CycleDetector` graph
+//! traversal, including cycle detection, stack cleanup, and determinism.
+
 use proptest::prelude::*;
 use std::collections::HashMap;
 
-use super::super::{canonicalize_cycle, CycleDetector};
-use super::{build_edge, path};
+use super::{BuildEdge, CycleDetector, canonicalize_cycle};
+
+fn path(name: &str) -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from(name)
+}
+
+fn build_edge(inputs: &[&str], implicit_deps: &[&str], output: &str) -> BuildEdge {
+    BuildEdge {
+        action_id: "id".into(),
+        inputs: inputs.iter().map(|name| path(name)).collect(),
+        implicit_deps: implicit_deps.iter().map(|name| path(name)).collect(),
+        explicit_outputs: vec![path(output)],
+        implicit_outputs: Vec::new(),
+        order_only_deps: Vec::new(),
+        phony: false,
+        always: false,
+    }
+}
 
 /// Generate a non-empty list of distinct single-character node names.
 fn node_names(min: usize, max: usize) -> impl Strategy<Value = Vec<String>> {
@@ -31,7 +52,7 @@ fn check_canonicalize_cycle(input: &[&str], expected: &[&str]) {
 }
 
 proptest! {
-    /// Canonicalisation is idempotent: applying it twice yields the same
+    /// Canonicalization is idempotent: applying it twice yields the same
     /// result as applying it once.
     #[test]
     fn canonicalize_is_idempotent(nodes in node_names(2, 10)) {
@@ -41,9 +62,9 @@ proptest! {
         prop_assert_eq!(once, twice);
     }
 
-    /// All rotations of a cycle canonicalise to the same sequence.
+    /// All rotations of a cycle canonicalize to the same sequence.
     #[test]
-    fn all_rotations_canonicalise_identically(nodes in node_names(2, 8)) {
+    fn all_rotations_canonicalize_identically(nodes in node_names(2, 8)) {
         let base = canonicalize_cycle(make_cycle(&nodes));
         for i in 1..nodes.len() {
             let mut rotated = nodes.clone();
@@ -135,7 +156,10 @@ fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::s
     targets
 }
 
-/// Build a cycle of length `cycle_len` starting at node index 0.
+/// Build a cycle graph from the provided node names, starting at node index 0.
+///
+/// Each node depends on the next name in the slice, and the last node depends
+/// on the first, preserving the input order as the cycle order.
 fn make_cycle_graph(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
     let mut targets = HashMap::new();
     let deps = nodes.iter().cycle().skip(1).take(nodes.len());

--- a/src/ir/cycle_property_tests.rs
+++ b/src/ir/cycle_property_tests.rs
@@ -118,3 +118,74 @@ fn find_cycle_detects_one_of_multiple_disjoint_cycles() {
 
     assert!(CycleDetector::find_cycle(&targets).is_some());
 }
+
+/// Generate a list of `count` distinct node names "n0", "n1", …
+fn sequential_nodes(count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("n{i}")).collect()
+}
+
+/// Build an acyclic chain: n0 → n1 → … → n(count-1) (no back-edges).
+fn make_acyclic_chain(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
+    let mut targets = HashMap::new();
+    for (i, name) in nodes.iter().enumerate() {
+        let inputs: Vec<&str> = if i + 1 < nodes.len() {
+            vec![nodes[i + 1].as_str()]
+        } else {
+            vec![]
+        };
+        targets.insert(path(name), build_edge(&inputs, &[], name));
+    }
+    targets
+}
+
+/// Build a cycle of length `cycle_len` starting at node index 0.
+fn make_cycle_graph(nodes: &[String]) -> HashMap<camino::Utf8PathBuf, super::super::BuildEdge> {
+    let len = nodes.len();
+    let mut targets = HashMap::new();
+    for (i, name) in nodes.iter().enumerate() {
+        let dep = &nodes[(i + 1) % len];
+        targets.insert(path(name), build_edge(&[dep.as_str()], &[], name));
+    }
+    targets
+}
+
+proptest! {
+    /// detect() returns None for acyclic chains and leaves the stack empty.
+    #[test]
+    fn detect_acyclic_graph_leaves_stack_empty(count in 2usize..=8) {
+        let nodes = sequential_nodes(count);
+        let targets = make_acyclic_chain(&nodes);
+        let mut detector = CycleDetector::new(&targets);
+        prop_assert!(detector.detect().is_none());
+        prop_assert!(
+            detector.stack.is_empty(),
+            "stack must be empty after acyclic traversal",
+        );
+    }
+
+    /// detect() returns Some for cyclic graphs and leaves the stack empty.
+    #[test]
+    fn detect_cyclic_graph_leaves_stack_empty(count in 2usize..=8) {
+        let nodes = sequential_nodes(count);
+        let targets = make_cycle_graph(&nodes);
+        let mut detector = CycleDetector::new(&targets);
+        prop_assert!(detector.detect().is_some());
+        prop_assert!(
+            detector.stack.is_empty(),
+            "stack must be empty after cycle detection",
+        );
+    }
+
+    /// detect() is deterministic: all invocations on the same graph return
+    /// the same canonical cycle.
+    #[test]
+    fn detect_is_deterministic_on_cyclic_graphs(count in 2usize..=6) {
+        let nodes = sequential_nodes(count);
+        let targets = make_cycle_graph(&nodes);
+        let first = CycleDetector::find_cycle(&targets);
+        for _ in 1..20 {
+            let next = CycleDetector::find_cycle(&targets);
+            prop_assert_eq!(&first, &next);
+        }
+    }
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Refactors IR cycle detection so traversal is driven through a reusable `CycleDetector::detect()` API with deterministic graph iteration, stronger state cleanup guarantees, and expanded test coverage.

## Functional Changes

- `analyse()` now delegates cycle discovery to `CycleDetector::detect()` instead of manually iterating target keys.
- Cycle detection now visits target nodes in sorted order, making the “first” reported cycle deterministic across runs regardless of `HashMap` iteration order.
- `CycleDetector::detect()` resets traversal state before each run, allowing repeated calls on the same detector to produce consistent results.
- DFS traversal now ensures the recursion stack is unwound even when a cycle is found, preventing stale stack state after early cycle detection.
- Cycle traversal now works with borrowed `Utf8Path` references internally while still storing owned paths in traversal state and reports.
- Missing dependencies are still collected as `(dependent, missing_dep)` pairs before the first detected cycle, and are now also emitted as debug-level tracing events.
- `canonicalize_cycle()` was simplified to remove the duplicate closing node before rotation, then re-close the cycle after rotating to the lexicographically smallest node.

## Tests

- Adds property-based tests for cycle canonicalization:
  - idempotency
  - rotation invariance
  - smallest-node-first ordering
  - closed-cycle output
- Adds property-based and targeted tests for detector behavior:
  - deterministic cycle detection
  - repeated `detect()` calls reset state
  - acyclic graphs return `None`
  - cyclic graphs return `Some`
  - stack is empty after both acyclic traversal and cycle detection
  - missing dependencies are reported before a later detected cycle
  - multiple disjoint cycles produce a valid canonical cycle

## Documentation

- Adds an IR cycle detection section to the developers guide describing:
  - `analyse()` as the entry point
  - `CycleDetectionReport`
  - `CycleDetector::new()` and `CycleDetector::detect()`
  - canonical cycle normalization
- Updates the design document to describe the new `detect` API.
- Normalizes several documentation spellings from British to US English, such as “serialisation” → “serialization” and “canonicalisation” → “canonicalization.”
<!-- kody-pr-summary:end -->