### PR TITLE
Refactor staging helpers to reduce complexity

### DIFF
--- a/.github/workflows/scripts/stage_common.py
+++ b/.github/workflows/scripts/stage_common.py
@@ -90,15 +90,10 @@ def stage_artifacts(config: StagingConfig, github_output: Path) -> StageResult:
     for path in (bin_dest, man_dest, licence_dest):
         _write_checksum(path)
 
-    _write_github_outputs(
-        github_output,
-        artifact_dir,
-        bin_dest,
-        man_dest,
-        licence_dest,
-    )
+    stage_result = StageResult(artifact_dir, bin_dest, man_dest, licence_dest)
+    _write_github_outputs(github_output, stage_result)
 
-    return StageResult(artifact_dir, bin_dest, man_dest, licence_dest)
+    return stage_result
 
 
 def _validate_and_locate_sources(
@@ -138,20 +133,14 @@ def _prepare_artifact_directory(dist_dir: Path, artifact_dir_name: str) -> Path:
     return artifact_dir
 
 
-def _write_github_outputs(
-    github_output: Path,
-    artifact_dir: Path,
-    bin_dest: Path,
-    man_dest: Path,
-    licence_dest: Path,
-) -> None:
+def _write_github_outputs(github_output: Path, stage_result: StageResult) -> None:
     """Emit the staged artefact metadata for downstream workflow steps."""
 
     outputs = {
-        "artifact_dir": artifact_dir,
-        "binary_path": bin_dest,
-        "man_path": man_dest,
-        "license_path": licence_dest,
+        "artifact_dir": stage_result.artifact_dir,
+        "binary_path": stage_result.binary_path,
+        "man_path": stage_result.man_path,
+        "license_path": stage_result.license_path,
     }
     output_lines: list[str] = []
     for key, path in outputs.items():

--- a/tests_python/test_stage_common.py
+++ b/tests_python/test_stage_common.py
@@ -235,10 +235,12 @@ def test_write_github_outputs_overwrites_existing_content(
 
     stage_common._write_github_outputs(
         github_output,
-        artifact_dir,
-        bin_path,
-        man_path,
-        licence_path,
+        stage_common.StageResult(
+            artifact_dir=artifact_dir,
+            binary_path=bin_path,
+            man_path=man_path,
+            license_path=licence_path,
+        ),
     )
 
     contents = github_output.read_text(encoding="utf-8").splitlines()
@@ -265,8 +267,10 @@ def test_write_github_outputs_errors_on_empty_value(
     with pytest.raises(RuntimeError, match="unexpectedly empty"):
         stage_common._write_github_outputs(
             github_output,
-            artifact_dir,
-            artifact_dir / "bin",
-            artifact_dir / "man",
-            artifact_dir / "license",
+            stage_common.StageResult(
+                artifact_dir=artifact_dir,
+                binary_path=artifact_dir / "bin",
+                man_path=artifact_dir / "man",
+                license_path=artifact_dir / "license",
+            ),
         )


### PR DESCRIPTION
## Summary
- extract `_validate_and_locate_sources`, `_prepare_artifact_directory`, and `_write_github_outputs` helpers in `stage_common.py`
- simplify `stage_artifacts` orchestration to lower cyclomatic complexity while preserving behaviour

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e65cd82cb083229d0bf502cd7532ef

## Summary by Sourcery

Refactor stage_artifacts to lower cyclomatic complexity by extracting key steps into reusable helpers for source validation, artifact directory setup, and GitHub output generation.

Enhancements:
- Extract source validation, artifact directory preparation, and GitHub output logic into dedicated helper functions
- Simplify stage_artifacts orchestration by delegating responsibilities to newly introduced helpers, reducing cyclomatic complexity