### PR TITLE
Clarify fetch documentation and ellipsis usage

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -249,7 +249,7 @@ dynamic capabilities to your manifest.
 - Expressions: `{{ 1 + 1 }}`, `{{ sources | map('basename') }}`
 
 - Control Structures (within specific keys like `foreach`, `when`, or inside
-  `macros`): `{% if enable %}...{% endif %}`, `{% for item in list %}…{%
+  `macros`): `{% if enable %}…{% endif %}`, `{% for item in list %}…{%
   endfor %}`
 
 **Important:** Structural Jinja (`{% %}`) is generally **not** allowed directly
@@ -334,6 +334,10 @@ templates.
 
 - `fetch(url, cache=False)`: Downloads content from a URL. If `cache=True`,
   caches the result in `.netsuke/fetch` within the workspace based on URL hash.
+  Enforces a configurable maximum response size (default 8 MiB); requests abort
+  with an error quoting the configured threshold when the limit is exceeded.
+  Cached downloads stream directly to disk and remove partial files on error.
+  Configure the limit with `StdlibConfig::with_fetch_max_response_bytes`.
   Marks template as impure.
 
 - `now(offset=None)`: Returns the current time as a timezone-aware object


### PR DESCRIPTION
## Summary
- use typographic ellipses consistently in the control structure example
- document the fetch stdlib response size limit, error messaging, and streaming behaviour

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6909c40a68d083229f7cc17f846c0c7c

## Summary by Sourcery

Clarify documentation by standardizing ellipsis usage in control structures and detailing the fetch function’s response size limit, error handling, streaming behavior, and configuration.

Documentation:
- Use typographic ellipses consistently in control structure examples
- Document fetch’s configurable maximum response size, abort behavior on limit exceedance, streaming-to-disk of cached downloads, and cleanup of partial files on error