### PR TITLE
Refactor test environment guards

### DIFF
--- a/test_support/src/env_guard.rs
+++ b/test_support/src/env_guard.rs
@@ -1,0 +1,117 @@
+//! Generic guard for restoring environment variables.
+
+use std::{
+    borrow::Cow,
+    ffi::{OsStr, OsString},
+};
+
+use crate::env_lock::EnvLock;
+
+/// Environment abstraction for applying environment mutations.
+///
+/// The trait is intentionally minimal so tests can provide mocks.
+pub trait Environment {
+    /// Set `key` to `value` within the environment.
+    ///
+    /// # Safety
+    ///
+    /// Mutating process-global state is `unsafe` in Rust 2024. Callers must
+    /// ensure mutations are serialised and restored.
+    unsafe fn set_var(&mut self, key: &str, value: &OsStr);
+
+    /// Remove `key` from the environment.
+    ///
+    /// # Safety
+    ///
+    /// Mutating process-global state is `unsafe` in Rust 2024. Callers must
+    /// ensure mutations are serialised and restored.
+    unsafe fn remove_var(&mut self, key: &str);
+}
+
+/// Concrete [`Environment`] backed by [`std::env`].
+#[derive(Debug, Default)]
+pub struct StdEnv;
+
+impl Environment for StdEnv {
+    unsafe fn set_var(&mut self, key: &str, value: &OsStr) {
+        unsafe { std::env::set_var(key, value) };
+    }
+
+    unsafe fn remove_var(&mut self, key: &str) {
+        unsafe { std::env::remove_var(key) };
+    }
+}
+
+/// RAII guard that restores an environment variable to its prior state on drop.
+///
+/// The guard captures the previous value of `key` and reinstates it when dropped,
+/// ensuring tests leave global process state untouched even if they panic.
+#[derive(Debug)]
+pub struct EnvGuard<E: Environment = StdEnv> {
+    key: Cow<'static, str>,
+    original: Option<OsString>,
+    env: E,
+    lock_on_drop: bool,
+}
+
+impl EnvGuard {
+    /// Create a guard for `key` using [`StdEnv`].
+    pub fn new(key: impl Into<Cow<'static, str>>, original: Option<OsString>) -> Self {
+        Self::with_env_and_lock(key, original, StdEnv::default(), true)
+    }
+
+    /// Create a guard that skips locking on drop.
+    pub fn new_unlocked(key: impl Into<Cow<'static, str>>, original: Option<OsString>) -> Self {
+        Self::with_env_and_lock(key, original, StdEnv::default(), false)
+    }
+}
+
+impl<E: Environment> EnvGuard<E> {
+    /// Create a guard for `key` using a custom environment implementation.
+    pub fn with_env(key: impl Into<Cow<'static, str>>, original: Option<OsString>, env: E) -> Self {
+        Self::with_env_and_lock(key, original, env, true)
+    }
+
+    /// Create a guard for `key` with an explicit locking strategy.
+    pub fn with_env_and_lock(
+        key: impl Into<Cow<'static, str>>,
+        original: Option<OsString>,
+        env: E,
+        lock_on_drop: bool,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            original,
+            env,
+            lock_on_drop,
+        }
+    }
+
+    /// Access the underlying environment implementation.
+    pub fn env_mut(&mut self) -> &mut E {
+        &mut self.env
+    }
+
+    /// Consume the guard returning the captured original value.
+    pub fn into_original(mut self) -> Option<OsString> {
+        self.original.take()
+    }
+
+    fn restore(&mut self) {
+        match self.original.take() {
+            Some(value) => unsafe { self.env.set_var(&self.key, &value) },
+            None => unsafe { self.env.remove_var(&self.key) },
+        }
+    }
+}
+
+impl<E: Environment> Drop for EnvGuard<E> {
+    fn drop(&mut self) {
+        if self.lock_on_drop {
+            let _lock = EnvLock::acquire();
+            self.restore();
+        } else {
+            self.restore();
+        }
+    }
+}

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod check_ninja;
 pub mod env;
+pub mod env_guard;
 pub mod env_lock;
 pub mod env_var_guard;
 pub mod path_guard;
@@ -20,6 +21,9 @@ pub use path_guard::PathGuard;
 
 /// Re-export of [`env_var_guard::EnvVarGuard`] for ergonomics in tests.
 pub use env_var_guard::EnvVarGuard;
+
+/// Re-export of the generic environment guard utilities.
+pub use env_guard::{EnvGuard, Environment, StdEnv};
 
 mod error;
 /// Format an error and its sources (outermost → root) using `Display`, joined

--- a/test_support/src/path_guard.rs
+++ b/test_support/src/path_guard.rs
@@ -3,44 +3,21 @@
 //! Provides a guard that resets the environment variable on drop so tests do
 //! not pollute global state.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 
-use crate::env_lock::EnvLock;
+use crate::env_guard::{EnvGuard, Environment, StdEnv};
 
 /// Environment abstraction for setting variables.
-pub trait Env {
-    /// Set `key` to `val` within the environment.
-    ///
-    /// # Safety
-    ///
-    /// Mutating process globals is `unsafe` in Rust 2024. Callers must ensure
-    /// access is serialised and state is restored.
-    unsafe fn set_var(&mut self, key: &str, val: &OsStr);
-}
+pub trait Env: Environment {}
 
-#[derive(Debug)]
-pub struct StdEnv;
-
-impl Env for StdEnv {
-    unsafe fn set_var(&mut self, key: &str, val: &OsStr) {
-        unsafe { std::env::set_var(key, val) };
-    }
-}
-
-/// Original `PATH` state captured by `PathGuard`.
-#[derive(Debug)]
-enum OriginalPath {
-    Unset,
-    Set(OsString),
-}
+impl<T: Environment> Env for T {}
 
 /// Guard that restores `PATH` to its original value when dropped.
 ///
 /// This uses RAII to ensure the environment is reset even if a test panics.
 #[derive(Debug)]
 pub struct PathGuard<E: Env = StdEnv> {
-    original: Option<OriginalPath>,
-    env: E,
+    inner: EnvGuard<E>,
 }
 
 impl PathGuard {
@@ -48,10 +25,8 @@ impl PathGuard {
     ///
     /// Returns a guard that restores the variable when dropped.
     pub fn new(original: Option<OsString>) -> Self {
-        let state = original.map_or(OriginalPath::Unset, OriginalPath::Set);
         Self {
-            original: Some(state),
-            env: StdEnv,
+            inner: EnvGuard::with_env_and_lock("PATH", original, StdEnv::default(), true),
         }
     }
 }
@@ -60,26 +35,12 @@ impl<E: Env> PathGuard<E> {
     /// Create a guard that uses `env` to restore `PATH`.
     pub fn with_env(original: OsString, env: E) -> Self {
         Self {
-            original: Some(OriginalPath::Set(original)),
-            env,
+            inner: EnvGuard::with_env_and_lock("PATH", Some(original), env, true),
         }
     }
 
     /// Access the underlying environment.
     pub fn env_mut(&mut self) -> &mut E {
-        &mut self.env
-    }
-}
-
-impl<E: Env> Drop for PathGuard<E> {
-    fn drop(&mut self) {
-        let _lock = EnvLock::acquire();
-        match self.original.take() {
-            Some(OriginalPath::Set(path)) => {
-                // Nightly marks `set_var` unsafe; restoring cleans up global state.
-                unsafe { self.env.set_var("PATH", &path) };
-            }
-            Some(OriginalPath::Unset) | None => unsafe { std::env::remove_var("PATH") },
-        }
+        self.inner.env_mut()
     }
 }

--- a/tests/path_guard_tests.rs
+++ b/tests/path_guard_tests.rs
@@ -5,12 +5,13 @@
 
 use mockall::{Sequence, mock};
 use std::ffi::OsStr;
-use test_support::{PathGuard, path_guard::Env};
+use test_support::{Environment, PathGuard};
 
 mock! {
     pub Env {}
-    impl Env for Env {
+    impl Environment for Env {
         unsafe fn set_var(&mut self, key: &str, val: &OsStr);
+        unsafe fn remove_var(&mut self, key: &str);
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce a reusable `EnvGuard` that captures environment state and controls drop locking semantics
- refactor the PATH, Ninja, and generic variable guards to delegate to the shared implementation and export the utilities
- update the path guard mock to implement the new `Environment` contract

closes #100

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d972dc40108322aa944fc731ee7656