### PR TITLE
Document cross-platform which filter design

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -972,7 +972,7 @@ entries were inspected, a shortened preview of the path list, and platform
 appropriate hints (for example suggesting `cwd_mode="always"` on Windows).
 Invalid arguments surface as `netsuke::jinja::which::args`.
 
-Unit tests cover POSIX and Windows specifics, canonicalisation, cache
+Unit tests cover POSIX and Windows specifics, canonicalization, cache
 validation, and list-all semantics. Behavioural MiniJinja fixtures exercise the
 filter in Stage 3/4 renders to prove determinism across repeated invocations
 with identical environments.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,7 +216,7 @@ library, and CLI ergonomics.
     `netsuke::jinja::which::args` diagnostics with PATH previews and
     platform-appropriate hints.
 
-  - [ ] Cover POSIX and Windows behaviour, canonicalisation, list-all mode,
+  - [ ] Cover POSIX and Windows behaviour, canonicalization, list-all mode,
     and cache validation with unit tests, plus MiniJinja fixtures that assert
     deterministic renders across repeated invocations.
 


### PR DESCRIPTION
## Summary
- document the cross-platform `which` MiniJinja filter design, covering API, semantics, caching, and diagnostics expectations
- add a roadmap checklist for implementing the `which` filter ahead of the UI-focused tasks

## Testing
- make fmt *(fails: existing markdownlint rules flag missing fence languages in docs/users-guide.md)*

------
https://chatgpt.com/codex/tasks/task_e_69048f84bcb883229348a4199fc2a8c6

## Summary by Sourcery

Document the cross-platform which MiniJinja filter design and add a roadmap checklist for its implementation

Documentation:
- Add a detailed design section in netsuke-design.md covering the which filter’s API, platform semantics, caching strategy, and diagnostics model
- Extend docs/roadmap.md with a step-by-step checklist to implement the which filter, including cache integration and testing requirements