### PR TITLE
Document uv requirement for staging composite

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1662,17 +1662,20 @@ operate on consistent metadata. Linux builds invoke the `rust-build-release`
 composite action to cross-compile for `x86_64` and `aarch64`, generate the
 staged binary + man page directory, and then call the shared `linux-packages`
 composite a second time with explicit metadata so the resulting `.deb` and
-`.rpm` archives both declare a runtime dependency on `ninja-build`.
-Windows builds reuse the same action for compilation and now invoke the generic
-staging composite defined in `.github/actions/stage`. The composite shells out
-to a Cyclopts-driven script that reads `.github/release-staging.toml`, merges
-the `[common]` configuration with the target-specific overrides, and copies the
-configured artefacts into a fresh `dist/{bin}_{platform}_{arch}` directory. The
-helper writes SHA-256 sums for every staged file and exports a JSON map of the
-artefact outputs, allowing the workflow to hydrate downstream steps without
-hard-coded path logic. Figure 8.1 summarises the configuration entities,
-including optional keys reserved for templated directories and explicit
-artefact destinations that the helper can adopt without breaking compatibility.
+`.rpm` archives both declare a runtime dependency on `ninja-build`. Windows
+builds reuse the same action for compilation and now invoke the generic staging
+composite defined in `.github/actions/stage`. The composite shells out to a
+Cyclopts-driven script that reads `.github/release-staging.toml`, merges the
+`[common]` configuration with the target-specific overrides, and copies the
+configured artefacts into a fresh `dist/{bin}_{platform}_{arch}` directory.
+Workflows must install `uv` before invoking the Stage composite, for example by
+using the `astral-sh/setup-uv` action, so the Cyclopts helper can invoke the
+tool. The helper writes SHA-256 sums for every staged file and exports a JSON
+map of the artefact outputs, allowing the workflow to hydrate downstream steps
+without hard-coded path logic. Figure 8.1 summarises the configuration
+entities, including optional keys reserved for templated directories and
+explicit artefact destinations that the helper can adopt without breaking
+compatibility.
 
 Figure 8.1: Entity relationship for the staging configuration schema.
 


### PR DESCRIPTION
## Summary
- add documentation noting that workflows must install uv before invoking the Stage composite

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68e802631ff483228d28ad6df51615e0

## Summary by Sourcery

Documentation:
- Note that workflows must install uv via astral-sh/setup-uv before invoking the Stage composite