### PR TITLE
Clarify and Document Formal Verification Details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 **/*~
 .crush
 build.ninja
+*:Zone.Identifier

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,0 +1,60 @@
+# Documentation contents
+
+This index groups the primary Netsuke documentation by purpose so design,
+operational, and contributor references are easier to find.
+
+## Core design and planning
+
+- [netsuke-design.md](netsuke-design.md): Primary architecture, manifest, and
+  execution design document.
+- [netsuke-cli-design-document.md](netsuke-cli-design-document.md): Command-line
+  interface design and user-experience requirements.
+- [roadmap.md](roadmap.md): Phased implementation plan and tracked delivery
+  work.
+- [formal-verification-methods-in-netsuke.md](formal-verification-methods-in-netsuke.md):
+  Recommended scope and delivery order for Kani, Proptest, and optional Verus
+  checks.
+- [adr-001-replace-serde-yml-with-serde-saphyr.md](adr-001-replace-serde-yml-with-serde-saphyr.md):
+  YAML parser migration decision record.
+- [adr-002-replace-cucumber-with-rstest-bdd.md](adr-002-replace-cucumber-with-rstest-bdd.md):
+  Behavioural-testing framework migration decision record.
+
+## User and operator guides
+
+- [quickstart.md](quickstart.md): First-run walkthrough for building with
+  Netsuke.
+- [users-guide.md](users-guide.md): End-user reference for authoring and
+  running Netsuke manifests.
+- [ortho-config-users-guide.md](ortho-config-users-guide.md): Configuration
+  system guide and precedence reference.
+- [translators-guide.md](translators-guide.md): Localization workflow and
+  translation guidance.
+
+## Contributor guidance
+
+- [developers-guide.md](developers-guide.md): Engineering workflow, quality
+  gates, and testing strategy.
+- [documentation-style-guide.md](documentation-style-guide.md): Documentation
+  conventions, roadmap-writing rules, and Markdown requirements.
+- [execplans/](execplans/): Execution plans and implementation handoff notes.
+
+## Testing and quality references
+
+- [behavioural-testing-in-rust-with-cucumber.md](behavioural-testing-in-rust-with-cucumber.md):
+  Historical behavioural-testing background.
+- [reliable-testing-in-rust-via-dependency-injection.md](reliable-testing-in-rust-via-dependency-injection.md):
+  Dependency-injection testing patterns used by the project.
+- [rstest-bdd-users-guide.md](rstest-bdd-users-guide.md): Current behavioural
+  testing framework reference.
+- [rstest-bdd-v0-5-0-migration-guide.md](rstest-bdd-v0-5-0-migration-guide.md):
+  Migration notes for the current `rstest-bdd` release.
+- [rust-doctest-dry-guide.md](rust-doctest-dry-guide.md): Doctest workflow and
+  dry-run guidance.
+- [rust-testing-with-rstest-fixtures.md](rust-testing-with-rstest-fixtures.md):
+  `rstest` fixture patterns used in the repository.
+- [snapshot-testing-in-netsuke-using-insta.md](snapshot-testing-in-netsuke-using-insta.md):
+  Snapshot-testing strategy and examples.
+- [test-isolation-with-ninja-env.md](test-isolation-with-ninja-env.md): Test
+  isolation strategy for Ninja process interactions.
+- [security-network-command-audit.md](security-network-command-audit.md):
+  Security review of network and command-execution surfaces.

--- a/docs/formal-verification-methods-in-netsuke.md
+++ b/docs/formal-verification-methods-in-netsuke.md
@@ -1,0 +1,266 @@
+# Formal verification methods in Netsuke
+
+## Executive summary
+
+Netsuke is a strong candidate for selective formal verification rather than
+whole-program proof. The repository is a single Rust package that compiles a
+YAML manifest with MiniJinja expansion into a deterministic Ninja build graph,
+then delegates execution to the Ninja subprocess.[^1][^2][^3][^4]
+
+The highest-return verification work is concentrated in the semantic core:
+
+1. Kani should verify bounded safety and error-handling properties in the
+   Intermediate Representation (IR) pipeline, especially duplicate-output
+   rejection, rule resolution, cycle detection, and command interpolation.[^5]
+2. Proptest should exercise determinism and manifest-expansion invariants that
+   are pure enough for generated testing but awkward to prove directly.[^2][^6]
+3. Verus should remain optional and limited to small proof kernels such as
+   cycle canonicalization after the Kani and Proptest suites have stabilized.
+4. Stateright should remain out of scope until Netsuke gains long-lived mutable
+   state, actor-style coordination, or a scheduler that is more complex than
+   the current Ninja hand-off.[^1][^4]
+
+## Current repository state
+
+The repository currently has no formal-verification tooling. `Cargo.toml`
+contains unit-testing, behavioural-testing, snapshot-testing, and CLI-testing
+dependencies, but no `proptest`, `kani`, `verus`, or Stateright support.[^1]
+The top-level `Makefile` exposes build, test, lint, formatting, Markdown lint,
+and Mermaid validation targets only.[^2] The current `CI` workflow runs the
+same conventional checks across supported toolchains and does not define a
+separate proof or model-checking job.[^3]
+
+That absence is useful context. Netsuke does not need a new verification
+workspace as a first step. The strongest verification targets already live in
+production modules with clear semantic boundaries, so a lightweight,
+module-adjacent approach is the most proportionate fit.
+
+## Recommended scope
+
+### Kani for the IR core
+
+`BuildGraph::from_manifest` is the main semantic commitment point. It resolves
+rules, registers actions, rejects duplicate outputs, records default targets,
+and reports cycles before the build graph is returned to the caller.[^5] A bug
+in this path risks producing a wrong graph rather than a clean failure.
+
+The first Kani harnesses should cover these properties:
+
+- Duplicate outputs always fail with `DuplicateOutput`.
+- Empty rules, multiple rules, and missing named rules return the correct
+  `IrGenError` variant.
+- Self-edges and bounded multi-node cycles always fail with
+  `CircularDependency`.
+- Acyclic bounded graphs are never rejected as cyclic.
+- Missing dependencies are recorded without creating false cycles.
+
+`src/ir/cycle.rs` is the strongest narrow proof candidate in the current
+repository. `canonicalize_cycle` has a crisp normalization contract that is
+small enough for Kani immediately and remains a plausible later Verus kernel if
+stronger proof obligations become worthwhile.[^7]
+
+### Kani for command interpolation
+
+`src/ir/cmd_interpolate.rs` is another high-value target because it is compact,
+load-bearing, and security-sensitive. `interpolate_command` replaces `$in` and
+`$out`, avoids rewriting inside backticks, and rejects commands when backticks
+are unmatched or the interpolated result fails the current `shlex` guard.[^8]
+
+The initial Kani properties should assert that:
+
+- Only whole-word `$in` and `$out` placeholders are rewritten.
+- Identifier-containing strings such as `$input` or `$output` are not
+  rewritten accidentally.
+- Backtick-delimited regions are preserved.
+- Odd numbers of backticks are rejected.
+- Successful interpolation always returns a string that passes the current
+  syntactic guard.
+
+### Proptest for determinism and manifest semantics
+
+Netsuke already documents deterministic graph generation as part of its public
+shape, and the implementation sorts actions, edges, and default targets when
+rendering the Ninja file.[^4][^6] That makes generated testing a natural fit
+for determinism checks.
+
+The first Proptest coverage should focus on:
+
+- stable Ninja output across `HashMap` insertion orders,
+- stable `default` target ordering,
+- `path_key` invariance for equivalent output sets, and
+- action-hash stability for field-preserving permutations.[^6]
+
+The manifest-expansion pipeline is also a strong Proptest target. The loader
+parses YAML first, expands `foreach` and `when`, deserializes into typed data,
+and only then renders string fields with MiniJinja.[^9] Generated testing
+should lock down these invariants:
+
+- `foreach` preserves non-control fields,
+- `when` is removed after evaluation,
+- `item` and `index` bindings are injected correctly,
+- static targets still honour `when`,
+- key order is preserved where the implementation intends to preserve it, and
+- rendering is idempotent once no Jinja syntax remains.[^9]
+
+### Optional Verus proof kernel
+
+Verus is not the correct first tool for the manifest or command-interpolation
+layers. The code that is most suitable for a later proof is
+`canonicalize_cycle`, because the function exposes a clear mathematical
+contract:
+
+- output length is preserved,
+- the cycle remains closed,
+- the interior node multiset is preserved, and
+- the chosen start node is stable under the repository's ordering rule.[^7]
+
+If Verus is introduced, it should prove only that narrow normalization model at
+first. Production `HashMap` structures, MiniJinja values, filesystem helpers,
+and subprocess orchestration should remain outside the first proof boundary.
+
+### Stateright remains deferred
+
+Stateright is not justified by the current architecture. Netsuke is a compiler
+and orchestrator that emits a static Ninja file and delegates execution to the
+Ninja subprocess.[^4][^10] There is no actor protocol, distributed state
+machine, or internal concurrent scheduler to model check today.
+
+Reconsidering Stateright would make sense only after a future daemon mode,
+watch service, remote-execution coordinator, or another long-lived concurrent
+subsystem exists.
+
+## Repository integration plan
+
+### Layout
+
+The preferred first layout is intentionally lightweight:
+
+```text
+.
+├── Cargo.toml
+├── Makefile
+├── scripts/
+│   ├── install-kani.sh
+│   ├── install-verus.sh
+│   └── run-verus.sh
+├── tools/
+│   ├── kani/
+│   │   └── VERSION
+│   └── verus/
+│       ├── VERSION
+│       └── SHA256SUMS
+├── verus/
+│   ├── netsuke_proofs.rs
+│   └── cycle_canonicalization.rs
+└── src/
+    ├── ir/
+    │   └── kani.rs
+    ├── manifest/
+    │   └── kani.rs
+    └── ninja_gen_kani.rs
+```
+
+This layout keeps Kani harnesses close to the internal helpers they exercise,
+which avoids widening the public API solely for proofs. Verus can remain
+outside Cargo until it proves its value.
+
+### Makefile and local workflow
+
+The first formal-verification commands should extend the existing `Makefile`
+without disturbing the current developer workflow.[^2]
+
+- `make kani` should run a small smoke-harness set suitable for pull requests.
+- `make kani-full` should run the full Kani suite.
+- `make formal-pr` should alias the fast pull-request checks.
+- `make formal-nightly` should combine deeper Kani runs with any later Verus
+  proofs.
+
+That split keeps the default quality gates fast while still allowing a deeper
+scheduled gate.
+
+### Continuous integration (CI)
+
+Formal verification should not be folded into the existing `build-test` job.
+The current `CI` workflow already performs formatting, linting, tests, and
+coverage, and those checks should remain intact.[^3]
+
+The first additional job should be a dedicated `kani-smoke` job that:
+
+- installs the pinned Kani toolchain,
+- runs `make kani`, and
+- caches tool downloads separately from the ordinary Rust build artefacts.
+
+Any later Verus job should be added only after a stable proof kernel exists.
+
+## Design decisions to settle before proof work
+
+Three contracts should be documented before proofs become gating checks.
+
+### Command placeholder contract
+
+The interpolation layer currently supports `$in` and `$out`, enforces
+identifier-style token boundaries, and suppresses substitution inside
+backticks.[^8] The project documentation should state whether:
+
+- those are the only supported placeholders,
+- backtick suppression is the full contract or a temporary subset of shell
+  command-substitution handling, and
+- `shlex::split` is part of the semantic acceptance contract or only a guard
+  against obviously malformed commands.
+
+### Cycle-participation contract
+
+`BuildEdge` records explicit inputs, explicit outputs, implicit outputs, and
+order-only dependencies, but the current cycle detector walks `edge.inputs`
+only.[^5][^7] Before proofs are written, the intended scope of cycle detection
+should be recorded explicitly:
+
+- explicit inputs only,
+- explicit inputs plus order-only dependencies, or
+- explicit, implicit, and order-only dependencies together.
+
+### Determinism contract
+
+The README promises a reproducible, fully static dependency graph, and the
+generator already sorts its output to support deterministic emission.[^4][^6]
+The formal-verification work should therefore define whether byte-for-byte
+stable Ninja output and stable action identifiers are public guarantees or
+current implementation details.
+
+## Recommended delivery order
+
+The delivery sequence should stay narrow:
+
+1. Add Kani tooling, local scripts, and pull-request smoke targets.
+2. Add Kani harnesses for IR generation, cycle handling, and command
+   interpolation.
+3. Add Proptest coverage for deterministic emission and manifest semantics.
+4. Document the deferred Stateright decision and the narrow Verus entry point.
+5. Add a small Verus proof kernel only after the earlier suites have stabilized
+   and the relevant contracts are written down.
+
+That order produces useful guarantees quickly without forcing the repository
+into a proof-first shape that its current architecture does not need.
+
+## References
+
+[^1]: [`Cargo.toml`](../Cargo.toml) lists the current package layout and
+  dependency set.
+[^2]: [`Makefile`](../Makefile) defines the current local quality-gate targets.
+[^3]: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) defines the
+  current continuous integration workflow.
+[^4]: [`README.md`](../README.md) describes Netsuke as a compiler from YAML and
+  Jinja to Ninja, with deterministic graph generation and Ninja execution.
+[^5]: [`src/ir/from_manifest.rs`](../src/ir/from_manifest.rs) defines
+  `BuildGraph::from_manifest`, duplicate-output rejection, rule resolution, and
+  cycle reporting.
+[^6]: [`src/ninja_gen.rs`](../src/ninja_gen.rs) sorts actions, edges, and
+  default targets to keep emitted Ninja text deterministic.
+[^7]: [`src/ir/cycle.rs`](../src/ir/cycle.rs) defines cycle analysis and
+  `canonicalize_cycle`.
+[^8]: [`src/ir/cmd_interpolate.rs`](../src/ir/cmd_interpolate.rs) defines
+  placeholder substitution and command validation.
+[^9]: [`src/manifest/mod.rs`](../src/manifest/mod.rs) describes the YAML-first
+  manifest pipeline and re-exports expansion and rendering helpers.
+[^10]: [`src/runner/mod.rs`](../src/runner/mod.rs) generates the Ninja manifest
+  and delegates execution to the Ninja subprocess.

--- a/docs/formal-verification-methods-in-netsuke.md
+++ b/docs/formal-verification-methods-in-netsuke.md
@@ -49,9 +49,9 @@ The first Kani harnesses should cover these properties:
 - Duplicate outputs always fail with `DuplicateOutput`.
 - Empty rules, multiple rules, and missing named rules return the correct
   `IrGenError` variant.
-- Self-edges and bounded multi-node cycles always fail with
-  `CircularDependency`.
-- Acyclic bounded graphs are never rejected as cyclic.
+- Self-edges and bounded multi-node cycles (up to 10 nodes with depth limit
+  of 20 edges) always fail with `CircularDependency`.
+- Acyclic bounded graphs (same size limits) are never rejected as cyclic.
 - Missing dependencies are recorded without creating false cycles.
 
 `src/ir/cycle.rs` is the strongest narrow proof candidate in the current
@@ -66,7 +66,8 @@ load-bearing, and security-sensitive. `interpolate_command` replaces `$in` and
 `$out`, avoids rewriting inside backticks, and rejects commands when backticks
 are unmatched or the interpolated result fails the current `shlex` guard.[^8]
 
-The initial Kani properties should assert that:
+The initial Kani properties should assert that (bounded to command strings up
+to 256 characters with at most 8 placeholder occurrences):
 
 - Only whole-word `$in` and `$out` placeholders are rewritten.
 - Identifier-containing strings such as `$input` or `$output` are not
@@ -83,7 +84,8 @@ shape, and the implementation sorts actions, edges, and default targets when
 rendering the Ninja file.[^4][^6] That makes generated testing a natural fit
 for determinism checks.
 
-The first Proptest coverage should focus on:
+The first Proptest coverage should focus on (generated graphs bounded to 50
+actions and 100 edges):
 
 - stable Ninja output across `HashMap` insertion orders,
 - stable `default` target ordering,
@@ -145,10 +147,10 @@ The preferred first layout is intentionally lightweight:
 │   └── run-verus.sh
 ├── tools/
 │   ├── kani/
-│   │   └── VERSION
+│   │   └── VERSION        # Update when new stable releases ship
 │   └── verus/
-│       ├── VERSION
-│       └── SHA256SUMS
+│       ├── VERSION        # Update when new stable releases ship
+│       └── SHA256SUMS     # Update alongside VERSION
 ├── verus/
 │   ├── netsuke_proofs.rs
 │   └── cycle_canonicalization.rs
@@ -163,6 +165,28 @@ The preferred first layout is intentionally lightweight:
 This layout keeps Kani harnesses close to the internal helpers they exercise,
 which avoids widening the public API solely for proofs. Verus can remain
 outside Cargo until it proves its value.
+
+#### Tool version pinning and updates
+
+The `tools/*/VERSION` files define the exact tool versions used in local
+development and continuous integration. These pins serve several purposes:
+
+- They ensure reproducible verification results across developer machines.
+- They prevent silent drift between local proofs and the CI verification
+  environment.
+- They allow deliberate testing of tool updates in isolation before promotion.
+
+**Update policy:**
+
+- Update `VERSION` files when new stable releases of Kani or Verus ship, after
+  verifying that all existing harnesses and proofs remain valid under the new
+  version.
+- Update `SHA256SUMS` alongside `VERSION` to match the published release
+  artefacts.
+- Document any version-specific workarounds or compatibility notes in commit
+  messages when updating tool pins.
+- If CI and local development ever use different tool versions, treat that as a
+  bug requiring immediate correction.
 
 ### Makefile and local workflow
 
@@ -200,7 +224,9 @@ Three contracts should be documented before proofs become gating checks.
 
 The interpolation layer currently supports `$in` and `$out`, enforces
 identifier-style token boundaries, and suppresses substitution inside
-backticks.[^8] The project documentation should state whether:
+backticks.[^8] This contract should be documented in the README under a new
+"Security and command interpolation" section, as it is a user-facing guarantee
+that affects manifest authoring. The project documentation should state whether:
 
 - those are the only supported placeholders,
 - backtick suppression is the full contract or a temporary subset of shell
@@ -212,8 +238,10 @@ backticks.[^8] The project documentation should state whether:
 
 `BuildEdge` records explicit inputs, explicit outputs, implicit outputs, and
 order-only dependencies, but the current cycle detector walks `edge.inputs`
-only.[^5][^7] Before proofs are written, the intended scope of cycle detection
-should be recorded explicitly:
+only.[^5][^7] This contract should be documented in the user guide under the
+dependency and build-graph semantics chapter, as it defines the behaviour users
+observe when circular dependencies are detected. Before proofs are written, the
+intended scope of cycle detection should be recorded explicitly:
 
 - explicit inputs only,
 - explicit inputs plus order-only dependencies, or
@@ -221,11 +249,14 @@ should be recorded explicitly:
 
 ### Determinism contract
 
-The README promises a reproducible, fully static dependency graph, and the
-generator already sorts its output to support deterministic emission.[^4][^6]
-The formal-verification work should therefore define whether byte-for-byte
-stable Ninja output and stable action identifiers are public guarantees or
-current implementation details.
+The README (line 17) promises "a reproducible, fully static dependency graph",
+and the generator already sorts its output to support deterministic
+emission.[^4][^6] This is already a user-facing guarantee in the README, and
+the formal-verification work should strengthen that existing contract by
+defining whether byte-for-byte stable Ninja output and stable action
+identifiers are public guarantees or current implementation details. Any
+expanded contract should be documented in the README immediately following the
+existing reproducibility statement.
 
 ## Recommended delivery order
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -327,3 +327,103 @@ library, and CLI ergonomics.
 configurable CLI that delivers real-time feedback, machine-readable
 diagnostics, and the onboarding experience defined in the Netsuke CLI design
 document.
+
+## 4. Formal verification and property testing
+
+Objective: To add bounded formal verification and generated testing where the
+repository's semantic risk is highest, while keeping the existing build, lint,
+and test workflow intact. See
+[formal-verification-methods-in-netsuke.md](formal-verification-methods-in-netsuke.md).
+
+### 4.1. Verification tooling and gating
+
+- [ ] 4.1.1. Add Kani tooling and local smoke targets. See
+  [formal-verification-methods-in-netsuke.md §Repository integration plan](formal-verification-methods-in-netsuke.md#repository-integration-plan).
+  - [ ] Pin the supported Kani version under `tools/kani/`.
+  - [ ] Add `scripts/install-kani.sh`.
+  - [ ] Add `make kani`, `make kani-full`, and `make formal-pr`.
+- [ ] 4.1.2. Add a dedicated `kani-smoke` continuous integration (CI) job.
+  Requires 4.1.1. See
+  [formal-verification-methods-in-netsuke.md §Continuous integration (CI)](formal-verification-methods-in-netsuke.md#continuous-integration-ci).
+  - [ ] Keep the existing `build-test` job unchanged.
+  - [ ] Run only the bounded smoke harness set on pull requests.
+  - [ ] Cache Kani tool downloads separately from ordinary Cargo artefacts.
+- [ ] 4.1.3. Record the phase-1 scope boundary for Verus and Stateright. See
+  [formal-verification-methods-in-netsuke.md §Optional Verus proof kernel](formal-verification-methods-in-netsuke.md#optional-verus-proof-kernel)
+   and
+  [formal-verification-methods-in-netsuke.md §Stateright remains deferred](formal-verification-methods-in-netsuke.md#stateright-remains-deferred).
+  - [ ] Document Verus as optional and proof-kernel-only.
+  - [ ] Document Stateright as deferred until Netsuke gains a stateful
+    concurrent subsystem.
+
+### 4.2. Intermediate Representation verification
+
+- [ ] 4.2.1. Add Kani harnesses for manifest-to-IR safety checks. Requires
+  4.1.1. See
+  [formal-verification-methods-in-netsuke.md §Kani for the IR core](formal-verification-methods-in-netsuke.md#kani-for-the-ir-core).
+  - [ ] Prove duplicate-output rejection on bounded manifests.
+  - [ ] Prove empty-rule, multiple-rule, and missing-rule error selection.
+  - [ ] Prove self-edge and small bounded multi-node cycle rejection.
+  - [ ] Prove missing dependencies do not create false cycles.
+- [ ] 4.2.2. Add Kani harnesses for cycle canonicalization. Requires 4.2.1.
+  See
+  [formal-verification-methods-in-netsuke.md §Optional Verus proof kernel](formal-verification-methods-in-netsuke.md#optional-verus-proof-kernel).
+  - [ ] Prove preserved length and closed-cycle output.
+  - [ ] Prove the interior node multiset is preserved.
+  - [ ] Prove the selected start node is stable under the current ordering
+    rule.
+- [ ] 4.2.3. Add Kani harnesses for command interpolation. Requires 4.1.1. See
+  [formal-verification-methods-in-netsuke.md §Kani for command interpolation](formal-verification-methods-in-netsuke.md#kani-for-command-interpolation).
+  - [ ] Prove `$in` and `$out` rewrite only at valid token boundaries.
+  - [ ] Prove backtick-delimited regions are preserved.
+  - [ ] Prove unmatched backticks are rejected.
+  - [ ] Prove successful results satisfy the current `shlex` guard.
+
+### 4.3. Determinism and manifest property testing
+
+- [ ] 4.3.1. Add Proptest coverage for deterministic Ninja emission. Requires
+  4.1.1. See the
+  [Proptest section](formal-verification-methods-in-netsuke.md#proptest-for-determinism-and-manifest-semantics).
+  - [ ] Prove Ninja output is stable across equivalent insertion orders.
+  - [ ] Prove `default` target ordering is stable.
+  - [ ] Prove `path_key` is invariant for equivalent output sets.
+- [ ] 4.3.2. Add Proptest coverage for manifest expansion invariants. Requires
+  4.1.1. See the
+  [Proptest section](formal-verification-methods-in-netsuke.md#proptest-for-determinism-and-manifest-semantics).
+  - [ ] Prove `foreach` preserves non-control fields.
+  - [ ] Prove `when` is removed after evaluation.
+  - [ ] Prove `item` and `index` are injected correctly for each expansion.
+  - [ ] Prove static targets still honour `when`.
+- [ ] 4.3.3. Add Proptest coverage for render stability. Requires 4.3.2. See
+  the
+  [Proptest section](formal-verification-methods-in-netsuke.md#proptest-for-determinism-and-manifest-semantics).
+  - [ ] Prove rendering is idempotent after Jinja syntax is exhausted.
+  - [ ] Prove variable rendering uses the intended snapshot semantics.
+
+### 4.4. Contract documentation and optional proof kernels
+
+- [ ] 4.4.1. Document the command placeholder contract. Requires 4.2.3. See
+  [formal-verification-methods-in-netsuke.md §Command placeholder contract](formal-verification-methods-in-netsuke.md#command-placeholder-contract).
+  - [ ] State the supported placeholders explicitly.
+  - [ ] State the current backtick-handling boundary explicitly.
+  - [ ] State whether `shlex::split` is part of the semantic acceptance
+    contract.
+- [ ] 4.4.2. Document which dependency kinds participate in cycle detection.
+  Requires 4.2.1. See
+  [formal-verification-methods-in-netsuke.md §Cycle-participation contract](formal-verification-methods-in-netsuke.md#cycle-participation-contract).
+  - [ ] Decide whether order-only dependencies participate.
+  - [ ] Decide whether implicit outputs participate.
+  - [ ] Align implementation, tests, and documentation with the chosen rule.
+- [ ] 4.4.3. Evaluate a minimal Verus proof kernel for cycle canonicalization.
+  Requires 4.2.2 and 4.1.3. See
+  [formal-verification-methods-in-netsuke.md §Optional Verus proof kernel](formal-verification-methods-in-netsuke.md#optional-verus-proof-kernel).
+  - [ ] Keep the proof outside Cargo.
+  - [ ] Use proof-specific model types rather than production `HashMap`
+    structures.
+  - [ ] Accept the proof only if it remains narrower and cheaper than the Kani
+    equivalent.
+
+**Success criterion:** Netsuke ships bounded Kani smoke checks for the IR core,
+generated property tests for deterministic emission and manifest semantics, and
+documented verification contracts that keep optional Verus work narrow and
+defer Stateright until the architecture justifies model checking.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -361,9 +361,11 @@ and test workflow intact. See
 - [ ] 4.2.1. Add Kani harnesses for manifest-to-IR safety checks. Requires
   4.1.1. See
   [formal-verification-methods-in-netsuke.md §Kani for the IR core](formal-verification-methods-in-netsuke.md#kani-for-the-ir-core).
-  - [ ] Prove duplicate-output rejection on bounded manifests.
+  - [ ] Prove duplicate-output rejection on bounded manifests (up to 10 nodes,
+    depth limit 20 edges).
   - [ ] Prove empty-rule, multiple-rule, and missing-rule error selection.
-  - [ ] Prove self-edge and small bounded multi-node cycle rejection.
+  - [ ] Prove self-edge and small bounded multi-node cycle rejection (same
+    limits).
   - [ ] Prove missing dependencies do not create false cycles.
 - [ ] 4.2.2. Add Kani harnesses for cycle canonicalization. Requires 4.2.1.
   See
@@ -374,7 +376,8 @@ and test workflow intact. See
     rule.
 - [ ] 4.2.3. Add Kani harnesses for command interpolation. Requires 4.1.1. See
   [formal-verification-methods-in-netsuke.md §Kani for command interpolation](formal-verification-methods-in-netsuke.md#kani-for-command-interpolation).
-  - [ ] Prove `$in` and `$out` rewrite only at valid token boundaries.
+  - [ ] Prove `$in` and `$out` rewrite only at valid token boundaries (bounded
+    to 256-character commands with at most 8 placeholders).
   - [ ] Prove backtick-delimited regions are preserved.
   - [ ] Prove unmatched backticks are rejected.
   - [ ] Prove successful results satisfy the current `shlex` guard.
@@ -384,7 +387,8 @@ and test workflow intact. See
 - [ ] 4.3.1. Add Proptest coverage for deterministic Ninja emission. Requires
   4.1.1. See the
   [Proptest section](formal-verification-methods-in-netsuke.md#proptest-for-determinism-and-manifest-semantics).
-  - [ ] Prove Ninja output is stable across equivalent insertion orders.
+  - [ ] Prove Ninja output is stable across equivalent insertion orders
+    (generated graphs bounded to 50 actions and 100 edges).
   - [ ] Prove `default` target ordering is stable.
   - [ ] Prove `path_key` is invariant for equivalent output sets.
 - [ ] 4.3.2. Add Proptest coverage for manifest expansion invariants. Requires
@@ -402,17 +406,21 @@ and test workflow intact. See
 
 ### 4.4. Contract documentation and optional proof kernels
 
-- [ ] 4.4.1. Document the command placeholder contract. Requires 4.2.3. See
+- [ ] 4.4.1. Document the command placeholder contract in the README. Requires
+  4.2.3. See
   [formal-verification-methods-in-netsuke.md §Command placeholder contract](formal-verification-methods-in-netsuke.md#command-placeholder-contract).
+  - [ ] Add a "Security and command interpolation" section to the README.
   - [ ] State the supported placeholders explicitly.
   - [ ] State the current backtick-handling boundary explicitly.
   - [ ] State whether `shlex::split` is part of the semantic acceptance
     contract.
-- [ ] 4.4.2. Document which dependency kinds participate in cycle detection.
-  Requires 4.2.1. See
+- [ ] 4.4.2. Document which dependency kinds participate in cycle detection in
+  the user guide. Requires 4.2.1. See
   [formal-verification-methods-in-netsuke.md §Cycle-participation contract](formal-verification-methods-in-netsuke.md#cycle-participation-contract).
   - [ ] Decide whether order-only dependencies participate.
   - [ ] Decide whether implicit outputs participate.
+  - [ ] Document the chosen rule in the user guide's dependency and build-graph
+    semantics chapter.
   - [ ] Align implementation, tests, and documentation with the chosen rule.
 - [ ] 4.4.3. Evaluate a minimal Verus proof kernel for cycle canonicalization.
   Requires 4.2.2 and 4.1.3. See


### PR DESCRIPTION
## Summary by Sourcery

Introduce formal verification documentation and a contents index for Netsuke, clarifying the scope and sequencing of Kani, Proptest, and optional Verus, and organizing existing docs by purpose.

Documentation:
- Add a detailed design document describing the recommended scope, tooling, and integration plan for formal verification and property testing in Netsuke.
- Add a documentation contents index that categorizes core design, user/operator guides, contributor docs, and testing/quality references for easier navigation.
- Add docs/formal-verification-methods-in-netsuke.md detailing recommended scope and delivery order for Kani, Proptest, and optional Verus checks.

Chores:
- Extend the project roadmap with a new section covering formal verification objectives, milestones, and success criteria.

📎 **Task**: https://www.devboxer.com/task/0120aa29-ff50-4754-b40f-ac2206609ab7