### PR TITLE
Refactor runner process helpers into dedicated module

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1606,6 +1606,11 @@ before spawning Ninja rather than forwarding the flag. Error scenarios are
 validated using clap's `ErrorKind` enumeration in unit tests and via Cucumber
 steps for behavioural coverage.
 
+The Ninja executable may be overridden via the `NINJA_ENV` environment
+variable. For example, `NINJA_ENV=/opt/ninja/bin/ninja netsuke build` forces
+Netsuke to execute the specified binary while preserving the default when the
+variable is unset or invalid.
+
 ### 8.5 Manual Pages
 
 The CLI definition doubles as the source for user documentation. A build script

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1598,10 +1598,13 @@ The CLI is implemented using clap's derive API in `src/cli.rs`. Clap's
 `default_value_t` attribute marks `Build` as the default subcommand, so
 invoking `netsuke` with no explicit command still triggers a build. CLI
 execution and dispatch live in `src/runner.rs`, keeping `main.rs` focused on
-parsing. The working directory flag mirrors Ninja's `-C` option but is resolved
-internally; Netsuke changes directory before spawning Ninja rather than
-forwarding the flag. Error scenarios are validated using clap's `ErrorKind`
-enumeration in unit tests and via Cucumber steps for behavioural coverage.
+parsing. Process management, Ninja invocation, argument redaction, and the
+temporary file helpers reside in `src/runner/process.rs`, allowing the runner
+entry point to delegate low-level concerns. The working directory flag mirrors
+Ninja's `-C` option but is resolved internally; Netsuke changes directory before
+spawning Ninja rather than forwarding the flag. Error scenarios are validated
+using clap's `ErrorKind` enumeration in unit tests and via Cucumber steps for
+behavioural coverage.
 
 ### 8.5 Manual Pages
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1601,10 +1601,10 @@ execution and dispatch live in `src/runner.rs`, keeping `main.rs` focused on
 parsing. Process management, Ninja invocation, argument redaction, and the
 temporary file helpers reside in `src/runner/process.rs`, allowing the runner
 entry point to delegate low-level concerns. The working directory flag mirrors
-Ninja's `-C` option but is resolved internally; Netsuke changes directory before
-spawning Ninja rather than forwarding the flag. Error scenarios are validated
-using clap's `ErrorKind` enumeration in unit tests and via Cucumber steps for
-behavioural coverage.
+Ninja's `-C` option but is resolved internally; Netsuke changes directory
+before spawning Ninja rather than forwarding the flag. Error scenarios are
+validated using clap's `ErrorKind` enumeration in unit tests and via Cucumber
+steps for behavioural coverage.
 
 ### 8.5 Manual Pages
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7,7 +7,6 @@
 use crate::cli::{BuildArgs, Cli, Commands};
 use crate::{ir::BuildGraph, manifest, ninja_gen};
 use anyhow::{Context, Result};
-use serde_json;
 use std::borrow::Cow;
 use std::path::Path;
 use tempfile::NamedTempFile;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -18,7 +18,7 @@ pub const NINJA_PROGRAM: &str = "ninja";
 pub use ninja_env::NINJA_ENV;
 
 mod process;
-#[cfg(any(test, doctest))]
+#[cfg(doctest)]
 pub use process::doc;
 pub use process::run_ninja;
 

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -27,7 +27,7 @@ impl CommandArg {
 
 // Public helpers for doctests only. This exposes internal helpers as a stable
 // testing surface without exporting them in release builds.
-#[doc(hidden)]
+#[cfg(any(test, doctest))]
 pub mod doc {
     pub use super::{
         CommandArg, contains_sensitive_keyword, create_temp_ninja_file, is_sensitive_arg,

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -59,7 +59,8 @@ fn is_sensitive_key(key: &str) -> bool {
 /// Check if `arg` contains a sensitive keyword.
 ///
 /// # Examples
-/// ```ignore
+/// ```
+/// # #[cfg(doctest)]
 /// # use netsuke::runner::doc::{CommandArg, contains_sensitive_keyword};
 /// assert!(contains_sensitive_keyword(&CommandArg::new("token=abc".into())));
 /// assert!(!contains_sensitive_keyword(&CommandArg::new("path=/tmp".into())));
@@ -74,7 +75,8 @@ pub fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
 /// Determine whether the argument should be redacted.
 ///
 /// # Examples
-/// ```ignore
+/// ```
+/// # #[cfg(doctest)]
 /// # use netsuke::runner::doc::{CommandArg, is_sensitive_arg};
 /// assert!(is_sensitive_arg(&CommandArg::new("password=123".into())));
 /// assert!(!is_sensitive_arg(&CommandArg::new("file=readme".into())));
@@ -89,7 +91,8 @@ pub fn is_sensitive_arg(arg: &CommandArg) -> bool {
 /// Sensitive values are replaced with `***REDACTED***`, preserving keys.
 ///
 /// # Examples
-/// ```ignore
+/// ```
+/// # #[cfg(doctest)]
 /// # use netsuke::runner::doc::{CommandArg, redact_argument};
 /// let arg = CommandArg::new("token=abc".into());
 /// assert_eq!(redact_argument(&arg).as_str(), "token=***REDACTED***");
@@ -132,7 +135,8 @@ pub fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
 /// Returns an error if the file cannot be created or written.
 ///
 /// # Examples
-/// ```ignore
+/// ```
+/// # #[cfg(doctest)]
 /// use netsuke::runner::doc::create_temp_ninja_file;
 /// use netsuke::runner::NinjaContent;
 /// let tmp = create_temp_ninja_file(&NinjaContent::new("".into())).unwrap();

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -1,3 +1,5 @@
+//! Process helpers for Ninja file lifecycle, argument redaction, and subprocess I/O.
+//! Internal to `runner`; public API is defined in `runner.rs`.
 use super::{BuildTargets, NINJA_PROGRAM, NinjaContent};
 use crate::cli::Cli;
 use anyhow::{Context, Result as AnyResult, anyhow};

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -354,7 +354,7 @@ fn canonicalize_utf8_path(path: &Path) -> io::Result<Utf8PathBuf> {
     }
 
     if utf8.parent().is_none() && utf8.file_name().is_none() {
-        return canonicalize_root_path(utf8);
+        return Ok(canonicalize_root_path(utf8));
     }
 
     if utf8.is_relative() {
@@ -370,8 +370,8 @@ fn canonicalize_current_dir() -> io::Result<Utf8PathBuf> {
     convert_path_to_utf8(resolved, Utf8Path::new("."))
 }
 
-fn canonicalize_root_path(utf8: &Utf8Path) -> io::Result<Utf8PathBuf> {
-    Ok(utf8.to_path_buf())
+fn canonicalize_root_path(utf8: &Utf8Path) -> Utf8PathBuf {
+    utf8.to_path_buf()
 }
 
 fn canonicalize_relative_path(utf8: &Utf8Path) -> io::Result<Utf8PathBuf> {

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -114,7 +114,8 @@ pub fn redact_argument(arg: &CommandArg) -> CommandArg {
 /// Redact sensitive information from all `args`.
 ///
 /// # Examples
-/// ```ignore
+/// ```
+/// # #[cfg(doctest)]
 /// # use netsuke::runner::doc::{CommandArg, redact_sensitive_args};
 /// let args = vec![
 ///     CommandArg::new("ninja".into()),
@@ -148,13 +149,14 @@ pub fn create_temp_ninja_file(content: &NinjaContent) -> AnyResult<NamedTempFile
         .suffix(".ninja")
         .tempfile()
         .context("create temp file")?;
-    tmp.as_file_mut()
-        .write_all(content.as_str().as_bytes())
-        .context("write temp Ninja file")?;
-    tmp.as_file_mut().flush().context("flush temp Ninja file")?;
-    tmp.as_file_mut()
-        .sync_all()
-        .context("sync temp Ninja file")?;
+    {
+        let handle = tmp.as_file_mut();
+        handle
+            .write_all(content.as_str().as_bytes())
+            .context("write temp ninja file")?;
+        handle.flush().context("flush temp ninja file")?;
+        handle.sync_all().context("sync temp ninja file")?;
+    }
     info!("Generated temporary Ninja file at {}", tmp.path().display());
     Ok(tmp)
 }
@@ -215,7 +217,7 @@ fn derive_dir_and_relative(path: &Utf8Path) -> AnyResult<(cap_fs::Dir, Utf8PathB
 /// Returns an error if the file cannot be written.
 ///
 /// # Examples
-/// ```ignore
+/// ```
 /// use std::path::Path;
 /// use netsuke::runner::doc::write_ninja_file;
 /// use netsuke::runner::NinjaContent;

--- a/src/runner/process.rs
+++ b/src/runner/process.rs
@@ -31,7 +31,7 @@ impl CommandArg {
 
 // Public helpers for doctests only. This exposes internal helpers as a stable
 // testing surface without exporting them in release builds.
-#[cfg(any(test, doctest))]
+#[cfg(doctest)]
 pub mod doc {
     pub use super::{
         CommandArg, contains_sensitive_keyword, create_temp_ninja_file, is_sensitive_arg,
@@ -58,7 +58,7 @@ fn is_sensitive_key(key: &str) -> bool {
 /// Check if `arg` contains a sensitive keyword.
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// # use netsuke::runner::doc::{CommandArg, contains_sensitive_keyword};
 /// assert!(contains_sensitive_keyword(&CommandArg::new("token=abc".into())));
 /// assert!(!contains_sensitive_keyword(&CommandArg::new("path=/tmp".into())));
@@ -73,7 +73,7 @@ pub fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
 /// Determine whether the argument should be redacted.
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// # use netsuke::runner::doc::{CommandArg, is_sensitive_arg};
 /// assert!(is_sensitive_arg(&CommandArg::new("password=123".into())));
 /// assert!(!is_sensitive_arg(&CommandArg::new("file=readme".into())));
@@ -88,7 +88,7 @@ pub fn is_sensitive_arg(arg: &CommandArg) -> bool {
 /// Sensitive values are replaced with `***REDACTED***`, preserving keys.
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// # use netsuke::runner::doc::{CommandArg, redact_argument};
 /// let arg = CommandArg::new("token=abc".into());
 /// assert_eq!(redact_argument(&arg).as_str(), "token=***REDACTED***");
@@ -110,7 +110,7 @@ pub fn redact_argument(arg: &CommandArg) -> CommandArg {
 /// Redact sensitive information from all `args`.
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// # use netsuke::runner::doc::{CommandArg, redact_sensitive_args};
 /// let args = vec![
 ///     CommandArg::new("ninja".into()),

--- a/src/runner/process/file_io.rs
+++ b/src/runner/process/file_io.rs
@@ -1,0 +1,146 @@
+//! File creation helpers for the Ninja runner.
+//! Handles temporary build files and writes to capability-based directories.
+
+use crate::runner::NinjaContent;
+use anyhow::{Context, Result as AnyResult, anyhow};
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std::{ambient_authority, fs as cap_fs};
+use std::io::Write;
+use std::path::Path;
+use tempfile::{Builder, NamedTempFile};
+use tracing::info;
+
+pub fn create_temp_ninja_file(content: &NinjaContent) -> AnyResult<NamedTempFile> {
+    let mut tmp = Builder::new()
+        .prefix("netsuke.")
+        .suffix(".ninja")
+        .tempfile()
+        .context("create temp file")?;
+    {
+        let handle = tmp.as_file_mut();
+        handle
+            .write_all(content.as_str().as_bytes())
+            .context("write temp ninja file")?;
+        handle.flush().context("flush temp ninja file")?;
+        handle.sync_all().context("sync temp ninja file")?;
+    }
+    info!("Generated temporary Ninja file at {}", tmp.path().display());
+    Ok(tmp)
+}
+
+pub fn write_ninja_file_utf8(
+    dir: &cap_fs::Dir,
+    path: &Utf8Path,
+    content: &NinjaContent,
+) -> AnyResult<()> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_str().is_empty()) {
+        dir.create_dir_all(parent.as_str())
+            .with_context(|| format!("failed to create parent directory {parent}"))?;
+    }
+    let mut file = dir
+        .create(path.as_str())
+        .with_context(|| format!("failed to create Ninja file at {path}"))?;
+    file.write_all(content.as_str().as_bytes())
+        .with_context(|| format!("failed to write Ninja file to {path}"))?;
+    file.flush()
+        .with_context(|| format!("failed to flush Ninja file at {path}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync Ninja file at {path}"))?;
+    Ok(())
+}
+
+fn derive_dir_and_relative(path: &Utf8Path) -> AnyResult<(cap_fs::Dir, Utf8PathBuf)> {
+    if path.is_relative() {
+        let dir = cap_fs::Dir::open_ambient_dir(".", ambient_authority())
+            .context("open ambient directory")?;
+        return Ok((dir, path.to_owned()));
+    }
+
+    let mut ancestors = path.ancestors();
+    ancestors.next();
+    let (base, dir) = ancestors
+        .find_map(|candidate| {
+            cap_fs::Dir::open_ambient_dir(candidate.as_str(), ambient_authority())
+                .ok()
+                .map(|dir| (candidate.to_owned(), dir))
+        })
+        .ok_or_else(|| anyhow!("no existing ancestor for {path}"))?;
+    let relative = path
+        .strip_prefix(&base)
+        .context("derive relative Ninja path")?
+        .to_owned();
+    Ok((dir, relative))
+}
+
+pub fn write_ninja_file(path: &Path, content: &NinjaContent) -> AnyResult<()> {
+    let utf8_path =
+        Utf8Path::from_path(path).ok_or_else(|| anyhow!("non-UTF-8 path is not supported"))?;
+    let (dir, relative) = derive_dir_and_relative(utf8_path)?;
+    write_ninja_file_utf8(&dir, &relative, content)?;
+    info!("Generated Ninja file at {utf8_path}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::NinjaContent;
+    use camino::Utf8PathBuf;
+    use cap_std::{ambient_authority, fs as cap_fs};
+    use std::io::{Read, Seek, SeekFrom};
+
+    #[test]
+    fn create_temp_ninja_file_supports_reopen() {
+        let content = NinjaContent::new(String::from("rule cc"));
+        let file = create_temp_ninja_file(&content).expect("create temp file");
+
+        let mut reopened = file.reopen().expect("reopen temp file");
+        let mut written = String::new();
+        reopened
+            .read_to_string(&mut written)
+            .expect("read reopened temp file");
+        assert_eq!(written, content.as_str());
+
+        let metadata = std::fs::metadata(file.path()).expect("query temp file metadata");
+        assert_eq!(metadata.len(), content.as_str().len() as u64);
+        assert!(file.path().to_string_lossy().ends_with(".ninja"));
+
+        reopened
+            .seek(SeekFrom::Start(0))
+            .expect("rewind reopened temp file");
+        written.clear();
+        reopened
+            .read_to_string(&mut written)
+            .expect("re-read reopened temp file");
+        assert_eq!(written, content.as_str());
+    }
+
+    #[test]
+    fn write_ninja_file_utf8_creates_parent_directories() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let dir =
+            cap_fs::Dir::open_ambient_dir(temp.path(), ambient_authority()).expect("open temp dir");
+        let nested = Utf8PathBuf::from("nested/build.ninja");
+        let content = NinjaContent::new(String::from("build all: phony"));
+
+        write_ninja_file_utf8(&dir, &nested, &content).expect("write ninja file");
+
+        let nested_path = temp.path().join("nested").join("build.ninja");
+        let written = std::fs::read_to_string(&nested_path).expect("read nested file");
+        assert_eq!(written, content.as_str());
+        assert!(nested_path.parent().expect("parent path").exists());
+    }
+
+    #[test]
+    fn write_ninja_file_handles_absolute_paths() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let nested = temp.path().join("nested").join("build.ninja");
+        let content = NinjaContent::new(String::from("build all: phony"));
+
+        write_ninja_file(&nested, &content).expect("write ninja file");
+
+        let written = std::fs::read_to_string(&nested).expect("read nested file");
+        assert_eq!(written, content.as_str());
+        assert!(nested.parent().expect("parent path").exists());
+    }
+}

--- a/src/runner/process/paths.rs
+++ b/src/runner/process/paths.rs
@@ -1,0 +1,70 @@
+//! Path resolution helpers for the Ninja runner.
+//! Canonicalises UTF-8 paths via capability-based handles.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std::{ambient_authority, fs as cap_fs};
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+
+pub fn canonicalize_utf8_path(path: &Path) -> io::Result<Utf8PathBuf> {
+    let utf8 = Utf8Path::from_path(path).ok_or_else(|| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            format!("path {} is not valid UTF-8", path.display()),
+        )
+    })?;
+
+    if utf8.as_str().is_empty() || utf8 == Utf8Path::new(".") {
+        return canonicalize_current_dir();
+    }
+
+    if utf8.parent().is_none() && utf8.file_name().is_none() {
+        return Ok(canonicalize_root_path(utf8));
+    }
+
+    if utf8.is_relative() {
+        return canonicalize_relative_path(utf8);
+    }
+
+    canonicalize_absolute_path(utf8)
+}
+
+fn canonicalize_current_dir() -> io::Result<Utf8PathBuf> {
+    let dir = cap_fs::Dir::open_ambient_dir(".", ambient_authority())?;
+    let resolved = dir.canonicalize(Path::new("."))?;
+    convert_path_to_utf8(resolved, Utf8Path::new("."))
+}
+
+fn canonicalize_root_path(utf8: &Utf8Path) -> Utf8PathBuf {
+    utf8.to_path_buf()
+}
+
+fn canonicalize_relative_path(utf8: &Utf8Path) -> io::Result<Utf8PathBuf> {
+    let dir = cap_fs::Dir::open_ambient_dir(".", ambient_authority())?;
+    let resolved = dir.canonicalize(utf8.as_std_path())?;
+    convert_path_to_utf8(resolved, utf8)
+}
+
+fn canonicalize_absolute_path(utf8: &Utf8Path) -> io::Result<Utf8PathBuf> {
+    let parent = utf8.parent().unwrap_or_else(|| Utf8Path::new("/"));
+    let handle = cap_fs::Dir::open_ambient_dir(parent.as_std_path(), ambient_authority())?;
+    let relative = utf8.strip_prefix(parent).unwrap_or(utf8);
+    let resolved = handle.canonicalize(relative.as_std_path())?;
+    let canonical = convert_path_to_utf8(resolved, relative)?;
+    if canonical.is_absolute() {
+        Ok(canonical)
+    } else {
+        let mut absolute = parent.to_path_buf();
+        absolute.push(&canonical);
+        Ok(absolute)
+    }
+}
+
+fn convert_path_to_utf8(buf: PathBuf, reference: &Utf8Path) -> io::Result<Utf8PathBuf> {
+    Utf8PathBuf::from_path_buf(buf).map_err(|_| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            format!("canonical path for {reference} is not valid UTF-8"),
+        )
+    })
+}

--- a/src/runner/process/redaction.rs
+++ b/src/runner/process/redaction.rs
@@ -1,0 +1,135 @@
+//! Argument redaction helpers for the Ninja runner.
+//! Provides the `CommandArg` wrapper used by doctests and logging.
+
+#[derive(Debug, Clone)]
+pub struct CommandArg(String);
+impl CommandArg {
+    #[must_use]
+    pub fn new(arg: String) -> Self {
+        Self(arg)
+    }
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    const SENSITIVE_KEYS: [&str; 7] = [
+        "password",
+        "token",
+        "secret",
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+    ];
+    SENSITIVE_KEYS
+        .iter()
+        .any(|candidate| key.eq_ignore_ascii_case(candidate))
+}
+
+/// Check if `arg` contains a sensitive keyword.
+///
+/// # Examples
+/// ```
+/// # #[cfg(doctest)]
+/// # use netsuke::runner::doc::{CommandArg, contains_sensitive_keyword};
+/// assert!(contains_sensitive_keyword(&CommandArg::new("token=abc".into())));
+/// assert!(!contains_sensitive_keyword(&CommandArg::new("path=/tmp".into())));
+/// ```
+#[must_use]
+pub fn contains_sensitive_keyword(arg: &CommandArg) -> bool {
+    arg.as_str()
+        .split_once('=')
+        .is_some_and(|(key, _)| is_sensitive_key(key.trim()))
+}
+
+/// Determine whether the argument should be redacted.
+///
+/// # Examples
+/// ```
+/// # #[cfg(doctest)]
+/// # use netsuke::runner::doc::{CommandArg, is_sensitive_arg};
+/// assert!(is_sensitive_arg(&CommandArg::new("password=123".into())));
+/// assert!(!is_sensitive_arg(&CommandArg::new("file=readme".into())));
+/// ```
+#[must_use]
+pub fn is_sensitive_arg(arg: &CommandArg) -> bool {
+    contains_sensitive_keyword(arg)
+}
+
+/// Redact sensitive information in a single argument.
+///
+/// Sensitive values are replaced with `***REDACTED***`, preserving keys.
+///
+/// # Examples
+/// ```
+/// # #[cfg(doctest)]
+/// # use netsuke::runner::doc::{CommandArg, redact_argument};
+/// let arg = CommandArg::new("token=abc".into());
+/// assert_eq!(redact_argument(&arg).as_str(), "token=***REDACTED***");
+/// let arg = CommandArg::new("path=/tmp".into());
+/// assert_eq!(redact_argument(&arg).as_str(), "path=/tmp");
+/// ```
+#[must_use]
+pub fn redact_argument(arg: &CommandArg) -> CommandArg {
+    if is_sensitive_arg(arg) {
+        if let Some((key, _)) = arg.as_str().split_once('=') {
+            let trimmed = key.trim();
+            return CommandArg::new(format!("{trimmed}=***REDACTED***"));
+        }
+        return CommandArg::new(String::from("***REDACTED***"));
+    }
+    arg.clone()
+}
+
+/// Redact sensitive information from all `args`.
+///
+/// # Examples
+/// ```
+/// # #[cfg(doctest)]
+/// # use netsuke::runner::doc::{CommandArg, redact_sensitive_args};
+/// let args = vec![
+///     CommandArg::new("ninja".into()),
+///     CommandArg::new("token=abc".into()),
+/// ];
+/// let redacted = redact_sensitive_args(&args);
+/// assert_eq!(redacted[1].as_str(), "token=***REDACTED***");
+/// ```
+#[must_use]
+pub fn redact_sensitive_args(args: &[CommandArg]) -> Vec<CommandArg> {
+    args.iter().map(redact_argument).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_sensitive_keyword_only_flags_known_keys() {
+        let token = CommandArg::new(String::from("token=abc"));
+        assert!(contains_sensitive_keyword(&token));
+
+        let positional = CommandArg::new(String::from("secrets.yml"));
+        assert!(!contains_sensitive_keyword(&positional));
+
+        let path_arg = CommandArg::new(String::from("path=/tmp/secrets.yml"));
+        assert!(!contains_sensitive_keyword(&path_arg));
+
+        let spaced = CommandArg::new(String::from("  PASSWORD = value "));
+        assert!(contains_sensitive_keyword(&spaced));
+    }
+
+    #[test]
+    fn redact_argument_preserves_non_sensitive_pairs() {
+        let redacted = redact_argument(&CommandArg::new(String::from("auth = token123")));
+        assert_eq!(redacted.as_str(), "auth=***REDACTED***");
+
+        let untouched = redact_argument(&CommandArg::new(String::from("path=/var/secrets")));
+        assert_eq!(untouched.as_str(), "path=/var/secrets");
+
+        let positional = redact_argument(&CommandArg::new(String::from("secret")));
+        assert_eq!(positional.as_str(), "secret");
+    }
+}

--- a/tests/runner_tests.rs
+++ b/tests/runner_tests.rs
@@ -1,5 +1,5 @@
 use netsuke::cli::{BuildArgs, Cli, Commands};
-use netsuke::runner::{BuildTargets, NinjaContent, doc, run, run_ninja};
+use netsuke::runner::{BuildTargets, run, run_ninja};
 use rstest::{fixture, rstest};
 use serial_test::serial;
 use std::path::{Path, PathBuf};
@@ -49,29 +49,6 @@ fn test_manifest() -> (tempfile::TempDir, PathBuf) {
     let manifest_path = temp.path().join("Netsukefile");
     std::fs::copy("tests/data/minimal.yml", &manifest_path).expect("copy manifest");
     (temp, manifest_path)
-}
-
-#[test]
-fn create_temp_ninja_file_writes_contents() {
-    let content = NinjaContent::new(String::from("rule cc"));
-    let file = doc::create_temp_ninja_file(&content).expect("create temp file");
-
-    let written = std::fs::read_to_string(file.path()).expect("read temp file");
-    assert_eq!(written, content.as_str());
-    assert!(file.path().to_string_lossy().ends_with(".ninja"));
-}
-
-#[test]
-fn write_ninja_file_creates_directories() {
-    let temp = tempfile::tempdir().expect("create temp dir");
-    let nested = temp.path().join("nested").join("build.ninja");
-    let content = NinjaContent::new(String::from("build all: phony"));
-
-    doc::write_ninja_file(&nested, &content).expect("write ninja file");
-
-    let written = std::fs::read_to_string(&nested).expect("read nested file");
-    assert_eq!(written, content.as_str());
-    assert!(nested.parent().expect("parent path").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move Ninja file creation, writing, and resolution utilities into `src/runner/process.rs`
- update the runner module to delegate process work to the new helpers and trim local imports
- closes #155

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d96f618bf083229c0679f8403b391f

## Summary by Sourcery

Extract and consolidate Ninja file and program management into a dedicated process module and update the runner to delegate to these new helpers.

Enhancements:
- Move temporary Ninja file creation, writing, and program resolution functions into src/runner/process.rs
- Update runner module to call process::create_temp_ninja_file, process::write_ninja_file, and process::resolve_ninja_program instead of local implementations

Documentation:
- Add documentation and examples for create_temp_ninja_file, write_ninja_file, and resolve_ninja_program in the process module