### PR TITLE
Add template library path filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "clap",
  "clap_mangen",
  "cucumber",
+ "digest",
  "glob",
  "insta",
  "itertools 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1033,7 @@ dependencies = [
  "insta",
  "itertools 0.12.1",
  "itoa",
+ "md-5",
  "miette",
  "minijinja",
  "mockable",
@@ -1036,6 +1047,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "serde_yml",
  "serial_test",
+ "sha1",
  "sha2",
  "shell-quote",
  "shlex",
@@ -1564,6 +1576,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1"
 miette = { version = "7.6.0", features = ["fancy"] }
 sha2 = "0.10"
 sha1 = "0.10"
-md-5 = "0.10"
+md5 = { package = "md-5", version = "0.10" }
 itoa = "1"
 itertools = "0.12"
 glob = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ anyhow = "1"
 thiserror = "1"
 miette = { version = "7.6.0", features = ["fancy"] }
 sha2 = "0.10"
+sha1 = "0.10"
+md-5 = "0.10"
 itoa = "1"
 itertools = "0.12"
 glob = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ include = [
 ]
 license = "ISC"
 
+[features]
+default = []
+legacy-digests = ["sha1", "md5"]
+
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
@@ -23,9 +27,10 @@ semver = { version = "1", features = ["serde"] }
 anyhow = "1"
 thiserror = "1"
 miette = { version = "7.6.0", features = ["fancy"] }
+digest = "0.10"
 sha2 = "0.10"
-sha1 = "0.10"
-md5 = { package = "md-5", version = "0.10" }
+sha1 = { version = "0.10", optional = true }
+md5 = { package = "md-5", version = "0.10", optional = true }
 itoa = "1"
 itertools = "0.12"
 glob = "0.3.3"

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -875,7 +875,13 @@ Implementation notes:
   entry so results are absolute and symlink-free.
 - `contents` and `linecount` currently support UTF-8 input; other encodings are
   rejected with an explicit error.
-- `hash` and `digest` accept `sha256` (default), `sha512`, `sha1`, and `md5`.
+- `hash` and `digest` accept `sha256` (default) and `sha512`. Legacy
+  algorithms `sha1` and `md5` are cryptographically broken and are disabled by
+  default; enabling them requires the `legacy-digests` Cargo feature and should
+  only be done for compatibility with existing ecosystems.
+- `expanduser` mirrors shell semantics by requiring either `HOME` or
+  `USERPROFILE`. Platform-specific forms such as `~user` or UNC paths are not
+  expanded automatically.
 - `with_suffix` removes dotted suffix segments (default `n = 1`) before
   appending the provided suffix.
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -867,6 +867,18 @@ All built-in filters use `snake_case`. The `camel_case` helper is provided in
 place of `camelCase` so naming remains consistent with `snake_case` and
 `kebab-case`.
 
+Implementation notes:
+
+- Filters use `cap-std` directories for all filesystem work, avoiding ambient
+  authority.
+- `realpath` canonicalises the parent directory before joining the resolved
+  entry so results are absolute and symlink-free.
+- `contents` and `linecount` currently support UTF-8 input; other encodings are
+  rejected with an explicit error.
+- `hash` and `digest` accept `sha256` (default), `sha512`, `sha1`, and `md5`.
+- `with_suffix` removes dotted suffix segments (default `n = 1`) before
+  appending the provided suffix.
+
 #### Generic collection filters
 
 | Filter                            | Purpose                                      |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -159,7 +159,7 @@ library, and CLI ergonomics.
   - [x] Implement the basic file-system tests (`dir`, `file`, `symlink`,
     `pipe`, `block_device`, `char_device`, legacy `device`). *(done)*
 
-  - [ ] Implement the path and file filters (basename, dirname, with_suffix,
+  - [x] Implement the path and file filters (basename, dirname, with_suffix,
     realpath, contents, hash, etc.).
 
   - [ ] Implement the generic collection filters (`uniq`, `flatten`,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,4 +1,4 @@
-//! File-system helpers for Jinja templates.
+//! File-system helpers for `MiniJinja` templates.
 //!
 //! Registers platform-aware file tests and a suite of path and file filters.
 //! Tests such as `dir`, `file`, and `symlink` inspect metadata without
@@ -17,7 +17,7 @@ use std::{env, fmt::Write as FmtWrite, io};
 
 type FileTest = (&'static str, fn(fs::FileType) -> bool);
 
-/// Register standard library helpers with the Jinja environment.
+/// Register standard library helpers with the `MiniJinja` environment.
 ///
 /// # Examples
 /// ```
@@ -252,14 +252,10 @@ fn with_suffix(
             stem.truncate(idx);
             removed += 1;
         } else {
-            stem.clear();
             break;
         }
     }
     stem.push_str(suffix);
-    if stem.is_empty() {
-        return Ok(base);
-    }
     let replacement = Utf8PathBuf::from(stem);
     base.push(&replacement);
     Ok(base)

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -445,6 +445,24 @@ fn io_to_error(path: &Utf8Path, action: &str, err: io::Error) -> Error {
             Cow::Borrowed("unexpected end of file"),
         ),
         IoErrorKind::BrokenPipe => (ErrorKind::InvalidOperation, Cow::Borrowed("broken pipe")),
+        IoErrorKind::ConnectionRefused => (
+            ErrorKind::InvalidOperation,
+            Cow::Borrowed("connection refused"),
+        ),
+        IoErrorKind::ConnectionReset => (
+            ErrorKind::InvalidOperation,
+            Cow::Borrowed("connection reset"),
+        ),
+        IoErrorKind::ConnectionAborted => (
+            ErrorKind::InvalidOperation,
+            Cow::Borrowed("connection aborted"),
+        ),
+        IoErrorKind::NotConnected => (ErrorKind::InvalidOperation, Cow::Borrowed("not connected")),
+        IoErrorKind::AddrInUse => (ErrorKind::InvalidOperation, Cow::Borrowed("address in use")),
+        IoErrorKind::AddrNotAvailable => (
+            ErrorKind::InvalidOperation,
+            Cow::Borrowed("address not available"),
+        ),
         _ => (ErrorKind::InvalidOperation, Cow::Owned(err.to_string())),
     };
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -276,12 +276,16 @@ fn relative_to(path: &Utf8Path, root: &Utf8Path) -> Result<String, Error> {
         })
 }
 
+fn is_user_specific_expansion(stripped: &str) -> bool {
+    matches!(
+        stripped.chars().next(),
+        Some(first) if first != '/' && first != std::path::MAIN_SEPARATOR
+    )
+}
+
 fn expanduser(raw: &str) -> Result<String, Error> {
     if let Some(stripped) = raw.strip_prefix("~") {
-        if let Some(first) = stripped.chars().next()
-            && first != '/'
-            && first != std::path::MAIN_SEPARATOR
-        {
+        if is_user_specific_expansion(stripped) {
             return Err(Error::new(
                 ErrorKind::InvalidOperation,
                 "user-specific ~ expansion is unsupported",

--- a/tests/std_filter_tests.rs
+++ b/tests/std_filter_tests.rs
@@ -1,0 +1,145 @@
+use camino::Utf8PathBuf;
+use cap_std::{ambient_authority, fs_utf8::Dir};
+use minijinja::{Environment, context};
+use netsuke::stdlib;
+use rstest::{fixture, rstest};
+use tempfile::tempdir;
+use test_support::{EnvVarGuard, env_lock::EnvLock};
+
+#[fixture]
+fn filter_workspace() -> (tempfile::TempDir, Utf8PathBuf) {
+    let temp = tempdir().expect("tempdir");
+    let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).expect("utf8");
+    let dir = Dir::open_ambient_dir(&root, ambient_authority()).expect("dir");
+    dir.write("file", b"data").expect("file");
+    dir.symlink("file", "link").expect("symlink");
+    dir.write("lines.txt", b"one\ntwo\nthree\n").expect("lines");
+    (temp, root)
+}
+
+fn render<'a>(
+    env: &mut Environment<'a>,
+    name: &'a str,
+    template: &'a str,
+    path: &Utf8PathBuf,
+) -> String {
+    env.add_template(name, template).expect("template");
+    env.get_template(name)
+        .expect("get template")
+        .render(context!(path => path.as_str()))
+        .expect("render")
+}
+
+#[rstest]
+fn basename_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file");
+    let output = render(&mut env, "basename", "{{ path | basename }}", &file);
+    assert_eq!(output, "file");
+}
+
+#[rstest]
+fn dirname_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file");
+    let output = render(&mut env, "dirname", "{{ path | dirname }}", &file);
+    assert_eq!(output, root.as_str());
+}
+
+#[rstest]
+fn with_suffix_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file.tar.gz");
+    Dir::open_ambient_dir(&root, ambient_authority())
+        .expect("dir")
+        .write("file.tar.gz", b"data")
+        .expect("write");
+    let first = render(
+        &mut env,
+        "suffix",
+        "{{ path | with_suffix('.log') }}",
+        &file,
+    );
+    assert_eq!(first, root.join("file.tar.log").as_str());
+    let second = render(
+        &mut env,
+        "suffix_alt",
+        "{{ path | with_suffix('.zip', 2) }}",
+        &file,
+    );
+    assert_eq!(second, root.join("file.zip").as_str());
+}
+
+#[rstest]
+fn realpath_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let link = root.join("link");
+    let output = render(&mut env, "realpath", "{{ path | realpath }}", &link);
+    assert_eq!(output, root.join("file").as_str());
+}
+
+#[rstest]
+fn contents_and_linecount_filters(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file");
+    let text = render(&mut env, "contents", "{{ path | contents }}", &file);
+    assert_eq!(text, "data");
+    let lines = render(
+        &mut env,
+        "linecount",
+        "{{ path | linecount }}",
+        &root.join("lines.txt"),
+    );
+    assert_eq!(lines.parse::<usize>().expect("usize"), 3);
+}
+
+#[rstest]
+fn hash_and_digest_filters(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file");
+    let hash = render(&mut env, "hash", "{{ path | hash }}", &file);
+    assert_eq!(
+        hash,
+        "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7"
+    );
+    let digest = render(&mut env, "digest", "{{ path | digest(8) }}", &file);
+    assert_eq!(digest, "3a6eb079");
+}
+
+#[rstest]
+fn size_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let file = root.join("file");
+    let size = render(&mut env, "size", "{{ path | size }}", &file);
+    assert_eq!(size.parse::<u64>().expect("u64"), 4);
+}
+
+#[rstest]
+fn expanduser_filter(filter_workspace: (tempfile::TempDir, Utf8PathBuf)) {
+    let (_temp, root) = filter_workspace;
+    let mut env = Environment::new();
+    stdlib::register(&mut env);
+    let _lock = EnvLock::acquire();
+    let _guard = EnvVarGuard::set("HOME", root.as_str());
+    let home = render(
+        &mut env,
+        "expanduser",
+        "{{ path | expanduser }}",
+        &Utf8PathBuf::from("~/workspace"),
+    );
+    assert_eq!(home, root.join("workspace").as_str());
+}


### PR DESCRIPTION
## Summary
- implement path and file filters in the Minijinja stdlib, including hashing and expanduser support
- add rstest coverage for the new filters and document the design updates
- wire in sha1/md5 dependencies for hashing

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d2546001688322ab61db963c05f88d

## Summary by Sourcery

Enhance the Minijinja standard library by refactoring filesystem helpers, registering both file-type tests and comprehensive path/file filters (including hashing, expanduser, and realpath), and bolstering documentation and test coverage

New Features:
- Add path filters (basename, dirname, with_suffix, relative_to, realpath, expanduser, size, contents, linecount, hash, digest) to the Minijinja stdlib
- Register platform‐aware file‐type tests (dir, file, symlink, pipe, block_device, char_device, device) in a dedicated setup function

Enhancements:
- Refactor filesystem helpers to use cap-std and camino for metadata and canonicalization
- Introduce unified error handling and helper routines for path operations
- Support multiple hashing algorithms (sha256 default, sha512, sha1, md5) for content hashing and digest

Build:
- Add sha1 and md5 dependencies to Cargo.toml

Documentation:
- Update netsuke-design with implementation notes for new filters
- Mark path and file filters as completed in the roadmap

Tests:
- Add rstest‐based integration tests covering all new path and file filters