### PR TITLE
Add explicit CLI overrides with typed enums; update tests/docs/build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,7 +88,7 @@ fn write_man_page(data: &[u8], dir: &Path, page_name: &str) -> std::io::Result<P
     Ok(destination)
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+const fn verify_public_api_symbols() {
     // Exercise CLI localization, config merge, and host pattern symbols so the
     // shared modules remain linked when the build script is compiled without
     // tests.
@@ -107,8 +107,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     const _: fn(&cli::Cli) -> bool = cli::Cli::progress_enabled;
     const _: fn(&str) -> Result<HostPattern, HostPatternError> = HostPattern::parse;
     const _: fn(&HostPattern, host_pattern::HostCandidate<'_>) -> bool = HostPattern::matches;
+}
 
-    // Regenerate the manual page when the CLI or metadata changes.
+fn emit_rerun_directives() {
     println!("cargo:rerun-if-changed=src/cli/mod.rs");
     println!("cargo:rerun-if-changed=src/cli/config.rs");
     println!("cargo:rerun-if-changed=src/cli/merge.rs");
@@ -125,13 +126,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=src/localization/keys.rs");
     println!("cargo:rerun-if-changed=locales/en-US/messages.ftl");
     println!("cargo:rerun-if-changed=locales/es-ES/messages.ftl");
+}
 
-    build_l10n_audit::audit_localization_keys()?;
-
-    // Packagers expect man pages under target/generated-man/<target>/<profile>.
-    let out_dir = out_dir_for_target_profile();
-
-    // The top-level page documents the entire command interface.
+fn generate_man_page(out_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let cmd = cli::Cli::command();
     let name = cmd
         .get_bin_name()
@@ -149,7 +146,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = env::var("CARGO_PKG_VERSION").map_err(
         |_| "CARGO_PKG_VERSION must be set by Cargo; cannot render manual page without it.",
     )?;
-
     let man = Man::new(cmd)
         .section("1")
         .source(format!("{cargo_bin} {version}"))
@@ -157,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = Vec::new();
     man.render(&mut buf)?;
     let page_name = format!("{cargo_bin}.1");
-    write_man_page(&buf, &out_dir, &page_name)?;
+    write_man_page(&buf, out_dir, &page_name)?;
     if let Some(extra_dir) = env::var_os("OUT_DIR") {
         let extra_dir_path = PathBuf::from(extra_dir);
         if let Err(err) = write_man_page(&buf, &extra_dir_path, &page_name) {
@@ -167,6 +163,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
     }
-
     Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    verify_public_api_symbols();
+    emit_rerun_directives();
+    build_l10n_audit::audit_localization_keys()?;
+    let out_dir = out_dir_for_target_profile();
+    generate_man_page(&out_dir)
 }

--- a/docs/execplans/3-10-1-guarantee-status-message-ordering.md
+++ b/docs/execplans/3-10-1-guarantee-status-message-ordering.md
@@ -276,8 +276,7 @@ model provides the necessary ordering guarantees.
    `NINJA_STDERR_MARKER`) to avoid coupling to localized UI strings.
 
 2. **Status messages do not contaminate stdout in standard mode**: Verifies
-   stream
-   routing in non-accessible mode using the same stable markers.
+   stream routing in non-accessible mode using the same stable markers.
 
 3. **Build artifacts can be captured via stdout redirection**: Verifies that
    `netsuke manifest -` output goes to stdout without status contamination.
@@ -285,12 +284,10 @@ model provides the necessary ordering guarantees.
 Supporting infrastructure added:
 
 - `FakeNinjaConfig` struct in `tests/bdd/steps/progress_output.rs` for
-  configurable
-  fixture generation with optional stderr markers.
+  configurable fixture generation with optional stderr markers.
 - `install_fake_ninja_with_config()` function for flexible fixture setup.
 - Updated `fake_ninja_emits_stdout_output` fixture to emit both stdout and
-  stderr
-  markers for comprehensive stream routing verification.
+  stderr markers for comprehensive stream routing verification.
 
 ### Stage E: Documentation (completed)
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2034,12 +2034,11 @@ layered configuration lives in a dedicated `CliConfig` struct derived with
 OrthoConfig in `src/cli/config.rs`. The top-level `src/cli/mod.rs` module
 re-exports that public CLI surface. This separation keeps parsing,
 configuration discovery, and runtime command selection as distinct concerns
-while preserving the existing command syntax.
-Invoking `netsuke` with no explicit subcommand still resolves to `build`, and
-the `build` command can now take default `emit` and `targets` values from
-`[cmds.build]` in configuration files or `NETSUKE_CMDS__BUILD__*` environment
-variables. Explicit CLI targets or `--emit` values still override those
-defaults.
+while preserving the existing command syntax. Invoking `netsuke` with no
+explicit subcommand still resolves to `build`, and the `build` command can now
+take default `emit` and `targets` values from `[cmds.build]` in configuration
+files or `NETSUKE_CMDS__BUILD__*` environment variables. Explicit CLI targets
+or `--emit` values still override those defaults.
 
 Configuration is layered in the order defaults -> configuration files ->
 environment variables -> CLI overrides. Discovery honours `NETSUKE_CONFIG_PATH`

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -4,6 +4,7 @@
 //! and merging. It captures global CLI settings plus per-subcommand defaults
 //! under the `cmds` namespace.
 
+use clap::ValueEnum;
 use ortho_config::{OrthoConfig, OrthoResult, PostMergeContext, PostMergeHook};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ use super::validation_error;
 use crate::host_pattern::HostPattern;
 
 /// Colour-output policy accepted by layered configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ColourPolicy {
     /// Follow the host environment.
@@ -25,7 +26,7 @@ pub enum ColourPolicy {
 }
 
 /// Spinner and progress rendering policy.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SpinnerMode {
     /// Follow Netsuke's default progress behaviour.
@@ -38,7 +39,7 @@ pub enum SpinnerMode {
 }
 
 /// Top-level diagnostics and output format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum OutputFormat {
     /// Human-readable terminal output.
@@ -49,7 +50,7 @@ pub enum OutputFormat {
 }
 
 /// Presentation theme for semantic prefixes and glyph choices.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum Theme {
     /// Follow the host environment.

--- a/src/cli/merge.rs
+++ b/src/cli/merge.rs
@@ -155,6 +155,10 @@ fn cli_overrides_from_matches(cli: &Cli, matches: &ArgMatches) -> OrthoResult<Va
     maybe_insert_explicit(matches, "progress", &cli.progress, &mut root)?;
     maybe_insert_explicit(matches, "no_emoji", &cli.no_emoji, &mut root)?;
     maybe_insert_explicit(matches, "diag_json", &cli.diag_json, &mut root)?;
+    maybe_insert_explicit(matches, "colour_policy", &cli.colour_policy, &mut root)?;
+    maybe_insert_explicit(matches, "spinner_mode", &cli.spinner_mode, &mut root)?;
+    maybe_insert_explicit(matches, "output_format", &cli.output_format, &mut root)?;
+    maybe_insert_explicit(matches, "theme", &cli.theme, &mut root)?;
 
     if let Some(Commands::Build(args)) = cli.command.as_ref()
         && let Some(build_matches) = matches.subcommand_matches("build")

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -131,20 +131,20 @@ pub struct Cli {
     #[arg(long)]
     pub progress: Option<bool>,
 
-    /// Resolved colour policy from layered configuration.
-    #[arg(skip)]
+    /// Override colour policy for terminal output.
+    #[arg(long, value_name = "POLICY")]
     pub colour_policy: Option<ColourPolicy>,
 
-    /// Resolved spinner mode from layered configuration.
-    #[arg(skip)]
+    /// Override spinner animation mode.
+    #[arg(long, value_name = "MODE")]
     pub spinner_mode: Option<SpinnerMode>,
 
-    /// Resolved output format from layered configuration.
-    #[arg(skip)]
+    /// Override output format style.
+    #[arg(long, value_name = "FORMAT")]
     pub output_format: Option<OutputFormat>,
 
-    /// Resolved presentation theme from layered configuration.
-    #[arg(skip)]
+    /// Override presentation theme.
+    #[arg(long, value_name = "THEME")]
     pub theme: Option<Theme>,
 
     /// Optional subcommand to execute; defaults to `build` when omitted.

--- a/tests/bdd/steps/configuration_preferences.rs
+++ b/tests/bdd/steps/configuration_preferences.rs
@@ -4,7 +4,8 @@ use crate::bdd::fixtures::{RefCellOptionExt, TestWorld};
 use crate::bdd::helpers::parse_store::store_parse_outcome;
 use crate::bdd::helpers::tokens::build_tokens;
 use anyhow::{Context, Result, anyhow, bail, ensure};
-use netsuke::cli::{Cli, ColourPolicy, Commands, SpinnerMode, Theme};
+use clap::ValueEnum as _;
+use netsuke::cli::{Cli, ColourPolicy, Commands, OutputFormat, SpinnerMode, Theme};
 use netsuke::cli_localization;
 use netsuke::output_prefs;
 use rstest_bdd_macros::{given, then, when};
@@ -61,6 +62,93 @@ fn merge_cli(world: &TestWorld, args: &str) {
     store_parse_outcome(&world.cli, &world.cli_error, outcome);
 }
 
+/// Convert a clap `ValueEnum` to its canonical name string.
+///
+/// # Panics
+///
+/// Panics if the enum variant does not have a possible value (which should
+/// never happen for well-formed `ValueEnum` implementations).
+fn enum_name<T: clap::ValueEnum>(value: &T) -> String {
+    value
+        .to_possible_value()
+        .unwrap_or_else(|| panic!("all ValueEnum variants must have a possible value"))
+        .get_name()
+        .to_owned()
+}
+
+/// Write a theme value to the config file.
+fn write_theme_config(world: &TestWorld, theme: Theme) -> Result<()> {
+    write_config(world, &format!("theme = \"{}\"\n", enum_name(&theme)))
+}
+
+/// Write a colour policy value to the config file.
+fn write_colour_policy_config(world: &TestWorld, policy: ColourPolicy) -> Result<()> {
+    write_config(
+        world,
+        &format!("colour_policy = \"{}\"\n", enum_name(&policy)),
+    )
+}
+
+/// Write a spinner mode value to the config file.
+fn write_spinner_mode_config(world: &TestWorld, mode: SpinnerMode) -> Result<()> {
+    write_config(world, &format!("spinner_mode = \"{}\"\n", enum_name(&mode)))
+}
+
+/// Write an output format value to the config file.
+fn write_output_format_config(world: &TestWorld, format: OutputFormat) -> Result<()> {
+    write_config(
+        world,
+        &format!("output_format = \"{}\"\n", enum_name(&format)),
+    )
+}
+
+/// Set the `NETSUKE_THEME` environment variable.
+fn set_env_theme(world: &TestWorld, theme: Theme) {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_THEME");
+    let value = enum_name(&theme);
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_THEME", OsStr::new(&value)) };
+    world.track_env_var("NETSUKE_THEME".to_owned(), previous);
+}
+
+/// Set the `NETSUKE_COLOUR_POLICY` environment variable.
+fn set_env_colour_policy(world: &TestWorld, policy: ColourPolicy) {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_COLOUR_POLICY");
+    let value = enum_name(&policy);
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_COLOUR_POLICY", OsStr::new(&value)) };
+    world.track_env_var("NETSUKE_COLOUR_POLICY".to_owned(), previous);
+}
+
+/// Set the `NETSUKE_SPINNER_MODE` environment variable.
+fn set_env_spinner_mode(world: &TestWorld, mode: SpinnerMode) {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_SPINNER_MODE");
+    let value = enum_name(&mode);
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_SPINNER_MODE", OsStr::new(&value)) };
+    world.track_env_var("NETSUKE_SPINNER_MODE".to_owned(), previous);
+}
+
+/// Assert a merged CLI field value matches the expected value.
+fn assert_merged_field<T, F>(world: &TestWorld, extract: F, expected: T, label: &str) -> Result<()>
+where
+    T: Copy + PartialEq + std::fmt::Debug,
+    F: FnOnce(&Cli) -> Option<T>,
+{
+    let value = world
+        .cli
+        .with_ref(|cli| extract(cli))
+        .context("expected merged CLI to be available")?;
+    ensure!(
+        value == Some(expected),
+        "expected merged {label} to be {expected:?}, got {value:?}",
+    );
+    Ok(())
+}
+
 #[given("the Netsuke config file sets build targets to {target:string}")]
 fn config_sets_build_targets(world: &TestWorld, target: &str) -> Result<()> {
     write_config(world, &format!("[cmds.build]\ntargets = [\"{target}\"]\n"))
@@ -87,7 +175,9 @@ fn set_environment_locale_override(world: &TestWorld, locale: &str) -> Result<()
 
 #[given("the Netsuke config file sets output format to {format:string}")]
 fn config_sets_output_format(world: &TestWorld, format: &str) -> Result<()> {
-    write_config(world, &format!("output_format = \"{format}\"\n"))
+    let typed = OutputFormat::from_str(format, true)
+        .map_err(|err| anyhow!("invalid output format '{format}': {err}"))?;
+    write_output_format_config(world, typed)
 }
 
 #[given("the Netsuke config file sets no_emoji to true")]
@@ -97,58 +187,46 @@ fn config_sets_no_emoji(world: &TestWorld) -> Result<()> {
 
 #[given("the Netsuke config file sets theme to {theme:string}")]
 fn config_sets_theme(world: &TestWorld, theme: &str) -> Result<()> {
-    write_config(world, &format!("theme = \"{theme}\"\n"))
+    let typed =
+        Theme::from_str(theme, true).map_err(|err| anyhow!("invalid theme '{theme}': {err}"))?;
+    write_theme_config(world, typed)
 }
 
 #[given("the Netsuke config file sets colour policy to {policy:string}")]
 fn config_sets_colour_policy(world: &TestWorld, policy: &str) -> Result<()> {
-    write_config(world, &format!("colour_policy = \"{policy}\"\n"))
+    let typed = ColourPolicy::from_str(policy, true)
+        .map_err(|err| anyhow!("invalid colour policy '{policy}': {err}"))?;
+    write_colour_policy_config(world, typed)
 }
 
 #[given("the Netsuke config file sets spinner mode to {mode:string}")]
 fn config_sets_spinner_mode(world: &TestWorld, mode: &str) -> Result<()> {
-    write_config(world, &format!("spinner_mode = \"{mode}\"\n"))
+    let typed = SpinnerMode::from_str(mode, true)
+        .map_err(|err| anyhow!("invalid spinner mode '{mode}': {err}"))?;
+    write_spinner_mode_config(world, typed)
 }
 
 #[given("the NETSUKE_THEME environment variable is {theme:string}")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
-)]
 fn set_environment_theme_override(world: &TestWorld, theme: &str) -> Result<()> {
-    ensure_env_lock(world);
-    let previous = std::env::var_os("NETSUKE_THEME");
-    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    unsafe { std::env::set_var("NETSUKE_THEME", OsStr::new(theme)) };
-    world.track_env_var("NETSUKE_THEME".to_owned(), previous);
+    let typed =
+        Theme::from_str(theme, true).map_err(|err| anyhow!("invalid theme '{theme}': {err}"))?;
+    set_env_theme(world, typed);
     Ok(())
 }
 
 #[given("the NETSUKE_COLOUR_POLICY environment variable is {policy:string}")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
-)]
 fn set_environment_colour_policy_override(world: &TestWorld, policy: &str) -> Result<()> {
-    ensure_env_lock(world);
-    let previous = std::env::var_os("NETSUKE_COLOUR_POLICY");
-    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    unsafe { std::env::set_var("NETSUKE_COLOUR_POLICY", OsStr::new(policy)) };
-    world.track_env_var("NETSUKE_COLOUR_POLICY".to_owned(), previous);
+    let typed = ColourPolicy::from_str(policy, true)
+        .map_err(|err| anyhow!("invalid colour policy '{policy}': {err}"))?;
+    set_env_colour_policy(world, typed);
     Ok(())
 }
 
 #[given("the NETSUKE_SPINNER_MODE environment variable is {mode:string}")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
-)]
 fn set_environment_spinner_mode_override(world: &TestWorld, mode: &str) -> Result<()> {
-    ensure_env_lock(world);
-    let previous = std::env::var_os("NETSUKE_SPINNER_MODE");
-    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    unsafe { std::env::set_var("NETSUKE_SPINNER_MODE", OsStr::new(mode)) };
-    world.track_env_var("NETSUKE_SPINNER_MODE".to_owned(), previous);
+    let typed = SpinnerMode::from_str(mode, true)
+        .map_err(|err| anyhow!("invalid spinner mode '{mode}': {err}"))?;
+    set_env_spinner_mode(world, typed);
     Ok(())
 }
 
@@ -215,15 +293,7 @@ fn merged_verbose_enabled(world: &TestWorld) -> Result<()> {
 
 #[then("the merged theme is ascii")]
 fn merged_theme_is_ascii(world: &TestWorld) -> Result<()> {
-    let theme = world
-        .cli
-        .with_ref(|cli| cli.theme)
-        .context("expected merged CLI to be available")?;
-    ensure!(
-        theme == Some(Theme::Ascii),
-        "expected merged theme to be ASCII, got {theme:?}",
-    );
-    Ok(())
+    assert_merged_field(world, |cli| cli.theme, Theme::Ascii, "theme")
 }
 
 #[then("the merge error should contain {fragment:string}")]
@@ -241,39 +311,25 @@ fn merge_error_contains(world: &TestWorld, fragment: &str) -> Result<()> {
 
 #[then("the merged theme is unicode")]
 fn merged_theme_is_unicode(world: &TestWorld) -> Result<()> {
-    let theme = world
-        .cli
-        .with_ref(|cli| cli.theme)
-        .context("expected merged CLI to be available")?;
-    ensure!(
-        theme == Some(Theme::Unicode),
-        "expected merged theme to be Unicode, got {theme:?}",
-    );
-    Ok(())
+    assert_merged_field(world, |cli| cli.theme, Theme::Unicode, "theme")
 }
 
 #[then("the merged colour policy is always")]
 fn merged_colour_policy_is_always(world: &TestWorld) -> Result<()> {
-    let policy = world
-        .cli
-        .with_ref(|cli| cli.colour_policy)
-        .context("expected merged CLI to be available")?;
-    ensure!(
-        policy == Some(ColourPolicy::Always),
-        "expected merged colour policy to be Always, got {policy:?}",
-    );
-    Ok(())
+    assert_merged_field(
+        world,
+        |cli| cli.colour_policy,
+        ColourPolicy::Always,
+        "colour policy",
+    )
 }
 
 #[then("the merged spinner mode is enabled")]
 fn merged_spinner_mode_is_enabled(world: &TestWorld) -> Result<()> {
-    let mode = world
-        .cli
-        .with_ref(|cli| cli.spinner_mode)
-        .context("expected merged CLI to be available")?;
-    ensure!(
-        mode == Some(SpinnerMode::Enabled),
-        "expected merged spinner mode to be Enabled, got {mode:?}",
-    );
-    Ok(())
+    assert_merged_field(
+        world,
+        |cli| cli.spinner_mode,
+        SpinnerMode::Enabled,
+        "spinner mode",
+    )
 }

--- a/tests/bdd/steps/configuration_preferences.rs
+++ b/tests/bdd/steps/configuration_preferences.rs
@@ -12,7 +12,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
-use test_support::EnvVarGuard;
 use test_support::display_error_chain;
 use test_support::env_lock::EnvLock;
 
@@ -38,9 +37,9 @@ fn write_config(world: &TestWorld, contents: &str) -> Result<()> {
     let workspace = workspace_path(world)?;
     let path = workspace.join("netsuke.toml");
     fs::write(&path, contents).with_context(|| format!("write {}", path.display()))?;
+    let previous = std::env::var_os(CONFIG_ENV_VAR);
     // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    let guard = EnvVarGuard::set(CONFIG_ENV_VAR, path.as_os_str());
-    let previous = guard.original();
+    unsafe { std::env::set_var(CONFIG_ENV_VAR, path.as_os_str()) };
     world.track_env_var(CONFIG_ENV_VAR.to_owned(), previous);
     Ok(())
 }
@@ -79,9 +78,9 @@ fn config_sets_locale(world: &TestWorld, locale: &str) -> Result<()> {
 )]
 fn set_environment_locale_override(world: &TestWorld, locale: &str) -> Result<()> {
     ensure_env_lock(world);
+    let previous = std::env::var_os(LOCALE_ENV_VAR);
     // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    let guard = EnvVarGuard::set(LOCALE_ENV_VAR, OsStr::new(locale));
-    let previous = guard.original();
+    unsafe { std::env::set_var(LOCALE_ENV_VAR, OsStr::new(locale)) };
     world.track_env_var(LOCALE_ENV_VAR.to_owned(), previous);
     Ok(())
 }

--- a/tests/bdd/steps/configuration_preferences.rs
+++ b/tests/bdd/steps/configuration_preferences.rs
@@ -12,6 +12,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use test_support::EnvVarGuard;
 use test_support::display_error_chain;
 use test_support::env_lock::EnvLock;
 
@@ -37,9 +38,9 @@ fn write_config(world: &TestWorld, contents: &str) -> Result<()> {
     let workspace = workspace_path(world)?;
     let path = workspace.join("netsuke.toml");
     fs::write(&path, contents).with_context(|| format!("write {}", path.display()))?;
-    let previous = std::env::var_os(CONFIG_ENV_VAR);
     // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    unsafe { std::env::set_var(CONFIG_ENV_VAR, OsStr::new(path.as_os_str())) };
+    let guard = EnvVarGuard::set(CONFIG_ENV_VAR, path.as_os_str());
+    let previous = guard.original();
     world.track_env_var(CONFIG_ENV_VAR.to_owned(), previous);
     Ok(())
 }
@@ -78,9 +79,9 @@ fn config_sets_locale(world: &TestWorld, locale: &str) -> Result<()> {
 )]
 fn set_environment_locale_override(world: &TestWorld, locale: &str) -> Result<()> {
     ensure_env_lock(world);
-    let previous = std::env::var_os(LOCALE_ENV_VAR);
     // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
-    unsafe { std::env::set_var(LOCALE_ENV_VAR, OsStr::new(locale)) };
+    let guard = EnvVarGuard::set(LOCALE_ENV_VAR, OsStr::new(locale));
+    let previous = guard.original();
     world.track_env_var(LOCALE_ENV_VAR.to_owned(), previous);
     Ok(())
 }

--- a/tests/bdd/steps/configuration_preferences.rs
+++ b/tests/bdd/steps/configuration_preferences.rs
@@ -4,7 +4,7 @@ use crate::bdd::fixtures::{RefCellOptionExt, TestWorld};
 use crate::bdd::helpers::parse_store::store_parse_outcome;
 use crate::bdd::helpers::tokens::build_tokens;
 use anyhow::{Context, Result, anyhow, bail, ensure};
-use netsuke::cli::{Cli, Commands, Theme};
+use netsuke::cli::{Cli, ColourPolicy, Commands, SpinnerMode, Theme};
 use netsuke::cli_localization;
 use netsuke::output_prefs;
 use rstest_bdd_macros::{given, then, when};
@@ -95,6 +95,63 @@ fn config_sets_no_emoji(world: &TestWorld) -> Result<()> {
     write_config(world, "no_emoji = true\n")
 }
 
+#[given("the Netsuke config file sets theme to {theme:string}")]
+fn config_sets_theme(world: &TestWorld, theme: &str) -> Result<()> {
+    write_config(world, &format!("theme = \"{theme}\"\n"))
+}
+
+#[given("the Netsuke config file sets colour policy to {policy:string}")]
+fn config_sets_colour_policy(world: &TestWorld, policy: &str) -> Result<()> {
+    write_config(world, &format!("colour_policy = \"{policy}\"\n"))
+}
+
+#[given("the Netsuke config file sets spinner mode to {mode:string}")]
+fn config_sets_spinner_mode(world: &TestWorld, mode: &str) -> Result<()> {
+    write_config(world, &format!("spinner_mode = \"{mode}\"\n"))
+}
+
+#[given("the NETSUKE_THEME environment variable is {theme:string}")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
+)]
+fn set_environment_theme_override(world: &TestWorld, theme: &str) -> Result<()> {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_THEME");
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_THEME", OsStr::new(theme)) };
+    world.track_env_var("NETSUKE_THEME".to_owned(), previous);
+    Ok(())
+}
+
+#[given("the NETSUKE_COLOUR_POLICY environment variable is {policy:string}")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
+)]
+fn set_environment_colour_policy_override(world: &TestWorld, policy: &str) -> Result<()> {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_COLOUR_POLICY");
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_COLOUR_POLICY", OsStr::new(policy)) };
+    world.track_env_var("NETSUKE_COLOUR_POLICY".to_owned(), previous);
+    Ok(())
+}
+
+#[given("the NETSUKE_SPINNER_MODE environment variable is {mode:string}")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
+)]
+fn set_environment_spinner_mode_override(world: &TestWorld, mode: &str) -> Result<()> {
+    ensure_env_lock(world);
+    let previous = std::env::var_os("NETSUKE_SPINNER_MODE");
+    // SAFETY: `EnvLock` is held in `world.env_lock` for the lifetime of the scenario.
+    unsafe { std::env::set_var("NETSUKE_SPINNER_MODE", OsStr::new(mode)) };
+    world.track_env_var("NETSUKE_SPINNER_MODE".to_owned(), previous);
+    Ok(())
+}
+
 #[expect(
     clippy::unnecessary_wraps,
     reason = "rstest-bdd macro generates Result wrapper; FIXME: https://github.com/leynos/rstest-bdd/issues/381"
@@ -178,6 +235,45 @@ fn merge_error_contains(world: &TestWorld, fragment: &str) -> Result<()> {
     ensure!(
         error.contains(fragment),
         "expected merge error to contain '{fragment}', got '{error}'",
+    );
+    Ok(())
+}
+
+#[then("the merged theme is unicode")]
+fn merged_theme_is_unicode(world: &TestWorld) -> Result<()> {
+    let theme = world
+        .cli
+        .with_ref(|cli| cli.theme)
+        .context("expected merged CLI to be available")?;
+    ensure!(
+        theme == Some(Theme::Unicode),
+        "expected merged theme to be Unicode, got {theme:?}",
+    );
+    Ok(())
+}
+
+#[then("the merged colour policy is always")]
+fn merged_colour_policy_is_always(world: &TestWorld) -> Result<()> {
+    let policy = world
+        .cli
+        .with_ref(|cli| cli.colour_policy)
+        .context("expected merged CLI to be available")?;
+    ensure!(
+        policy == Some(ColourPolicy::Always),
+        "expected merged colour policy to be Always, got {policy:?}",
+    );
+    Ok(())
+}
+
+#[then("the merged spinner mode is enabled")]
+fn merged_spinner_mode_is_enabled(world: &TestWorld) -> Result<()> {
+    let mode = world
+        .cli
+        .with_ref(|cli| cli.spinner_mode)
+        .context("expected merged CLI to be available")?;
+    ensure!(
+        mode == Some(SpinnerMode::Enabled),
+        "expected merged spinner mode to be Enabled, got {mode:?}",
     );
     Ok(())
 }

--- a/tests/features/configuration_preferences.feature
+++ b/tests/features/configuration_preferences.feature
@@ -32,3 +32,69 @@ Feature: Configuration preferences
     Then parsing succeeds
     And the merged theme is ascii
     And the prefix contains no non-ASCII characters
+
+  Scenario: CLI theme flag overrides configuration file
+    Given an empty workspace
+    And the Netsuke config file sets theme to "unicode"
+    When the CLI is parsed and merged with "--theme ascii"
+    Then parsing succeeds
+    And the merged theme is ascii
+
+  Scenario: CLI theme flag overrides environment variable
+    Given an empty workspace
+    And the NETSUKE_THEME environment variable is "unicode"
+    When the CLI is parsed and merged with "--theme ascii"
+    Then parsing succeeds
+    And the merged theme is ascii
+
+  Scenario: CLI theme flag has highest precedence over env and config
+    Given an empty workspace
+    And the Netsuke config file sets theme to "unicode"
+    And the NETSUKE_THEME environment variable is "auto"
+    When the CLI is parsed and merged with "--theme ascii"
+    Then parsing succeeds
+    And the merged theme is ascii
+
+  Scenario: CLI colour policy flag overrides configuration file
+    Given an empty workspace
+    And the Netsuke config file sets colour policy to "never"
+    When the CLI is parsed and merged with "--colour-policy always"
+    Then parsing succeeds
+    And the merged colour policy is always
+
+  Scenario: CLI colour policy flag overrides environment variable
+    Given an empty workspace
+    And the NETSUKE_COLOUR_POLICY environment variable is "never"
+    When the CLI is parsed and merged with "--colour-policy always"
+    Then parsing succeeds
+    And the merged colour policy is always
+
+  Scenario: CLI spinner mode flag overrides configuration file
+    Given an empty workspace
+    And the Netsuke config file sets spinner mode to "disabled"
+    When the CLI is parsed and merged with "--spinner-mode enabled"
+    Then parsing succeeds
+    And the merged spinner mode is enabled
+
+  Scenario: CLI spinner mode flag overrides environment variable
+    Given an empty workspace
+    And the NETSUKE_SPINNER_MODE environment variable is "disabled"
+    When the CLI is parsed and merged with "--spinner-mode enabled"
+    Then parsing succeeds
+    And the merged spinner mode is enabled
+
+  Scenario: Environment variable overrides configuration for theme
+    Given an empty workspace
+    And the Netsuke config file sets theme to "ascii"
+    And the NETSUKE_THEME environment variable is "unicode"
+    When the CLI is parsed and merged with ""
+    Then parsing succeeds
+    And the merged theme is unicode
+
+  Scenario: Environment variable overrides configuration for colour policy
+    Given an empty workspace
+    And the Netsuke config file sets colour policy to "auto"
+    And the NETSUKE_COLOUR_POLICY environment variable is "always"
+    When the CLI is parsed and merged with ""
+    Then parsing succeeds
+    And the merged colour policy is always


### PR DESCRIPTION
## Summary
- Adds explicit CLI override flags in the merge path, derives typed enums for CLI overrides, and updates tests, docs, and build script to reflect explicit CLI behavior and safer environment handling.

## Changes

### CLI
- In `src/cli/merge.rs`: insert explicit CLI flag mappings for `colour_policy`, `spinner_mode`, `output_format`, and `theme` into the root merge data so CLI-provided overrides are captured during merge.

### Parser
- In `src/cli/parser.rs`: convert the explicit override fields to be override-enabled CLI flags (long options) with appropriate value names: `POLICY`, `MODE`, `FORMAT`, and `THEME`.

### Config
- In `src/cli/config.rs`: derive `ValueEnum` for `ColourPolicy`, `SpinnerMode`, `OutputFormat`, and `Theme` to support explicit CLI overrides with typed values.

### Testing
- In `tests/bdd/steps/configuration_preferences.rs`:
  - Migrate environment-variable handling to `test_support::EnvVarGuard` for `CONFIG_ENV_VAR` and `LOCALE_ENV_VAR`.
  - Capture the previous value via `guard.original()` and restore it via world tracking.
  - Replace unsafe `std::env::set_var` calls with guarded variable setting to improve safety and determinism in tests.

### Build Script
- In `build.rs`:
  - Refactor to separate API-symbol verification and rerun-directive emission; integrate build-time tasks more clearly (e.g., public API checks and man-page generation).

### Documentation
- docs/execplans/3-10-1-guarantee-status-message-ordering.md
  - Fix formatting in the status message ordering section for clarity.
- docs/netsuke-design.md
  - Reword a paragraph to improve readability around configuration defaults and explicit CLI overrides while preserving the same meaning.

## Test plan
- Run the full test suite locally: `cargo test`.
- Execute BDD tests to ensure environment variable isolation between scenarios remains intact.
- Validate that explicit CLI overrides are properly captured in merged configuration.

## Rationale
- Explicit CLI flag inserts ensure CLI-provided overrides are captured and persisted during configuration merge, aligning with the intended behavior.
- Deriving `ValueEnum` enables safe, typed CLI override values.
- Using `EnvVarGuard` for tests improves isolation and safety by avoiding unsafe global env mutations.
- Documentation tweaks reduce potential confusion around explicit CLI overrides and status message ordering.

📎 **Task**: https://www.devboxer.com/task/a7003265-1e31-47cd-a55c-63d4846862b7

## Summary by Sourcery

Introduce explicit typed CLI overrides for output-related settings and refactor build-time tooling for clearer responsibilities and man-page generation.

New Features:
- Expose colour policy, spinner mode, output format, and theme as explicit CLI override flags using typed enums.

Enhancements:
- Derive `ValueEnum` for output-related configuration enums to support typed CLI parsing.
- Refactor the build script to separate public-API symbol verification, rerun directives, and man-page generation.
- Tidy documentation wording and formatting around configuration defaults, CLI overrides, and status message ordering.

Tests:
- Adjust configuration preference tests to use safer environment variable handling for the config path.