### PR TITLE
Add release workflow dry-run support

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -34,8 +34,7 @@ jobs:
           shopt -s nullglob
           mapfile -t files < <(find dist -type f)
           if [ "${#files[@]}" -eq 0 ]; then
-            echo '::error title=Missing artefacts::No files downloaded from'
-            echo 'reusable release workflow'
+            echo '::error title=Missing artefacts::No artefacts downloaded'
             exit 1
           fi
           printf 'Found %s artefact(s) in dist/\n' "${#files[@]}"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,6 +1,7 @@
+---
 name: Release Dry Run
 
-on:
+'on':
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -20,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artefacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: >-
+          actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # v4
         with:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
@@ -31,7 +34,8 @@ jobs:
           shopt -s nullglob
           mapfile -t files < <(find dist -type f)
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "::error title=Missing artefacts::No files downloaded from reusable release workflow"
+            echo '::error title=Missing artefacts::No files downloaded from'
+            echo 'reusable release workflow'
             exit 1
           fi
           printf 'Found %s artefact(s) in dist/\n' "${#files[@]}"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,37 @@
+name: Release Dry Run
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+env:
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.yml
+    with:
+      publish: false
+    secrets: inherit
+
+  validate-artifacts:
+    name: Validate packaged artefacts
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artefacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          path: dist
+          pattern: ${{ env.REPO_NAME }}-*
+      - name: Ensure artefacts exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          mapfile -t files < <(find dist -type f)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error title=Missing artefacts::No files downloaded from reusable release workflow"
+            exit 1
+          fi
+          printf 'Found %s artefact(s) in dist/\n' "${#files[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_call:
+    inputs:
+      publish:
+        description: >-
+          Whether the workflow should publish artefacts to the GitHub release
+          associated with the tag. Defaults to `false` when invoked as a
+          reusable workflow.
+        required: false
+        type: boolean
+        default: false
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -16,15 +26,59 @@ jobs:
   metadata:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: ${{ steps.read_version.outputs.version }}
       bin_name: ${{ steps.bin_name.outputs.value }}
+      should_publish: ${{ steps.publish.outputs.value }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
-      - id: version
+      - id: publish
+        name: Determine publish mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = 'workflow_call' ]; then
+            if [ "${{ inputs.publish }}" = 'true' ]; then
+              echo "value=true" >>"$GITHUB_OUTPUT"
+            else
+              echo "value=false" >>"$GITHUB_OUTPUT"
+            fi
+          else
+            echo "value=true" >>"$GITHUB_OUTPUT"
+          fi
+      - id: read_version
+        name: Read package version from Cargo.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          version="$({
+            python3 - <<'PY'
+import os
+import sys
+import tomllib
+
+toml_path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
+with open(toml_path, 'rb') as fh:
+    data = tomllib.load(fh)
+package = data.get('package') or {}
+version = package.get('version')
+if not version:
+    raise SystemExit('package.version is missing')
+sys.stdout.write(version)
+PY
+          } 2>/tmp/version.err)"
+          if [ -z "$version" ]; then
+            printf '::error title=Version parse failure::Could not read package.version from %s.\n' "$toml_path"
+            cat /tmp/version.err >&2 || true
+            exit 1
+          fi
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+      - id: ensure_version
+        if: steps.publish.outputs.value == 'true'
         name: Verify tag matches Cargo.toml
         uses: leynos/shared-actions/.github/actions/ensure-cargo-version@5f276592fc649268327339d48a56fac3a23b49f0
       - id: bin_name
@@ -210,6 +264,7 @@ with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("packag
             dist/${{ needs.metadata.outputs.bin_name }}-${{ needs.metadata.outputs.version }}-${{ matrix.artifact_suffix }}.pkg
 
   release:
+    if: needs.metadata.outputs.should_publish == 'true'
     permissions:
       contents: write
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   metadata:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.read_version.outputs.version }}
+      version: ${{ steps.ensure_version.outputs['crate-version'] }}
       bin_name: ${{ steps.bin_name.outputs.value }}
       should_publish: ${{ steps.publish.outputs.value }}
     steps:
@@ -54,26 +54,12 @@ jobs:
           else
             echo "value=true" >>"$GITHUB_OUTPUT"
           fi
-      - id: read_version
-        name: Read package version from Cargo.toml
-        shell: bash
-        run: |
-          set -euo pipefail
-          manifest_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          version="$(python3 .github/workflows/scripts/read_manifest.py \
-            --manifest-path "$manifest_path" version 2>/tmp/version.err)"
-          if [ -z "$version" ]; then
-            printf '::error title=Version parse failure::Could not read '
-            printf 'package.version from %s.\n' "$manifest_path"
-            cat /tmp/version.err >&2 || true
-            exit 1
-          fi
-          echo "version=$version" >>"$GITHUB_OUTPUT"
       - id: ensure_version
-        if: steps.publish.outputs.value == 'true'
-        name: Verify tag matches Cargo.toml
+        name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@5f276592fc649268327339d48a56fac3a23b49f0
+          leynos/shared-actions/.github/actions/ensure-cargo-version@0ac4b6ec81dbef45594b37bc2afaaa60e30b5b20
+        with:
+          check-tag: ${{ steps.publish.outputs.value == 'true' }}
       - id: bin_name
         name: Extract binary name from Cargo.toml
         shell: bash
@@ -324,10 +310,14 @@ jobs:
             find dist -type f \
               \( -name "*.deb" -o -name "*.rpm" -o -name "*.pkg" -o -name "*.msi" \
               -o -name "${bin_name}" -o -name "${bin_name}.exe" \
-              -o -name "${bin_name}.1" -o -name "*.sha256" \) -print
+              -o -name "${bin_name}.1" -o -name "*.sha256" \)
+              -print
           )
           if [ "${#files[@]}" -eq 0 ]; then
-            echo "::error title=No artefacts uploaded::No files found in dist/"
+            printf -v message '%s%s' \
+              '::error title=No artefacts uploaded::No files found in ' \
+              'dist/'
+            printf '%s\n' "$message"
             exit 1
           fi
           declare -A seen=()
@@ -341,15 +331,21 @@ jobs:
               asset_name="${dir_name}-${base_name}"
             fi
             if [[ -n "${seen[$asset_name]:-}" ]]; then
-              echo "::error title=Duplicate release asset::Asset name '$asset_name' would be uploaded more than once"
+              printf '%s' '::error title=Duplicate release asset::Asset name '
+              printf '%s\n' "'${asset_name}' would be uploaded more than once"
               exit 1
             fi
             seen[$asset_name]=1
-            gh release upload "${{ github.ref_name }}" "$file#${asset_name}" --clobber \
+            gh release upload "${{ github.ref_name }}" \
+              "$file#${asset_name}" --clobber \
               && uploaded=$((uploaded + 1))
           done
           if [ "$uploaded" -eq 0 ]; then
-            echo "::error title=No artefacts uploaded::No files were published to the release"
+            printf -v message '%s%s%s' \
+              '::error title=No artefacts uploaded::No files were ' \
+              'published to the ' \
+              'release'
+            printf '%s\n' "$message"
             exit 1
           fi
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,10 @@ jobs:
           name="$(python3 .github/workflows/scripts/read_manifest.py \
             --manifest-path "$manifest_path" name 2>/tmp/name.err)"
           if [ -z "$name" ]; then
-            echo '::error title=Cargo.toml parse failure::Could not read '
-            echo "package.name from ${manifest_path}."
+            message='::error title=Cargo.toml parse failure::Could not read '
+            message+='package.name from '
+            message+="${manifest_path}."
+            echo "$message"
             cat /tmp/name.err >&2 || true
             exit 1
           fi
@@ -310,10 +312,9 @@ jobs:
               -print
           )
           if [ "${#files[@]}" -eq 0 ]; then
-            printf -v message '%s%s' \
-              '::error title=No artefacts uploaded::No files found in ' \
-              'dist/'
-            printf '%s\n' "$message"
+            message='::error title=No artefacts uploaded::No files found in '
+            message+='dist/'
+            echo "$message"
             exit 1
           fi
           declare -A seen=()
@@ -337,11 +338,9 @@ jobs:
               && uploaded=$((uploaded + 1))
           done
           if [ "$uploaded" -eq 0 ]; then
-            printf -v message '%s%s%s' \
-              '::error title=No artefacts uploaded::No files were ' \
-              'published to the ' \
-              'release'
-            printf '%s\n' "$message"
+            message='::error title=No artefacts uploaded::No files were '
+            message+='published to the release'
+            echo "$message"
             exit 1
           fi
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = 'workflow_call' ]; then
-            if [ "${{ inputs.publish }}" = 'true' ]; then
-              echo "value=true" >>"$GITHUB_OUTPUT"
-            else
-              echo "value=false" >>"$GITHUB_OUTPUT"
-            fi
+            echo "value=${{ inputs.publish }}" >>"$GITHUB_OUTPUT"
           else
             echo "value=true" >>"$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+---
 name: Release Binary
 
-on:
+'on':
   push:
     tags:
       - 'v*.*.*'
@@ -30,9 +31,13 @@ jobs:
       bin_name: ${{ steps.bin_name.outputs.value }}
       should_publish: ${{ steps.publish.outputs.value }}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - uses: >-
+          actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        # v4.1.2
       - name: Setup Python 3.11
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: >-
+          actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5
         with:
           python-version: '3.11'
       - id: publish
@@ -54,24 +59,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          version="$(python3 - 2>/tmp/version.err <<'PY'
-import os
-import sys
-import tomllib
-
-toml_path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
-with open(toml_path, 'rb') as fh:
-    data = tomllib.load(fh)
-package = data.get('package') or {}
-version = package.get('version')
-if not version:
-    raise SystemExit('package.version is missing')
-sys.stdout.write(version)
-PY
-          )"
+          manifest_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          version="$(python3 .github/workflows/scripts/read_manifest.py \
+            --manifest-path "$manifest_path" version 2>/tmp/version.err)"
           if [ -z "$version" ]; then
-            printf '::error title=Version parse failure::Could not read package.version from %s.\n' "$toml_path"
+            printf '::error title=Version parse failure::Could not read '
+            printf 'package.version from %s.\n' "$manifest_path"
             cat /tmp/version.err >&2 || true
             exit 1
           fi
@@ -79,31 +72,23 @@ PY
       - id: ensure_version
         if: steps.publish.outputs.value == 'true'
         name: Verify tag matches Cargo.toml
-        uses: leynos/shared-actions/.github/actions/ensure-cargo-version@5f276592fc649268327339d48a56fac3a23b49f0
+        uses: >-
+          leynos/shared-actions/.github/actions/ensure-cargo-version@5f276592fc649268327339d48a56fac3a23b49f0
       - id: bin_name
         name: Extract binary name from Cargo.toml
         shell: bash
         run: |
           set -euo pipefail
-          toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          name="$(python3 - <<'PY'
-import os
-import sys
-import tomllib
-
-toml_path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
-with open(toml_path, 'rb') as fh:
-    data = tomllib.load(fh)
-package = data.get('package') or {}
-name = package.get('name', '')
-sys.stdout.write(name)
-PY
-          )"
+          manifest_path="${CARGO_TOML_PATH:-Cargo.toml}"
+          name="$(python3 .github/workflows/scripts/read_manifest.py \
+            --manifest-path "$manifest_path" name 2>/tmp/name.err)"
           if [ -z "$name" ]; then
-            echo "::error title=Cargo.toml parse failure::Could not read package.name from ${toml_path}."
+            echo '::error title=Cargo.toml parse failure::Could not read '
+            echo "package.name from ${manifest_path}."
+            cat /tmp/name.err >&2 || true
             exit 1
           fi
-          echo "value=$name" >> "$GITHUB_OUTPUT"
+          echo "value=$name" >>"$GITHUB_OUTPUT"
 
   build-linux:
     needs: metadata
@@ -117,36 +102,44 @@ PY
           - target: aarch64-unknown-linux-gnu
             artifact: linux-arm64
             package_arch: arm64
-    steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
-      - name: Build Linux release
-        uses: leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
-        with:
-          target: ${{ matrix.target }}
-          bin-name: ${{ needs.metadata.outputs.bin_name }}
-          version: ${{ needs.metadata.outputs.version }}
-          # Package formats are produced by linux-packages below
-      - name: Package Linux artefacts with dependencies
-        uses: leynos/shared-actions/.github/actions/linux-packages@7bc9b6c15964ef98733aa647b76d402146284ba3
-        with:
-          project-dir: .
-          package-name: ${{ needs.metadata.outputs.bin_name }}
-          bin-name: ${{ needs.metadata.outputs.bin_name }}
-          target: ${{ matrix.target }}
-          version: ${{ needs.metadata.outputs.version }}
-          formats: deb,rpm
-          man-paths: dist/${{ needs.metadata.outputs.bin_name }}_linux_${{ matrix.package_arch }}/${{ needs.metadata.outputs.bin_name }}.1
-          outdir: dist
-          deb-depends: ninja-build
-          rpm-depends: ninja-build
-      - name: Prune packaging metadata
-        shell: bash
-        run: rm -rf dist/.man dist/nfpm.yaml
-      - name: Upload Linux artefacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: ${{ env.REPO_NAME }}-${{ matrix.artifact }}
-          path: dist
+      steps:
+        - uses: >-
+            actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+          # v4.1.2
+        - name: Build Linux release
+          uses: >-
+            leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
+          with:
+            target: ${{ matrix.target }}
+            bin-name: ${{ needs.metadata.outputs.bin_name }}
+            version: ${{ needs.metadata.outputs.version }}
+            # Package formats are produced by linux-packages below
+        - name: Package Linux artefacts with dependencies
+          uses: >-
+            leynos/shared-actions/.github/actions/linux-packages@7bc9b6c15964ef98733aa647b76d402146284ba3
+          with:
+            project-dir: .
+            package-name: ${{ needs.metadata.outputs.bin_name }}
+            bin-name: ${{ needs.metadata.outputs.bin_name }}
+            target: ${{ matrix.target }}
+            version: ${{ needs.metadata.outputs.version }}
+            formats: deb,rpm
+            man-paths: >-
+              dist/${{ needs.metadata.outputs.bin_name }}_linux_${{
+              matrix.package_arch }}/${{ needs.metadata.outputs.bin_name }}.1
+            outdir: dist
+            deb-depends: ninja-build
+            rpm-depends: ninja-build
+        - name: Prune packaging metadata
+          shell: bash
+          run: rm -rf dist/.man dist/nfpm.yaml
+        - name: Upload Linux artefacts
+          uses: >-
+            actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+          # v4
+          with:
+            name: ${{ env.REPO_NAME }}-${{ matrix.artifact }}
+            path: dist
 
   build-windows:
     needs: metadata
@@ -159,13 +152,18 @@ PY
           - target: aarch64-pc-windows-msvc
             package_arch: arm64
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - uses: >-
+          actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        # v4.1.2
       - name: Install uv
-        uses: astral-sh/setup-uv@4cda7d73322c50eac316ad623a716f09a2db2ac7  # v3.1.2
+        uses: >-
+          astral-sh/setup-uv@4cda7d73322c50eac316ad623a716f09a2db2ac7
+        # v3.1.2
         with:
           python-version: '3.11'
       - name: Build Windows release
-        uses: leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
+        uses: >-
+          leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
         with:
           target: ${{ matrix.target }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}
@@ -183,7 +181,8 @@ PY
           uv run .github/workflows/scripts/stage_windows.py
       - id: package
         name: Build Windows installer package
-        uses: leynos/shared-actions/.github/actions/windows-package@7bc9b6c15964ef98733aa647b76d402146284ba3
+        uses: >-
+          leynos/shared-actions/.github/actions/windows-package@7bc9b6c15964ef98733aa647b76d402146284ba3
         env:
           PRODUCT_NAME: ${{ needs.metadata.outputs.bin_name }}
           MANUFACTURER: Leynos
@@ -197,7 +196,9 @@ PY
           license-plaintext-path: LICENSE
           upload-artifact: 'false'
       - name: Upload Windows artefacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: >-
+          actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # v4
         with:
           name: ${{ env.REPO_NAME }}-windows-${{ matrix.package_arch }}
           path: |
@@ -219,13 +220,18 @@ PY
             package_arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - uses: >-
+          actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        # v4.1.2
       - name: Install uv
-        uses: astral-sh/setup-uv@4cda7d73322c50eac316ad623a716f09a2db2ac7  # v3.1.2
+        uses: >-
+          astral-sh/setup-uv@4cda7d73322c50eac316ad623a716f09a2db2ac7
+        # v3.1.2
         with:
           python-version: '3.11'
       - name: Build macOS release
-        uses: leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
+        uses: >-
+          leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
         with:
           target: ${{ matrix.target }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}
@@ -243,7 +249,8 @@ PY
           uv run .github/workflows/scripts/stage_macos.py
       - id: pkg
         name: Build macOS installer package
-        uses: leynos/shared-actions/.github/actions/macos-package@7bc9b6c15964ef98733aa647b76d402146284ba3
+        uses: >-
+          leynos/shared-actions/.github/actions/macos-package@7bc9b6c15964ef98733aa647b76d402146284ba3
         with:
           name: ${{ needs.metadata.outputs.bin_name }}
           identifier: com.leynos.${{ needs.metadata.outputs.bin_name }}
@@ -264,12 +271,16 @@ PY
           mkdir -p "$(dirname "$dest")"
           mv "$PKG_PATH" "$dest"
       - name: Upload macOS artefacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: >-
+          actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # v4
         with:
           name: ${{ env.REPO_NAME }}-${{ matrix.artifact_suffix }}
           path: |
             ${{ steps.stage.outputs.artifact_dir }}
-            dist/${{ needs.metadata.outputs.bin_name }}-${{ needs.metadata.outputs.version }}-${{ matrix.artifact_suffix }}.pkg
+            dist/${{ needs.metadata.outputs.bin_name }}-${{
+              needs.metadata.outputs.version }}-${{
+              matrix.artifact_suffix }}.pkg
 
   release:
     if: needs.metadata.outputs.should_publish == 'true'
@@ -282,17 +293,24 @@ PY
       - build-macos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - uses: >-
+          actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        # v4.1.2
       - name: Ensure release exists (draft)
         shell: bash
         run: |
           set -euo pipefail
           gh release view "${{ github.ref_name }}" >/dev/null 2>&1 || \
-            gh release create "${{ github.ref_name }}" --draft --verify-tag --notes "Automated release for ${{ github.ref_name }}"
+            gh release create "${{ github.ref_name }}" \
+              --draft \
+              --verify-tag \
+              --notes "Automated release for ${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      - uses: >-
+          actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # v4
         with:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
@@ -328,7 +346,7 @@ PY
             fi
             seen[$asset_name]=1
             gh release upload "${{ github.ref_name }}" "$file#${asset_name}" --clobber \
-              && uploaded=$((uploaded+1))
+              && uploaded=$((uploaded + 1))
           done
           if [ "$uploaded" -eq 0 ]; then
             echo "::error title=No artefacts uploaded::No files were published to the release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          version="$({
-            python3 - <<'PY'
+          version="$(python3 - 2>/tmp/version.err <<'PY'
 import os
 import sys
 import tomllib
@@ -70,7 +69,7 @@ if not version:
     raise SystemExit('package.version is missing')
 sys.stdout.write(version)
 PY
-          } 2>/tmp/version.err)"
+          )"
           if [ -z "$version" ]; then
             printf '::error title=Version parse failure::Could not read package.version from %s.\n' "$toml_path"
             cat /tmp/version.err >&2 || true
@@ -87,9 +86,18 @@ PY
         run: |
           set -euo pipefail
           toml_path="${CARGO_TOML_PATH:-Cargo.toml}"
-          name="$(
-            python3 -c 'import os, sys, tomllib; path = os.environ.get("CARGO_TOML_PATH", "Cargo.toml");
-with open(path, "rb") as fh: data = tomllib.load(fh); package = data.get("package") or {}; sys.stdout.write(package.get("name", ""))' || echo ""
+          name="$(python3 - <<'PY'
+import os
+import sys
+import tomllib
+
+toml_path = os.environ.get('CARGO_TOML_PATH', 'Cargo.toml')
+with open(toml_path, 'rb') as fh:
+    data = tomllib.load(fh)
+package = data.get('package') or {}
+name = package.get('name', '')
+sys.stdout.write(name)
+PY
           )"
           if [ -z "$name" ]; then
             echo "::error title=Cargo.toml parse failure::Could not read package.name from ${toml_path}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,44 +102,44 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             artifact: linux-arm64
             package_arch: arm64
-      steps:
-        - uses: >-
-            actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-          # v4.1.2
-        - name: Build Linux release
-          uses: >-
-            leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
-          with:
-            target: ${{ matrix.target }}
-            bin-name: ${{ needs.metadata.outputs.bin_name }}
-            version: ${{ needs.metadata.outputs.version }}
-            # Package formats are produced by linux-packages below
-        - name: Package Linux artefacts with dependencies
-          uses: >-
-            leynos/shared-actions/.github/actions/linux-packages@7bc9b6c15964ef98733aa647b76d402146284ba3
-          with:
-            project-dir: .
-            package-name: ${{ needs.metadata.outputs.bin_name }}
-            bin-name: ${{ needs.metadata.outputs.bin_name }}
-            target: ${{ matrix.target }}
-            version: ${{ needs.metadata.outputs.version }}
-            formats: deb,rpm
-            man-paths: >-
-              dist/${{ needs.metadata.outputs.bin_name }}_linux_${{
-              matrix.package_arch }}/${{ needs.metadata.outputs.bin_name }}.1
-            outdir: dist
-            deb-depends: ninja-build
-            rpm-depends: ninja-build
-        - name: Prune packaging metadata
-          shell: bash
-          run: rm -rf dist/.man dist/nfpm.yaml
-        - name: Upload Linux artefacts
-          uses: >-
-            actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-          # v4
-          with:
-            name: ${{ env.REPO_NAME }}-${{ matrix.artifact }}
-            path: dist
+    steps:
+      - uses: >-
+          actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        # v4.1.2
+      - name: Build Linux release
+        uses: >-
+          leynos/shared-actions/.github/actions/rust-build-release@7bc9b6c15964ef98733aa647b76d402146284ba3
+        with:
+          target: ${{ matrix.target }}
+          bin-name: ${{ needs.metadata.outputs.bin_name }}
+          version: ${{ needs.metadata.outputs.version }}
+          # Package formats are produced by linux-packages below
+      - name: Package Linux artefacts with dependencies
+        uses: >-
+          leynos/shared-actions/.github/actions/linux-packages@7bc9b6c15964ef98733aa647b76d402146284ba3
+        with:
+          project-dir: .
+          package-name: ${{ needs.metadata.outputs.bin_name }}
+          bin-name: ${{ needs.metadata.outputs.bin_name }}
+          target: ${{ matrix.target }}
+          version: ${{ needs.metadata.outputs.version }}
+          formats: deb,rpm
+          man-paths: >-
+            dist/${{ needs.metadata.outputs.bin_name }}_linux_${{
+            matrix.package_arch }}/${{ needs.metadata.outputs.bin_name }}.1
+          outdir: dist
+          deb-depends: ninja-build
+          rpm-depends: ninja-build
+      - name: Prune packaging metadata
+        shell: bash
+        run: rm -rf dist/.man dist/nfpm.yaml
+      - name: Upload Linux artefacts
+        uses: >-
+          actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # v4
+        with:
+          name: ${{ env.REPO_NAME }}-${{ matrix.artifact }}
+          path: dist
 
   build-windows:
     needs: metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,8 +328,8 @@ jobs:
               asset_name="${dir_name}-${base_name}"
             fi
             if [[ -n "${seen[$asset_name]:-}" ]]; then
-              printf '%s' '::error title=Duplicate release asset::Asset name '
-              printf '%s\n' "'${asset_name}' would be uploaded more than once"
+              printf '::error title=Duplicate release asset::Asset name '\''%s'\'' would be uploaded more than once\n' \
+                "${asset_name}"
               exit 1
             fi
             seen[$asset_name]=1

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -57,8 +57,8 @@ def main() -> int:
     manifest_path = args.manifest_path or os.environ.get(
         "CARGO_TOML_PATH", "Cargo.toml"
     )
-    manifest = read_manifest(Path(manifest_path))
     try:
+        manifest = read_manifest(Path(manifest_path))
         value = get_field(manifest, args.field)
     except (KeyError, FileNotFoundError) as exc:
         print(exc, file=sys.stderr)

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Utility helpers for extracting fields from Cargo.toml."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import tomllib
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read selected fields from a Cargo.toml manifest and print them to "
+            "stdout."
+        )
+    )
+    parser.add_argument(
+        "field",
+        choices=("name", "version"),
+        help="The manifest field to print."
+    )
+    parser.add_argument(
+        "--manifest-path",
+        default=None,
+        help=(
+            "Path to the Cargo.toml file. Defaults to the CARGO_TOML_PATH "
+            "environment variable when set, otherwise Cargo.toml in the "
+            "current working directory."
+        ),
+    )
+    return parser.parse_args()
+
+
+def read_manifest(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Manifest {path} does not exist")
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def get_field(manifest: dict[str, object], field: str) -> str:
+    package = manifest.get("package") or {}
+    if not isinstance(package, dict):
+        raise KeyError("package table missing from manifest")
+    value = package.get(field, "")
+    if not isinstance(value, str) or not value:
+        raise KeyError(f"package.{field} is missing")
+    return value
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = args.manifest_path or os.environ.get(
+        "CARGO_TOML_PATH", "Cargo.toml"
+    )
+    manifest = read_manifest(Path(manifest_path))
+    try:
+        value = get_field(manifest, args.field)
+    except (KeyError, FileNotFoundError) as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    print(value, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- allow the release workflow to decide whether to publish via a reusable input
- parse the package version independently of the publish check and skip release uploads when disabled
- add a pull request dry-run workflow that reuses the release pipeline and verifies artefacts are produced

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbbe32e24883228d69b623f3d219bc

## Summary by Sourcery

Make the release workflow reusable with a publish toggle and add a PR dry-run workflow to generate and verify artifacts without publishing

New Features:
- Add a ‘publish’ input to the release workflow to conditionally skip actual release uploads
- Introduce a pull request dry-run workflow that reuses the release pipeline and verifies generated artifacts

Enhancements:
- Decouple version extraction from publish checks and skip release steps when publishing is disabled
- Extract Cargo.toml parsing into a standalone read_manifest.py utility

CI:
- Enable workflow_call usage in release.yml and add a separate release-dry-run.yml workflow for PRs

Tests:
- Add a validation job to ensure packaged artifacts exist in the dry-run workflow