### PR TITLE
Refactor filter success helper to use parameter object

### DIFF
--- a/tests/std_filter_tests/path_filters.rs
+++ b/tests/std_filter_tests/path_filters.rs
@@ -151,8 +151,7 @@ where
         });
         with_clean_env_vars(home, move || {
             let FilterSuccessSpec { name, template, path } = spec;
-            let result = fallible::render(env, name, template, path)
-                .with_context(|| format!("render template '{}'", name))?;
+            let result = fallible::render(env, name, template, path)?;
             let expected_value = expected(root);
             ensure!(
                 result == expected_value,


### PR DESCRIPTION
## Summary
- add a FilterSuccessSpec parameter object for filter success assertions
- update assert_filter_success_with_env and its call site to use the new struct

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68fd6afc879883228b4bc37cbaf69ca7

## Summary by Sourcery

Introduce a parameter object for filter success tests and refactor the helper and its usages to use it

Enhancements:
- Add FilterSuccessSpec struct to encapsulate filter success test parameters
- Change assert_filter_success_with_env to accept a FilterSuccessSpec instead of separate arguments
- Update test cases to construct and pass FilterSuccessSpec to the helper