### PR TITLE
Add Windows MSI packaging to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,11 +119,29 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
         run: |
           set -euo pipefail
           uv run .github/workflows/scripts/stage_windows.py
+      - id: package
+        name: Build Windows installer package
+        uses: leynos/shared-actions/.github/actions/windows-package@7bc9b6c15964ef98733aa647b76d402146284ba3
+        env:
+          PRODUCT_NAME: ${{ needs.metadata.outputs.bin_name }}
+          MANUFACTURER: Leynos
+          BINARY_PATH: ${{ replace(steps.stage.outputs.binary_path, '/', '\\') }}
+          MAN_PATH: ${{ replace(steps.stage.outputs.man_path, '/', '\\') }}
+        with:
+          architecture: ${{ matrix.package_arch == 'amd64' && 'x64' || 'arm64' }}
+          version: ${{ needs.metadata.outputs.version }}
+          output-basename: ${{ needs.metadata.outputs.bin_name }}
+          output-directory: dist
+          license-plaintext-path: LICENSE
+          license-rtf-path: dist\\${{ needs.metadata.outputs.bin_name }}-license.rtf
+          upload-artifact: 'false'
       - name: Upload Windows artefacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ env.REPO_NAME }}-windows-${{ matrix.package_arch }}
-          path: ${{ steps.stage.outputs.artifact_dir }}
+          path: |
+            ${{ steps.stage.outputs.artifact_dir }}
+            ${{ steps.package.outputs.msi-path }}
 
   build-macos:
     needs: metadata
@@ -220,7 +238,7 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
           bin_name="${BIN_NAME:?BIN_NAME must be provided}"
           mapfile -t files < <(
             find dist -type f \
-              \( -name "*.deb" -o -name "*.rpm" -o -name "*.pkg" \
+              \( -name "*.deb" -o -name "*.rpm" -o -name "*.pkg" -o -name "*.msi" \
               -o -name "${bin_name}" -o -name "${bin_name}.exe" \
               -o -name "${bin_name}.1" -o -name "*.sha256" \) -print
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
           PRODUCT_NAME: ${{ needs.metadata.outputs.bin_name }}
           MANUFACTURER: Leynos
           BINARY_PATH: ${{ replace(steps.stage.outputs.binary_path, '/', '\\') }}
-          LICENSE_RTF_PATH: ${{ format('dist\\{0}-license.rtf', needs.metadata.outputs.bin_name) }}
+          LICENSE_RTF_PATH: ${{ replace(format('dist/{0}-license.rtf', needs.metadata.outputs.bin_name), '/', '\\') }}
         with:
           architecture: ${{ matrix.package_arch == 'amd64' && 'x64' || 'arm64' }}
           version: ${{ needs.metadata.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,6 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
           output-basename: ${{ needs.metadata.outputs.bin_name }}
           output-directory: dist
           license-plaintext-path: LICENSE
-          license-rtf-path: dist\\${{ needs.metadata.outputs.bin_name }}-license.rtf
           upload-artifact: 'false'
       - name: Upload Windows artefacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
           PRODUCT_NAME: ${{ needs.metadata.outputs.bin_name }}
           MANUFACTURER: Leynos
           BINARY_PATH: ${{ replace(steps.stage.outputs.binary_path, '/', '\\') }}
-          MAN_PATH: ${{ replace(steps.stage.outputs.man_path, '/', '\\') }}
+          LICENSE_RTF_PATH: ${{ format('dist\\{0}-license.rtf', needs.metadata.outputs.bin_name) }}
         with:
           architecture: ${{ matrix.package_arch == 'amd64' && 'x64' || 'arm64' }}
           version: ${{ needs.metadata.outputs.version }}

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1630,7 +1630,12 @@ wrapper `.github/workflows/scripts/stage_windows.py`, which delegates to
 `.github/workflows/scripts/stage_common.py`. The helper consumes Cyclopts
 parameters for the build metadata, resolves GitHub-provided environment
 variables for workspace details, mirrors the man page, and writes SHA-256 sums
-ready for publishing while enforcing a Windows-specific binary suffix.
+ready for publishing while enforcing a Windows-specific binary suffix. The
+staged artefacts feed a WiX v4 authoring template stored in
+`installer/Package.wxs`; the workflow invokes the shared
+`windows-package@7bc9b6c15964ef98733aa647b76d402146284ba3` composite to convert
+the repository licence into RTF, embed the binary plus manual page, and output a
+signed MSI installer alongside the staged directory.
 
 macOS releases execute the shared action twice: once on an Intel runner and
 again on Apple Silicon. They invoke the uv staging wrapper

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1634,8 +1634,13 @@ ready for publishing while enforcing a Windows-specific binary suffix. The
 staged artefacts feed a WiX v4 authoring template stored in
 `installer/Package.wxs`; the workflow invokes the shared
 `windows-package@7bc9b6c15964ef98733aa647b76d402146284ba3` composite to convert
-the repository licence into RTF, embed the binary plus manual page, and output a
-signed MSI installer alongside the staged directory.
+the repository licence into RTF, embed the binary, and output a signed MSI
+installer alongside the staged directory. The installer uses WiX v4 syntax,
+installs per-machine, and presents the minimal UI appropriate for a CLI tool.
+Windows does not modify the PATH, so users must add the installation directory
+manually if they want global command resolution. The Unix manual page remains
+in the staged artefacts for parity with the other platforms but is not bundled
+into the installer to avoid shipping an inaccessible help format.
 
 macOS releases execute the shared action twice: once on an Intel runner and
 again on Apple Silicon. They invoke the uv staging wrapper

--- a/installer/Package.wxs
+++ b/installer/Package.wxs
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+      Name="$(env.PRODUCT_NAME) $(var.Version)"
+      Version="$(var.Version)"
+      Manufacturer="$(env.MANUFACTURER)"
+      UpgradeCode="{870359C0-A975-4DCB-992A-AD67D97292DD}"
+      Language="1033"
+      Description="$(env.PRODUCT_NAME) command line interface"
+      InstallScope="perMachine">
+    <MediaTemplate EmbedCab="yes" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(env.LICENSE_RTF_PATH)" />
+    <UI Id="WixUI_Minimal" />
+    <Feature Id="MainApplication" Title="$(env.PRODUCT_NAME)" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="$(env.PRODUCT_NAME)" />
+    </StandardDirectory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents">
+      <Component Id="BinaryComponent" Guid="{8A7AA941-A8C3-4314-8A7D-3195B4806511}" Directory="INSTALLFOLDER">
+        <File Id="Executable" Source="$(env.BINARY_PATH)" KeyPath="yes" />
+      </Component>
+      <Component Id="ManualComponent" Guid="{EFF49296-93FA-482D-802F-12D8333309A9}" Directory="INSTALLFOLDER">
+        <File Id="Manual" Source="$(env.MAN_PATH)" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/installer/Package.wxs
+++ b/installer/Package.wxs
@@ -27,9 +27,6 @@
       <Component Id="BinaryComponent" Guid="{8A7AA941-A8C3-4314-8A7D-3195B4806511}" Directory="INSTALLFOLDER">
         <File Id="Executable" Source="$(env.BINARY_PATH)" KeyPath="yes" />
       </Component>
-      <Component Id="ManualComponent" Guid="{EFF49296-93FA-482D-802F-12D8333309A9}" Directory="INSTALLFOLDER">
-        <File Id="Manual" Source="$(env.MAN_PATH)" />
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
## Summary
- add WiX-based Windows MSI packaging using the shared windows-package composite action
- publish the generated MSI alongside the staged Windows artefacts and include it in release uploads
- document the new installer flow and add the WiX authoring template

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68db8f6a4edc8322863558ee3f6d3ce9

## Summary by Sourcery

Add Windows MSI packaging to the release workflow by integrating a WiX-based installer step, publishing the MSI artifact alongside existing Windows binaries, and updating documentation with the new installer flow.

New Features:
- Add a Build Windows installer package step using the shared windows-package composite action
- Publish the generated MSI alongside staged Windows artifacts and include it in release uploads
- Add a WiX authoring template (installer/Package.wxs) for building the MSI installer

Documentation:
- Document the new installer flow and WiX template in the design documentation