### PR TITLE
Handle invalid Cargo manifest decoding errors

### DIFF
--- a/.github/actions/upload-release-assets/action.yml
+++ b/.github/actions/upload-release-assets/action.yml
@@ -1,0 +1,30 @@
+name: Upload release artefacts
+description: Upload staged artefacts to a GitHub release or validate them in dry-run mode.
+inputs:
+  release-tag:
+    description: Git tag identifying the release to publish to.
+    required: true
+  bin-name:
+    description: Binary name used to derive artefact names.
+    required: true
+  dist-dir:
+    description: Directory containing staged artefacts.
+    required: false
+    default: dist
+  dry-run:
+    description: When true, only validate artefacts and print the upload plan.
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Upload release artefacts
+      shell: bash
+      env:
+        INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
+        INPUT_BIN_NAME: ${{ inputs.bin-name }}
+        INPUT_DIST_DIR: ${{ inputs.dist-dir }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+        "$GITHUB_WORKSPACE/scripts/upload_release_assets.py"

--- a/.github/actions/upload-release-assets/action.yml
+++ b/.github/actions/upload-release-assets/action.yml
@@ -15,10 +15,18 @@ inputs:
     description: When true, only validate artefacts and print the upload plan.
     required: false
     default: "false"
+outputs:
+  upload-error:
+    description: Whether the invocation detected an error.
+    value: ${{ steps.invoke.outputs.upload-error }}
+  error-message:
+    description: Summary of the error when ``upload-error`` is ``true``.
+    value: ${{ steps.invoke.outputs.error-message }}
 runs:
   using: composite
   steps:
-    - name: Upload release artefacts
+    - id: invoke
+      name: Upload release artefacts
       shell: bash
       env:
         INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
@@ -26,5 +34,22 @@ runs:
         INPUT_DIST_DIR: ${{ inputs.dist-dir }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
       run: |
-        set -euo pipefail
-        "$GITHUB_WORKSPACE/scripts/upload_release_assets.py"
+        set -uo pipefail
+        log_file="$(mktemp)"
+        if "$GITHUB_WORKSPACE/scripts/upload_release_assets.py" >"$log_file" 2>&1; then
+          cat "$log_file"
+          {
+            echo "upload-error=false"
+            echo "error-message="
+          } >>"$GITHUB_OUTPUT"
+        else
+          status=$?
+          cat "$log_file"
+          {
+            echo "upload-error=true"
+            echo "error-message<<'EOF'"
+            cat "$log_file"
+            printf 'Exit code: %s\n' "$status"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,14 +27,10 @@ jobs:
         with:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
-      - name: Ensure artefacts exist
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          mapfile -t files < <(find dist -type f)
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo '::error title=Missing artefacts::No artefacts downloaded'
-            exit 1
-          fi
-          printf 'Found %s artefact(s) in dist/\n' "${#files[@]}"
+      - name: Validate artefacts
+        uses: ./.github/actions/upload-release-assets
+        with:
+          release-tag: ${{ github.ref_name }}
+          bin-name: ${{ needs.release.outputs.bin_name }}
+          dist-dir: dist
+          dry-run: "true"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,10 +27,17 @@ jobs:
         with:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
-      - name: Validate artefacts
+      - id: validate
+        name: Validate artefacts
         uses: ./.github/actions/upload-release-assets
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.release.outputs.bin_name }}
           dist-dir: dist
           dry-run: "true"
+      - name: Check validation errors
+        if: steps.validate.outputs.upload-error == 'true'
+        run: |
+          echo "Error validating release assets:"
+          printf '%s\n' "${{ steps.validate.outputs.error-message }}"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ name: Release Binary
         required: false
         type: boolean
         default: false
+    outputs:
+      bin_name:
+        description: Binary name derived from Cargo metadata.
+        value: ${{ jobs.metadata.outputs.bin_name }}
+      version:
+        description: Crate version resolved from Cargo.toml.
+        value: ${{ jobs.metadata.outputs.version }}
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,51 +299,11 @@ jobs:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
       - name: Upload artefacts to release
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          bin_name="${BIN_NAME:?BIN_NAME must be provided}"
-          mapfile -t files < <(
-            find dist -type f \
-              \( -name "*.deb" -o -name "*.rpm" -o -name "*.pkg" -o -name "*.msi" \
-              -o -name "${bin_name}" -o -name "${bin_name}.exe" \
-              -o -name "${bin_name}.1" -o -name "*.sha256" \)
-              -print
-          )
-          if [ "${#files[@]}" -eq 0 ]; then
-            message='::error title=No artefacts uploaded::No files found in '
-            message+='dist/'
-            echo "$message"
-            exit 1
-          fi
-          declare -A seen=()
-          uploaded=0
-          for file in "${files[@]}"; do
-            dir_name="$(basename "$(dirname "$file")")"
-            base_name="$(basename "$file")"
-            if [[ "$base_name" =~ \.(deb|rpm|pkg)$ ]]; then
-              asset_name="$base_name"
-            else
-              asset_name="${dir_name}-${base_name}"
-            fi
-            if [[ -n "${seen[$asset_name]:-}" ]]; then
-              printf '::error title=Duplicate release asset::Asset name '\''%s'\'' would be uploaded more than once\n' \
-                "${asset_name}"
-              exit 1
-            fi
-            seen[$asset_name]=1
-            gh release upload "${{ github.ref_name }}" \
-              "$file#${asset_name}" --clobber \
-              && uploaded=$((uploaded + 1))
-          done
-          if [ "$uploaded" -eq 0 ]; then
-            message='::error title=No artefacts uploaded::No files were '
-            message+='published to the release'
-            echo "$message"
-            exit 1
-          fi
+        uses: ./.github/actions/upload-release-assets
+        with:
+          release-tag: ${{ github.ref_name }}
+          bin-name: ${{ needs.metadata.outputs.bin_name }}
+          dist-dir: dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BIN_NAME: ${{ needs.metadata.outputs.bin_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ name: Release Binary
       version:
         description: Crate version resolved from Cargo.toml
         value: ${{ jobs.metadata.outputs.version }}
+      should_publish:
+        description: Whether artefacts should be published to the release
+        value: ${{ jobs.metadata.outputs.should_publish }}
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ name: Release Binary
         default: false
     outputs:
       bin_name:
-        description: Binary name derived from Cargo metadata.
+        description: Binary name extracted from Cargo.toml.
         value: ${{ jobs.metadata.outputs.bin_name }}
       version:
         description: Crate version resolved from Cargo.toml.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,8 @@ jobs:
         with:
           path: dist
           pattern: ${{ env.REPO_NAME }}-*
-      - name: Upload artefacts to release
+      - id: upload_assets
+        name: Upload artefacts to release
         uses: ./.github/actions/upload-release-assets
         with:
           release-tag: ${{ github.ref_name }}
@@ -317,3 +318,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check asset upload errors
+        if: steps.upload_assets.outputs.upload-error == 'true'
+        run: |
+          echo "Error uploading release assets:"
+          printf '%s\n' "${{ steps.upload_assets.outputs.error-message }}"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ name: Release Binary
         default: false
     outputs:
       bin_name:
-        description: Binary name extracted from Cargo.toml.
+        description: Binary name extracted from Cargo.toml
         value: ${{ jobs.metadata.outputs.bin_name }}
       version:
-        description: Crate version resolved from Cargo.toml.
+        description: Crate version resolved from Cargo.toml
         value: ${{ jobs.metadata.outputs.version }}
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 name: Release Binary
 
-'on':
+on:
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -1,5 +1,43 @@
 #!/usr/bin/env python3
-"""Utility helpers for extracting fields from Cargo.toml."""
+"""
+Utility helpers for extracting fields from Cargo.toml.
+
+Summary
+-------
+Parse and extract package metadata fields from Cargo manifest files.
+
+Purpose
+-------
+Provide both a CLI tool and programmatic API for reading ``name`` and
+``version`` fields from Cargo.toml manifests, with robust error handling
+for missing files, invalid TOML, and unexpected structure.
+
+Usage
+-----
+CLI invocation::
+
+    python read_manifest.py name --manifest-path /path/to/Cargo.toml
+    python read_manifest.py version
+
+Programmatic usage::
+
+    from pathlib import Path
+    manifest = read_manifest(Path("Cargo.toml"))
+    name = get_field(manifest, "name")
+
+Examples
+--------
+Extract the package name from a manifest::
+
+    $ python read_manifest.py name --manifest-path Cargo.toml
+    netsuke
+
+Use the CARGO_TOML_PATH environment variable::
+
+    $ export CARGO_TOML_PATH=/path/to/Cargo.toml
+    $ python read_manifest.py version
+    1.2.3
+"""
 
 from __future__ import annotations
 
@@ -19,7 +57,21 @@ PARSER_DESCRIPTION = " ".join(
 
 
 def parse_args() -> argparse.Namespace:
-    """Return the parsed CLI arguments for manifest field extraction."""
+    """
+    Return the parsed CLI arguments for manifest field extraction.
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed arguments containing ``field`` (str) and optional
+        ``manifest_path`` (str or None).
+
+    Examples
+    --------
+    >>> args = parse_args()  # With sys.argv = ["script.py", "name"]
+    >>> args.field
+    'name'
+    """
     parser = argparse.ArgumentParser(description=PARSER_DESCRIPTION)
     parser.add_argument(
         "field", choices=("name", "version"), help="The manifest field to print."
@@ -111,7 +163,22 @@ def get_field(manifest: dict[str, object], field: str) -> str:
 
 
 def main() -> int:
-    """Entry point for the manifest reader CLI."""
+    """
+    Entry point for the manifest reader CLI.
+
+    Returns
+    -------
+    int
+        Exit code: 0 for success, 1 for errors (missing file, invalid
+        TOML, or missing fields).
+
+    Examples
+    --------
+    Typical CLI invocation::
+
+        $ python read_manifest.py name --manifest-path Cargo.toml
+        netsuke
+    """
     args = parse_args()
     manifest_path = args.manifest_path or os.environ.get(
         "CARGO_TOML_PATH", "Cargo.toml"

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -37,7 +37,34 @@ def parse_args() -> argparse.Namespace:
 
 
 def read_manifest(path: Path) -> dict[str, object]:
-    """Load and return the parsed Cargo manifest as a dictionary."""
+    """
+    Load and return the parsed Cargo manifest as a dictionary.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the ``Cargo.toml`` file.
+
+    Returns
+    -------
+    dict[str, object]
+        Parsed manifest fields keyed by section.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the manifest file does not exist.
+    tomllib.TOMLDecodeError
+        If the manifest contains invalid TOML syntax.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> manifest_path = Path("Cargo.toml")
+    >>> data = read_manifest(manifest_path)
+    >>> "package" in data
+    True
+    """
     if not path.is_file():
         message = f"Manifest {path} does not exist"
         raise FileNotFoundError(message)
@@ -46,7 +73,32 @@ def read_manifest(path: Path) -> dict[str, object]:
 
 
 def get_field(manifest: dict[str, object], field: str) -> str:
-    """Extract a package field from the manifest, raising if it is missing."""
+    """
+    Extract a package field from the manifest, raising if it is missing.
+
+    Parameters
+    ----------
+    manifest : dict[str, object]
+        The parsed Cargo manifest dictionary.
+    field : str
+        The package field to extract, such as ``"name"`` or ``"version"``.
+
+    Returns
+    -------
+    str
+        The non-empty field value from the package section.
+
+    Raises
+    ------
+    KeyError
+        If the package table is missing or the field is absent or blank.
+
+    Examples
+    --------
+    >>> manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
+    >>> get_field(manifest, "name")
+    'netsuke'
+    """
     package = manifest.get("package") or {}
     if not isinstance(package, dict):
         message = "package table missing from manifest"

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -10,18 +10,19 @@ from pathlib import Path
 
 import tomllib
 
+PARSER_DESCRIPTION = " ".join(
+    [
+        "Read selected fields from a Cargo.toml manifest and print them to",
+        "stdout.",
+    ]
+)
+
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Read selected fields from a Cargo.toml manifest and print them to "
-            "stdout."
-        )
-    )
+    """Return the parsed CLI arguments for manifest field extraction."""
+    parser = argparse.ArgumentParser(description=PARSER_DESCRIPTION)
     parser.add_argument(
-        "field",
-        choices=("name", "version"),
-        help="The manifest field to print."
+        "field", choices=("name", "version"), help="The manifest field to print."
     )
     parser.add_argument(
         "--manifest-path",
@@ -36,23 +37,29 @@ def parse_args() -> argparse.Namespace:
 
 
 def read_manifest(path: Path) -> dict[str, object]:
+    """Load and return the parsed Cargo manifest as a dictionary."""
     if not path.is_file():
-        raise FileNotFoundError(f"Manifest {path} does not exist")
+        message = f"Manifest {path} does not exist"
+        raise FileNotFoundError(message)
     with path.open("rb") as handle:
         return tomllib.load(handle)
 
 
 def get_field(manifest: dict[str, object], field: str) -> str:
+    """Extract a package field from the manifest, raising if it is missing."""
     package = manifest.get("package") or {}
     if not isinstance(package, dict):
-        raise KeyError("package table missing from manifest")
+        message = "package table missing from manifest"
+        raise KeyError(message)
     value = package.get(field, "")
     if not isinstance(value, str) or not value:
-        raise KeyError(f"package.{field} is missing")
+        message = f"package.{field} is missing"
+        raise KeyError(message)
     return value
 
 
 def main() -> int:
+    """Entry point for the manifest reader CLI."""
     args = parse_args()
     manifest_path = args.manifest_path or os.environ.get(
         "CARGO_TOML_PATH", "Cargo.toml"

--- a/.github/workflows/scripts/read_manifest.py
+++ b/.github/workflows/scripts/read_manifest.py
@@ -60,7 +60,7 @@ def main() -> int:
     try:
         manifest = read_manifest(Path(manifest_path))
         value = get_field(manifest, args.field)
-    except (KeyError, FileNotFoundError) as exc:
+    except (KeyError, FileNotFoundError, tomllib.TOMLDecodeError) as exc:
         print(exc, file=sys.stderr)
         return 1
     print(value, end="")

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,6 +38,7 @@ select = [
 ]
 per-file-ignores = {"**/test_*.py" = ["S101"]}
 ignore = ["D205"]
+task-tags = ["TODO", "FIXME"]
 
 [lint.flake8-import-conventions]
 # Declare the banned `from` imports.
@@ -61,5 +62,5 @@ msgspec = "ms"
 typing = "typ"
 
 [lint.pydocstyle]
-# Enforce NumPy docstring 
+# Enforce NumPy docstring
 convention = "numpy"

--- a/scripts/tests/test_upload_release_assets.py
+++ b/scripts/tests/test_upload_release_assets.py
@@ -1,0 +1,102 @@
+"""Tests for the upload_release_assets helper script."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "upload_release_assets.py"
+
+
+@pytest.fixture(scope="session")
+def module():
+    spec = importlib.util.spec_from_file_location(
+        "upload_release_assets", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+def create_file(path: Path, content: bytes = b"data") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def test_discover_assets_collects_expected_files(module, tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    create_file(dist / "linux" / "netsuke", b"binary")
+    create_file(dist / "linux" / "netsuke.sha256", b"checksum")
+    create_file(dist / "linux" / "netsuke.deb", b"deb")
+    create_file(dist / "windows" / "netsuke.exe", b"exe")
+    create_file(dist / "windows" / "netsuke.msi", b"msi")
+    create_file(dist / "man" / "netsuke.1", b"man")
+
+    assets = module.discover_assets(dist, bin_name="netsuke")
+
+    assert [asset.asset_name for asset in assets] == [
+        "linux-netsuke",
+        "netsuke.deb",
+        "linux-netsuke.sha256",
+        "man-netsuke.1",
+        "windows-netsuke.exe",
+        "windows-netsuke.msi",
+    ]
+
+
+def test_discover_assets_rejects_duplicates(module, tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    create_file(dist / "a" / "netsuke.pkg", b"pkg-a")
+    create_file(dist / "b" / "netsuke.pkg", b"pkg-b")
+
+    with pytest.raises(module.AssetError) as exc:
+        module.discover_assets(dist, bin_name="netsuke")
+
+    assert "Asset name collision" in str(exc.value)
+
+
+def test_discover_assets_rejects_empty_files(module, tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    create_file(dist / "linux" / "netsuke", b"")
+
+    with pytest.raises(module.AssetError) as exc:
+        module.discover_assets(dist, bin_name="netsuke")
+
+    assert "is empty" in str(exc.value)
+
+
+def test_cli_dry_run_outputs_summary(module, tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    create_file(dist / "linux" / "netsuke", b"binary")
+    create_file(dist / "linux" / "netsuke.sha256", b"checksum")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--release-tag",
+            "v1.2.3",
+            "--bin-name",
+            "netsuke",
+            "--dist-dir",
+            str(dist),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Planned uploads:" in result.stdout
+    assert "linux-netsuke" in result.stdout
+    assert "linux-netsuke.sha256" in result.stdout
+    assert "[dry-run] gh release upload v1.2.3" in result.stdout

--- a/scripts/tests/test_upload_release_assets.py
+++ b/scripts/tests/test_upload_release_assets.py
@@ -27,6 +27,7 @@ def module():
 
 
 def create_file(path: Path, content: bytes = b"data") -> None:
+    """Create a file with ``content``, creating parent directories as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(content)
 

--- a/scripts/tests/test_upload_release_assets.py
+++ b/scripts/tests/test_upload_release_assets.py
@@ -27,7 +27,7 @@ def module():
 
 
 def create_file(path: Path, content: bytes = b"data") -> None:
-    """Create a file with ``content``, creating parent directories as needed."""
+    """Create a file with the given content, ensuring parent directories exist."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(content)
 
@@ -83,7 +83,7 @@ def test_cli_dry_run_outputs_summary(module, tmp_path: Path) -> None:
     create_file(dist / "linux" / "netsuke", b"binary")
     create_file(dist / "linux" / "netsuke.sha256", b"checksum")
 
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - trusted arguments within tests
         [
             sys.executable,
             str(SCRIPT_PATH),

--- a/scripts/tests/test_upload_release_assets.py
+++ b/scripts/tests/test_upload_release_assets.py
@@ -83,7 +83,7 @@ def test_cli_dry_run_outputs_summary(module, tmp_path: Path) -> None:
     create_file(dist / "linux" / "netsuke", b"binary")
     create_file(dist / "linux" / "netsuke.sha256", b"checksum")
 
-    result = subprocess.run(  # noqa: S603 - trusted arguments within tests
+    result = subprocess.run(  # noqa: S603 # FIXME: subprocess required for CLI integration test with trusted arguments
         [
             sys.executable,
             str(SCRIPT_PATH),

--- a/scripts/upload_release_assets.py
+++ b/scripts/upload_release_assets.py
@@ -119,9 +119,9 @@ def discover_assets(dist_dir: Path, *, bin_name: str) -> list[ReleaseAsset]:
 
     Parameters
     ----------
-    dist_dir:
+    dist_dir : Path
         Root directory that contains the staged artefacts.
-    bin_name:
+    bin_name : str
         Binary name used to match platform-specific artefacts.
 
     Returns
@@ -134,6 +134,11 @@ def discover_assets(dist_dir: Path, *, bin_name: str) -> list[ReleaseAsset]:
     AssetError
         If no artefacts are found, an artefact is empty, or multiple files would
         upload with the same asset name.
+
+    Examples
+    --------
+    >>> discover_assets(Path("dist"), bin_name="netsuke")  # doctest: +SKIP
+    [ReleaseAsset(path=PosixPath('dist/netsuke'), ...)]
     """
     if not dist_dir.exists():
         message = f"Artefact directory {dist_dir} does not exist"
@@ -171,11 +176,11 @@ def upload_assets(
 
     Parameters
     ----------
-    release_tag:
+    release_tag : str
         Git tag identifying the release that should receive the artefacts.
-    assets:
+    assets : Iterable[ReleaseAsset]
         Iterable of artefacts to publish.
-    dry_run:
+    dry_run : bool
         When ``True``, print the planned ``gh`` invocations without executing
         them.
 
@@ -185,6 +190,14 @@ def upload_assets(
         If ``gh`` returns a non-zero status while uploading.
     CommandNotFound
         If the ``gh`` executable is not available in ``PATH``.
+
+    Examples
+    --------
+    >>> upload_assets(  # doctest: +SKIP
+    ...     release_tag="v1.2.3",
+    ...     assets=[ReleaseAsset(Path("dist/netsuke"), "netsuke", 1024)],
+    ...     dry_run=True,
+    ... )
     """
     gh_cmd: BoundCommand | None = None
     for asset in assets:
@@ -214,13 +227,13 @@ def main(
 
     Parameters
     ----------
-    release_tag:
+    release_tag : str
         Git tag identifying the release to publish to.
-    bin_name:
+    bin_name : str
         Binary name used to derive artefact names during discovery.
-    dist_dir:
+    dist_dir : Path
         Directory containing staged artefacts.
-    dry_run:
+    dry_run : bool
         When ``True``, validate artefacts and print the upload plan without
         uploading.
 
@@ -229,6 +242,16 @@ def main(
     int
         Exit code: ``0`` on success, ``1`` when artefact discovery or upload
         fails.
+
+    Examples
+    --------
+    >>> main(  # doctest: +SKIP
+    ...     release_tag="v1.2.3",
+    ...     bin_name="netsuke",
+    ...     dist_dir=Path("dist"),
+    ...     dry_run=True,
+    ... )
+    0
     """
     try:
         assets = discover_assets(dist_dir, bin_name=bin_name)

--- a/scripts/upload_release_assets.py
+++ b/scripts/upload_release_assets.py
@@ -87,8 +87,7 @@ def _require_non_empty(path: Path) -> int:
 
 
 def _register_asset(asset_name: str, path: Path, seen: dict[str, Path]) -> None:
-    previous = seen.get(asset_name)
-    if previous:
+    if previous := seen.get(asset_name):
         message = (
             "Asset name collision: "
             f"{asset_name} would upload both {previous} and {path}"

--- a/scripts/upload_release_assets.py
+++ b/scripts/upload_release_assets.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=2.9", "plumbum"]
+# ///
+
+"""Upload packaged release artefacts to a GitHub release.
+
+The script discovers artefacts in a staging directory, validates their
+filenames and sizes, and optionally uploads them using the GitHub CLI. It is
+idempotent and supports a dry-run mode used by the release dry-run workflow to
+assert expected asset names without mutating state.
+
+Examples
+--------
+Upload artefacts to the ``v1.2.3`` release::
+
+    upload_release_assets --release-tag v1.2.3 --bin-name netsuke
+
+Inspect the planned uploads without publishing anything::
+
+    upload_release_assets --release-tag v1.2.3 --bin-name netsuke --dry-run
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Iterable
+import sys
+
+import cyclopts
+from cyclopts import App, Parameter
+from plumbum import local
+
+
+class AssetError(RuntimeError):
+    """Raised when the staged artefacts are invalid."""
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    """Artefact staged for upload to a GitHub release."""
+
+    path: Path
+    asset_name: str
+    size: int
+
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+
+def _is_candidate(path: Path, bin_name: str) -> bool:
+    name = path.name
+    if name in {bin_name, f"{bin_name}.exe", f"{bin_name}.1"}:
+        return True
+    if name.endswith(".sha256"):
+        return True
+    return path.suffix in {".deb", ".rpm", ".pkg", ".msi"}
+
+
+def _resolve_asset_name(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix in {".deb", ".rpm", ".pkg"}:
+        return path.name
+    return f"{path.parent.name}-{path.name}"
+
+
+def discover_assets(dist_dir: Path, *, bin_name: str) -> list[ReleaseAsset]:
+    """Return the artefacts that should be published.
+
+    Parameters
+    ----------
+    dist_dir:
+        Root directory that contains the staged artefacts.
+    bin_name:
+        Binary name used to match platform-specific artefacts.
+
+    Returns
+    -------
+    list[ReleaseAsset]
+        Ordered collection of artefacts ready to upload.
+
+    Raises
+    ------
+    AssetError
+        If no artefacts are found, an artefact is empty, or multiple files would
+        upload with the same asset name.
+    """
+
+    if not dist_dir.exists():
+        raise AssetError(f"Artefact directory {dist_dir} does not exist")
+
+    assets: list[ReleaseAsset] = []
+    seen: dict[str, Path] = {}
+
+    for path in sorted(p for p in dist_dir.rglob("*") if p.is_file()):
+        if not _is_candidate(path, bin_name):
+            continue
+        size = path.stat().st_size
+        if size <= 0:
+            raise AssetError(f"Artefact {path} is empty")
+        asset_name = _resolve_asset_name(path)
+        previous = seen.get(asset_name)
+        if previous:
+            raise AssetError(
+                "Asset name collision: "
+                f"{asset_name} would upload both {previous} and {path}"
+            )
+        seen[asset_name] = path
+        assets.append(ReleaseAsset(path=path, asset_name=asset_name, size=size))
+
+    if not assets:
+        raise AssetError(f"No artefacts discovered in {dist_dir}")
+
+    return assets
+
+
+def _render_summary(assets: Iterable[ReleaseAsset]) -> str:
+    lines = ["Planned uploads:"]
+    for asset in assets:
+        lines.append(
+            f"  - {asset.asset_name} ({asset.size} bytes) -> {asset.path}"
+        )
+    return "\n".join(lines)
+
+
+def upload_assets(
+    *, release_tag: str, assets: Iterable[ReleaseAsset], dry_run: bool = False
+) -> None:
+    """Upload artefacts to GitHub using the ``gh`` CLI."""
+
+    gh_cmd = None
+    for asset in assets:
+        descriptor = f"{asset.path}#{asset.asset_name}"
+        if dry_run:
+            print(f"[dry-run] gh release upload {release_tag} {descriptor} --clobber")
+            continue
+        if gh_cmd is None:
+            gh_cmd = local["gh"]
+        gh_cmd[
+            "release",
+            "upload",
+            release_tag,
+            descriptor,
+            "--clobber",
+        ]()
+
+
+def main(
+    *,
+    release_tag: str,
+    bin_name: str,
+    dist_dir: Path = Path("dist"),
+    dry_run: bool = False,
+) -> int:
+    """Entry point shared by the CLI and tests."""
+
+    try:
+        assets = discover_assets(dist_dir, bin_name=bin_name)
+    except AssetError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    if dry_run:
+        print(_render_summary(assets))
+
+    try:
+        upload_assets(release_tag=release_tag, assets=assets, dry_run=dry_run)
+    except Exception as exc:  # pragma: no cover - surfaced by plumbum
+        print(exc, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+@app.default
+def cli(
+    *,
+    release_tag: Annotated[str, Parameter(required=True)],
+    bin_name: Annotated[str, Parameter(required=True)],
+    dist_dir: Path = Path("dist"),
+    dry_run: bool = False,
+) -> int:
+    """Cyclopts-bound CLI entry point."""
+
+    return main(
+        release_tag=release_tag,
+        bin_name=bin_name,
+        dist_dir=dist_dir,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via CLI
+    raise SystemExit(app())

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -1,0 +1,125 @@
+"""Tests for the read_manifest helper script."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from typing import Any
+
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / ".github" / "workflows" / "scripts" / "read_manifest.py"
+
+
+def load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("read_manifest", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[assignment]
+    return module
+
+
+class ReadManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = load_script_module()
+
+    def setUp(self) -> None:
+        self.tempdir = TemporaryDirectory()
+        self.temp_path = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _write_manifest(self, content: str) -> Path:
+        manifest = self.temp_path / "Cargo.toml"
+        manifest.write_text(dedent(content), encoding="utf-8")
+        return manifest
+
+    def test_get_field_returns_name(self) -> None:
+        manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
+        self.assertEqual(self.module.get_field(manifest, "name"), "netsuke")
+
+    def test_get_field_returns_version(self) -> None:
+        manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
+        self.assertEqual(self.module.get_field(manifest, "version"), "1.2.3")
+
+    def test_get_field_raises_when_missing(self) -> None:
+        manifest = {"package": {"name": "netsuke"}}
+        with self.assertRaises(KeyError):
+            self.module.get_field(manifest, "version")
+
+    def test_main_reads_manifest_path_argument(self) -> None:
+        manifest = self._write_manifest(
+            """
+            [package]
+            name = "netsuke"
+            version = "1.2.3"
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(manifest)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "netsuke")
+        self.assertEqual(result.stderr, "")
+
+    def test_main_prefers_environment_manifest_path(self) -> None:
+        manifest = self._write_manifest(
+            """
+            [package]
+            name = "netsuke"
+            version = "1.2.3"
+            """
+        )
+        env = os.environ.copy()
+        env["CARGO_TOML_PATH"] = str(manifest)
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=self.temp_path,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "1.2.3")
+        self.assertEqual(result.stderr, "")
+
+    def test_main_reports_missing_manifest(self) -> None:
+        missing = self.temp_path / "missing.toml"
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(missing)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not exist", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_main_reports_invalid_toml(self) -> None:
+        manifest = self._write_manifest("not = [valid")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(manifest)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -78,7 +78,17 @@ SCRIPT_PATH = REPO_ROOT / ".github" / "workflows" / "scripts" / "read_manifest.p
 
 @dataclasses.dataclass(slots=True)
 class CLIResult:
-    """Result container returned by :func:`ReadManifestTests._invoke_cli`."""
+    """CLI invocation outcome.
+
+    Attributes
+    ----------
+    exit_code : int
+        Exit status returned by the CLI process.
+    stdout : str
+        Captured standard output emitted by the CLI.
+    stderr : str
+        Captured standard error emitted by the CLI.
+    """
 
     exit_code: int
     stdout: str

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -150,16 +150,21 @@ def read_manifest_tests(
     return ReadManifestTests(module=read_manifest_module, temp_path=tmp_path)
 
 
-def test_get_field_returns_name(read_manifest_module: types.ModuleType) -> None:
-    """It returns the package name from the manifest."""
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    (
+        ("name", "netsuke"),
+        ("version", "1.2.3"),
+    ),
+)
+def test_get_field_returns_value(
+    read_manifest_module: types.ModuleType,
+    field: str,
+    expected: str,
+) -> None:
+    """It returns the requested package metadata from the manifest."""
     manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
-    assert read_manifest_module.get_field(manifest, "name") == "netsuke"
-
-
-def test_get_field_returns_version(read_manifest_module: types.ModuleType) -> None:
-    """It returns the package version from the manifest."""
-    manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
-    assert read_manifest_module.get_field(manifest, "version") == "1.2.3"
+    assert read_manifest_module.get_field(manifest, field) == expected
 
 
 def test_get_field_raises_when_missing(read_manifest_module: types.ModuleType) -> None:

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -2,27 +2,26 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
-from dataclasses import dataclass
+import dataclasses
 import importlib.util
-from io import StringIO
 import os
 import subprocess
 import sys
+import types
+import typing as typ
+from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import Any
+from unittest import mock
 
-import unittest
-from unittest.mock import patch
-
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = REPO_ROOT / ".github" / "workflows" / "scripts" / "read_manifest.py"
 
 
-@dataclass(slots=True)
+@dataclasses.dataclass(slots=True)
 class CLIResult:
     """Result container returned by :func:`ReadManifestTests._invoke_cli`."""
 
@@ -32,9 +31,8 @@ class CLIResult:
 
 
 @contextmanager
-def change_directory(path: Path) -> Any:
+def change_directory(path: Path) -> typ.Iterator[None]:
     """Temporarily change the working directory for the current process."""
-
     original = Path.cwd()
     os.chdir(path)
     try:
@@ -43,27 +41,26 @@ def change_directory(path: Path) -> Any:
         os.chdir(original)
 
 
-def load_script_module() -> Any:
+def load_script_module() -> types.ModuleType:
+    """Import the read_manifest script as a module for reuse in tests."""
     spec = importlib.util.spec_from_file_location("read_manifest", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-    assert spec and spec.loader
+    assert spec is not None
+    assert spec.loader is not None
     spec.loader.exec_module(module)  # type: ignore[assignment]
+    assert isinstance(module, types.ModuleType)
     return module
 
 
-class ReadManifestTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.module = load_script_module()
+@dataclasses.dataclass(slots=True)
+class ReadManifestTests:
+    """Helpers that exercise the manifest-reading CLI in different scenarios."""
 
-    def setUp(self) -> None:
-        self.tempdir = TemporaryDirectory()
-        self.temp_path = Path(self.tempdir.name)
-
-    def tearDown(self) -> None:
-        self.tempdir.cleanup()
+    module: types.ModuleType
+    temp_path: Path
 
     def _write_manifest(self, content: str) -> Path:
+        """Write ``content`` to ``Cargo.toml`` in the temporary directory."""
         manifest = self.temp_path / "Cargo.toml"
         manifest.write_text(dedent(content), encoding="utf-8")
         return manifest
@@ -75,37 +72,49 @@ class ReadManifestTests(unittest.TestCase):
         cwd: Path | None = None,
     ) -> CLIResult:
         """Execute the CLI and capture its exit code and output streams."""
-
         stdout = StringIO()
         stderr = StringIO()
         with ExitStack() as stack:
-            stack.enter_context(patch.object(sys, "argv", [str(SCRIPT_PATH), *args]))
+            stack.enter_context(
+                mock.patch.object(sys, "argv", [str(SCRIPT_PATH), *args])
+            )
             if env:
-                stack.enter_context(patch.dict(os.environ, env, clear=False))
+                stack.enter_context(mock.patch.dict(os.environ, env, clear=False))
             if cwd:
                 stack.enter_context(change_directory(cwd))
             stack.enter_context(redirect_stdout(stdout))
             stack.enter_context(redirect_stderr(stderr))
             exit_code = self.module.main()
-        return CLIResult(exit_code=exit_code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+        return CLIResult(
+            exit_code=exit_code,
+            stdout=stdout.getvalue(),
+            stderr=stderr.getvalue(),
+        )
 
     def _assert_manifest_error(
         self,
         manifest_path: Path,
         expected_stderr_fragment: str | None = None,
     ) -> None:
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(manifest_path)],
+        """Assert that invoking the CLI fails for ``manifest_path``."""
+        result = subprocess.run(  # noqa: S603 - executed with trusted inputs in tests
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "name",
+                "--manifest-path",
+                str(manifest_path),
+            ],
             check=False,
             capture_output=True,
             text=True,
         )
-        self.assertNotEqual(result.returncode, 0)
+        assert result.returncode != 0
         if expected_stderr_fragment is not None:
-            self.assertIn(expected_stderr_fragment, result.stderr)
+            assert expected_stderr_fragment in result.stderr
         else:
-            self.assertTrue(result.stderr)
-        self.assertEqual(result.stdout, "")
+            assert result.stderr
+        assert result.stdout == ""
 
     def _assert_successful_field_read(
         self,
@@ -117,87 +126,128 @@ class ReadManifestTests(unittest.TestCase):
         env: dict[str, str] | None = None,
         cwd: Path | None = None,
     ) -> None:
+        """Assert that the CLI prints ``expected_value`` for ``field``."""
         manifest = self._write_manifest(manifest_content)
         args = cli_args or (field, "--manifest-path", str(manifest))
         result = self._invoke_cli(*args, env=env, cwd=cwd)
-        self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.stdout, expected_value)
-        self.assertEqual(result.stderr, "")
+        assert result.exit_code == 0
+        assert result.stdout == expected_value
+        assert result.stderr == ""
 
-    def test_get_field_returns_name(self) -> None:
-        manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
-        self.assertEqual(self.module.get_field(manifest, "name"), "netsuke")
 
-    def test_get_field_returns_version(self) -> None:
-        manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
-        self.assertEqual(self.module.get_field(manifest, "version"), "1.2.3")
+@pytest.fixture(scope="module")
+def read_manifest_module() -> types.ModuleType:
+    """Load the read_manifest script once for all tests."""
+    return load_script_module()
 
-    def test_get_field_raises_when_missing(self) -> None:
-        manifest = {"package": {"name": "netsuke"}}
-        with self.assertRaises(KeyError):
-            self.module.get_field(manifest, "version")
 
-    def test_get_field_rejects_non_string_values(self) -> None:
-        manifest = {
-            "package": {
-                "name": "netsuke",
-                "version": 123,
-                "authors": ["alice", "bob"],
-                "metadata": {"license": "MIT"},
-            }
+@pytest.fixture
+def read_manifest_tests(
+    read_manifest_module: types.ModuleType,
+    tmp_path: Path,
+) -> ReadManifestTests:
+    """Provide helpers that operate within a temporary working directory."""
+    return ReadManifestTests(module=read_manifest_module, temp_path=tmp_path)
+
+
+def test_get_field_returns_name(read_manifest_module: types.ModuleType) -> None:
+    """It returns the package name from the manifest."""
+    manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
+    assert read_manifest_module.get_field(manifest, "name") == "netsuke"
+
+
+def test_get_field_returns_version(read_manifest_module: types.ModuleType) -> None:
+    """It returns the package version from the manifest."""
+    manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
+    assert read_manifest_module.get_field(manifest, "version") == "1.2.3"
+
+
+def test_get_field_raises_when_missing(read_manifest_module: types.ModuleType) -> None:
+    """It raises when the requested field is absent."""
+    manifest = {"package": {"name": "netsuke"}}
+    with pytest.raises(KeyError):
+        read_manifest_module.get_field(manifest, "version")
+
+
+def test_get_field_rejects_non_string_values(
+    read_manifest_module: types.ModuleType,
+) -> None:
+    """It rejects non-string manifest entries."""
+    manifest = {
+        "package": {
+            "name": "netsuke",
+            "version": 123,
+            "authors": ["alice", "bob"],
+            "metadata": {"license": "MIT"},
         }
-        with self.assertRaises(KeyError):
-            self.module.get_field(manifest, "version")
-        with self.assertRaises(KeyError):
-            self.module.get_field(manifest, "authors")
-        with self.assertRaises(KeyError):
-            self.module.get_field(manifest, "metadata")
-
-    def test_main_reads_manifest_path_argument(self) -> None:
-        self._assert_successful_field_read(
-            """
-            [package]
-            name = "netsuke"
-            version = "1.2.3"
-            """,
-            field="name",
-            expected_value="netsuke",
-        )
-
-    def test_main_prefers_environment_manifest_path(self) -> None:
-        manifest = self._write_manifest(
-            """
-            [package]
-            name = "netsuke"
-            version = "1.2.3"
-            """
-        )
-        env = {"CARGO_TOML_PATH": str(manifest)}
-        result = self._invoke_cli("version", env=env, cwd=self.temp_path)
-        self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.stdout, "1.2.3")
-        self.assertEqual(result.stderr, "")
-
-    def test_main_reports_missing_manifest(self) -> None:
-        missing = self.temp_path / "missing.toml"
-        self._assert_manifest_error(missing, "does not exist")
-
-    def test_main_reports_invalid_toml(self) -> None:
-        manifest = self._write_manifest("not = [valid")
-        self._assert_manifest_error(manifest)
-
-    def test_main_reports_valid_toml_with_unexpected_structure(self) -> None:
-        manifest = self._write_manifest(
-            """
-            [unexpected_section]
-            foo = "bar"
-            """
-        )
-        result = self._invoke_cli("name", "--manifest-path", str(manifest))
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("missing", result.stderr.lower())
-        self.assertEqual(result.stdout, "")
+    }
+    with pytest.raises(KeyError):
+        read_manifest_module.get_field(manifest, "version")
+    with pytest.raises(KeyError):
+        read_manifest_module.get_field(manifest, "authors")
+    with pytest.raises(KeyError):
+        read_manifest_module.get_field(manifest, "metadata")
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_main_reads_manifest_path_argument(
+    read_manifest_tests: ReadManifestTests,
+) -> None:
+    """It reads manifests from the path provided via CLI arguments."""
+    read_manifest_tests._assert_successful_field_read(
+        """
+        [package]
+        name = "netsuke"
+        version = "1.2.3"
+        """,
+        field="name",
+        expected_value="netsuke",
+    )
+
+
+def test_main_prefers_environment_manifest_path(
+    read_manifest_tests: ReadManifestTests,
+) -> None:
+    """It prefers the manifest path supplied via environment variable."""
+    manifest = read_manifest_tests._write_manifest(
+        """
+        [package]
+        name = "netsuke"
+        version = "1.2.3"
+        """
+    )
+    env = {"CARGO_TOML_PATH": str(manifest)}
+    result = read_manifest_tests._invoke_cli(
+        "version",
+        env=env,
+        cwd=read_manifest_tests.temp_path,
+    )
+    assert result.exit_code == 0
+    assert result.stdout == "1.2.3"
+    assert result.stderr == ""
+
+
+def test_main_reports_missing_manifest(
+    read_manifest_tests: ReadManifestTests,
+) -> None:
+    """It surfaces errors when the manifest file does not exist."""
+    missing = read_manifest_tests.temp_path / "missing.toml"
+    read_manifest_tests._assert_manifest_error(missing, "does not exist")
+
+
+def test_main_reports_invalid_toml(read_manifest_tests: ReadManifestTests) -> None:
+    """It surfaces errors for invalid TOML content."""
+    manifest = read_manifest_tests._write_manifest("not = [valid")
+    read_manifest_tests._assert_manifest_error(manifest)
+
+
+def test_main_reports_valid_toml_with_unexpected_structure(
+    read_manifest_tests: ReadManifestTests,
+) -> None:
+    """It reports a descriptive error when required sections are missing."""
+    manifest = read_manifest_tests._write_manifest(
+        """
+        [unexpected_section]
+        foo = "bar"
+        """
+    )
+    read_manifest_tests._assert_manifest_error(manifest, "missing")

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -78,7 +78,8 @@ SCRIPT_PATH = REPO_ROOT / ".github" / "workflows" / "scripts" / "read_manifest.p
 
 @dataclasses.dataclass(slots=True)
 class CLIResult:
-    """CLI invocation outcome.
+    """
+    Result container returned by ReadManifestTests._invoke_cli.
 
     Attributes
     ----------

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
+from dataclasses import dataclass
 import importlib.util
+from io import StringIO
 import os
-import subprocess
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -12,10 +14,32 @@ from textwrap import dedent
 from typing import Any
 
 import unittest
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = REPO_ROOT / ".github" / "workflows" / "scripts" / "read_manifest.py"
+
+
+@dataclass(slots=True)
+class CLIResult:
+    """Result container returned by :func:`ReadManifestTests._invoke_cli`."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+@contextmanager
+def change_directory(path: Path) -> Any:
+    """Temporarily change the working directory for the current process."""
+
+    original = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original)
 
 
 def load_script_module() -> Any:
@@ -43,6 +67,27 @@ class ReadManifestTests(unittest.TestCase):
         manifest.write_text(dedent(content), encoding="utf-8")
         return manifest
 
+    def _invoke_cli(
+        self,
+        *args: str,
+        env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> CLIResult:
+        """Execute the CLI and capture its exit code and output streams."""
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(sys, "argv", [str(SCRIPT_PATH), *args]))
+            if env:
+                stack.enter_context(patch.dict(os.environ, env, clear=False))
+            if cwd:
+                stack.enter_context(change_directory(cwd))
+            stack.enter_context(redirect_stdout(stdout))
+            stack.enter_context(redirect_stderr(stderr))
+            exit_code = self.module.main()
+        return CLIResult(exit_code=exit_code, stdout=stdout.getvalue(), stderr=stderr.getvalue())
+
     def test_get_field_returns_name(self) -> None:
         manifest = {"package": {"name": "netsuke", "version": "1.2.3"}}
         self.assertEqual(self.module.get_field(manifest, "name"), "netsuke")
@@ -56,6 +101,22 @@ class ReadManifestTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.module.get_field(manifest, "version")
 
+    def test_get_field_rejects_non_string_values(self) -> None:
+        manifest = {
+            "package": {
+                "name": "netsuke",
+                "version": 123,
+                "authors": ["alice", "bob"],
+                "metadata": {"license": "MIT"},
+            }
+        }
+        with self.assertRaises(KeyError):
+            self.module.get_field(manifest, "version")
+        with self.assertRaises(KeyError):
+            self.module.get_field(manifest, "authors")
+        with self.assertRaises(KeyError):
+            self.module.get_field(manifest, "metadata")
+
     def test_main_reads_manifest_path_argument(self) -> None:
         manifest = self._write_manifest(
             """
@@ -64,13 +125,8 @@ class ReadManifestTests(unittest.TestCase):
             version = "1.2.3"
             """
         )
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(manifest)],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0)
+        result = self._invoke_cli("name", "--manifest-path", str(manifest))
+        self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "netsuke")
         self.assertEqual(result.stderr, "")
 
@@ -82,42 +138,36 @@ class ReadManifestTests(unittest.TestCase):
             version = "1.2.3"
             """
         )
-        env = os.environ.copy()
-        env["CARGO_TOML_PATH"] = str(manifest)
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "version"],
-            check=False,
-            capture_output=True,
-            text=True,
-            env=env,
-            cwd=self.temp_path,
-        )
-        self.assertEqual(result.returncode, 0)
+        env = {"CARGO_TOML_PATH": str(manifest)}
+        result = self._invoke_cli("version", env=env, cwd=self.temp_path)
+        self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.stdout, "1.2.3")
         self.assertEqual(result.stderr, "")
 
     def test_main_reports_missing_manifest(self) -> None:
         missing = self.temp_path / "missing.toml"
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(missing)],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        self.assertNotEqual(result.returncode, 0)
+        result = self._invoke_cli("name", "--manifest-path", str(missing))
+        self.assertNotEqual(result.exit_code, 0)
         self.assertIn("does not exist", result.stderr)
         self.assertEqual(result.stdout, "")
 
     def test_main_reports_invalid_toml(self) -> None:
         manifest = self._write_manifest("not = [valid")
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_PATH), "name", "--manifest-path", str(manifest)],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        self.assertNotEqual(result.returncode, 0)
+        result = self._invoke_cli("name", "--manifest-path", str(manifest))
+        self.assertNotEqual(result.exit_code, 0)
         self.assertTrue(result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_main_reports_valid_toml_with_unexpected_structure(self) -> None:
+        manifest = self._write_manifest(
+            """
+            [unexpected_section]
+            foo = "bar"
+            """
+        )
+        result = self._invoke_cli("name", "--manifest-path", str(manifest))
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("missing", result.stderr.lower())
         self.assertEqual(result.stdout, "")
 
 

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -224,7 +224,7 @@ class ReadManifestTests:
         expected_stderr_fragment: str | None = None,
     ) -> None:
         """Assert that invoking the CLI fails for ``manifest_path``."""
-        result = subprocess.run(  # noqa: S603  # Security: executed with trusted inputs in tests.
+        result = subprocess.run(  # noqa: S603  # TODO(release-ci): FIXME: Security false positive; executed with trusted inputs in tests. https://github.com/leynos/netsuke/pull/179#discussion_r2404108802
             [
                 sys.executable,
                 str(SCRIPT_PATH),

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -32,11 +32,11 @@ Create a minimal manifest and query the package name::
 
     path = Path("/tmp/Cargo.toml")
     path.write_text(dedent(
-        """
+        '''
         [package]
         name = "netsuke"
         version = "1.2.3"
-        """
+        '''
     ), encoding="utf-8")
 
     completed = subprocess.run(
@@ -92,12 +92,11 @@ class CLIInvocationConfig:
     Attributes
     ----------
     cli_args : tuple[str, ...] | None
-        Optional CLI arguments to pass; defaults to the field and manifest
-        path pair used by the helpers.
+        Optional CLI arguments to pass; defaults to field and manifest path.
     env : dict[str, str] | None
-        Optional environment overrides provided to the subprocess.
+        Optional environment variables to set during invocation.
     cwd : Path | None
-        Optional working directory applied during invocation.
+        Optional working directory for the invocation.
     """
 
     cli_args: tuple[str, ...] | None = None
@@ -135,15 +134,15 @@ class ReadManifestTests:
     Methods
     -------
     _write_manifest(content: str) -> Path
-        Persist TOML content to ``Cargo.toml`` within the temporary
-        workspace.
+        Write TOML content to a temporary ``Cargo.toml``.
     _invoke_cli(*args, env=None, cwd=None) -> CLIResult
-        Execute the CLI in-process while capturing output and exit status.
+        Execute the CLI in-process and capture output.
     _assert_manifest_error(manifest_path, expected_stderr_fragment=None) -> None
-        Assert the CLI fails for a given manifest path and examine stderr.
-    _assert_successful_field_read(manifest_content, field, expected_value,
-                                  *, config=None) -> None
-        Assert the CLI surfaces the expected field value without errors.
+        Assert the CLI fails for the given manifest path.
+    _assert_successful_field_read(
+        manifest_content, field, expected_value, *, config=None
+    ) -> None
+        Assert the CLI prints the expected value for the field.
     """
 
     module: types.ModuleType

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -235,6 +235,7 @@ class ReadManifestTests:
         expected_stderr_fragment: str | None = None,
     ) -> None:
         """Assert that invoking the CLI fails for ``manifest_path``."""
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit -- test-only; argv fully controlled  # noqa: E501
         result = subprocess.run(  # noqa: S603  # TODO(release-ci): FIXME: Security false positive; executed with trusted inputs in tests. https://github.com/leynos/netsuke/pull/179#discussion_r2404108802
             [
                 sys.executable,

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -116,7 +116,21 @@ def change_directory(path: Path) -> typ.Iterator[None]:
 
 
 def load_script_module() -> types.ModuleType:
-    """Import the read_manifest script as a module for reuse in tests."""
+    """
+    Import the read_manifest script as a module for reuse in tests.
+
+    Returns
+    -------
+    types.ModuleType
+        The loaded ``read_manifest`` module exposing its helper functions.
+
+    Examples
+    --------
+    >>> module = load_script_module()
+    >>> manifest = {"package": {"name": "foo"}}
+    >>> module.get_field(manifest, "name")
+    'foo'
+    """
     spec = importlib.util.spec_from_file_location("read_manifest", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type] # FIXME: stdlib typing lacks precise module_from_spec signature
     assert spec is not None
@@ -186,7 +200,7 @@ class ReadManifestTests:
         expected_stderr_fragment: str | None = None,
     ) -> None:
         """Assert that invoking the CLI fails for ``manifest_path``."""
-        result = subprocess.run(  # noqa: S603 - executed with trusted inputs in tests
+        result = subprocess.run(  # noqa: S603 # FIXME: executed with trusted inputs in tests
             [
                 sys.executable,
                 str(SCRIPT_PATH),

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -107,7 +107,26 @@ class CLIInvocationConfig:
 
 @contextmanager
 def change_directory(path: Path) -> typ.Iterator[None]:
-    """Temporarily change the working directory for the current process."""
+    """
+    Temporarily change the working directory for the current process.
+
+    Parameters
+    ----------
+    path : Path
+        Target directory that should become the working directory.
+
+    Yields
+    ------
+    None
+        Control to the caller while the working directory is set to ``path``.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> with change_directory(Path("/tmp")):
+    ...     Path.cwd().as_posix()
+    '/tmp'
+    """
     original = Path.cwd()
     os.chdir(path)
     try:

--- a/tests_python/test_read_manifest.py
+++ b/tests_python/test_read_manifest.py
@@ -122,7 +122,7 @@ def load_script_module() -> types.ModuleType:
     Returns
     -------
     types.ModuleType
-        The loaded ``read_manifest`` module exposing its helper functions.
+        The loaded read_manifest module with all its functions and constants.
 
     Examples
     --------


### PR DESCRIPTION
## Summary
- catch `tomllib.TOMLDecodeError` in the manifest reader CLI so invalid TOML fails fast
- add Python unit tests that exercise the script's field extraction, CLI options, and error paths

## Testing
- python -m unittest discover -s tests_python
- make check-fmt
- make lint
- make test


------
https://chatgpt.com/codex/tasks/task_e_68de5d76681c83229e66aaeefe15c1a8

## Summary by Sourcery

Improve the manifest reader CLI to handle invalid TOML, refactor release workflows to use a new Python upload-release-assets action, update lint settings, and add comprehensive tests for both tools

New Features:
- Catch invalid TOML decode errors in the manifest reader CLI to fail fast
- Add a Python-based upload_release_assets script and composite GitHub Action for uploading release artefacts

Enhancements:
- Replace inline Bash upload logic in release workflows with the reusable upload-release-assets action
- Add detailed docstrings to read_manifest CLI functions

CI:
- Update release and release-dry-run workflows to emit metadata outputs and invoke the upload-release-assets action
- Add task-tags configuration to ruff.toml for linting

Tests:
- Add unit tests for read_manifest covering field extraction, CLI options, and error paths
- Add tests for upload_release_assets script including asset discovery, collision and empty-file handling, and dry-run mode