### PR TITLE
Remove duplicate workspace fixture in stage CLI tests

### DIFF
--- a/tests_python/test_stage_cli.py
+++ b/tests_python/test_stage_cli.py
@@ -35,16 +35,6 @@ class _StubCycloptsApp:
         message = "Stub CLI should not be invoked directly"
         raise RuntimeError(message)  # pragma: no cover - not exercised
 
-
-@pytest.fixture
-def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Provide an isolated workspace and set ``GITHUB_WORKSPACE``."""
-    root = tmp_path / "workspace"
-    root.mkdir()
-    monkeypatch.setenv("GITHUB_WORKSPACE", str(root))
-    return root
-
-
 def _remove_sys_path_entry(entry: str) -> None:
     """Remove ``entry`` from ``sys.path`` if present, preferring index 0."""
 


### PR DESCRIPTION
## Summary
- delete the local workspace pytest fixture from the stage CLI test module so it uses the shared fixture

## Testing
- pytest tests_python/test_stage_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ec399079f883228bee5f0ce091a267

## Summary by Sourcery

Tests:
- Remove local workspace pytest fixture from tests_python/test_stage_cli.py to rely on the shared fixture