### PR TITLE
Remove duplicate workspace fixture from stage CLI tests

### DIFF
--- a/tests_python/test_stage_cli.py
+++ b/tests_python/test_stage_cli.py
@@ -35,16 +35,6 @@ class _StubCycloptsApp:
         message = "Stub CLI should not be invoked directly"
         raise RuntimeError(message)  # pragma: no cover - not exercised
 
-
-@pytest.fixture
-def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Provide an isolated workspace and set ``GITHUB_WORKSPACE``."""
-    root = tmp_path / "workspace"
-    root.mkdir()
-    monkeypatch.setenv("GITHUB_WORKSPACE", str(root))
-    return root
-
-
 def _remove_sys_path_entry(entry: str) -> None:
     """Remove ``entry`` from ``sys.path`` if present, preferring index 0."""
 


### PR DESCRIPTION
## Summary
- remove the redundant workspace fixture from the stage CLI tests so they rely on the shared version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eed66b0c50832282a1b7858e452fa2

## Summary by Sourcery

Tests:
- Remove the duplicate workspace fixture from stage CLI tests to use the shared fixture