### PR TITLE
3.12.2: Insta snapshot tests for progress, status, timing, prefixes

### DIFF
--- a/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
+++ b/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -120,18 +120,23 @@ than hunting through substring assertions.
 
 ## Progress
 
-- [ ] Researched existing test infrastructure, reporter API surfaces, and
+- [x] Researched existing test infrastructure, reporter API surfaces, and
       insta usage patterns.
-- [ ] Drafted this ExecPlan.
-- [ ] Stage A: Add insta snapshot tests for AccessibleReporter output.
-- [ ] Stage B: Add insta snapshot tests for timing summary rendering.
-- [ ] Stage C: Add insta snapshot tests for prefix and spacing accessors.
-- [ ] Stage D: Add BDD scenarios for full-output snapshot verification.
-- [ ] Stage E: Documentation, roadmap update, and final validation.
+- [x] Drafted this ExecPlan.
+- [x] Stage A: Add insta snapshot tests for AccessibleReporter output.
+- [x] Stage B: Add insta snapshot tests for timing summary rendering.
+- [x] Stage C: Add insta snapshot tests for prefix and spacing accessors.
+- [x] Stage D: Add BDD scenarios for full-output snapshot verification.
+- [x] Stage E: Documentation, roadmap update, and final validation.
 
 ## Surprises & discoveries
 
-(None yet.)
+- `rstest-bdd` passed quoted literal arguments (for example `"Info:"`) through
+  to the new alignment step verbatim, so the step needed to trim surrounding
+  quotes before comparing normalized stderr lines.
+- The `leta` language-server background `cargo check` held the shared target
+  directory lock during targeted test runs. Killing that background check was
+  necessary before the repo-local cargo test slices could proceed.
 
 ## Decision log
 
@@ -167,9 +172,33 @@ than hunting through substring assertions.
   producing separate, reviewable snapshot files for each theme. The pattern is
   established in `src/output_prefs_tests.rs`. Date/Author: 2026-03-23 / Codex.
 
+- Decision: normalize quoted literal arguments inside the new
+  `progress_output` BDD alignment step by trimming surrounding `"` characters
+  before comparison. Rationale: rstest-bdd passed the quoted fragments from the
+  feature file to the step function verbatim, and the assertion should match
+  the human-visible content rather than the Gherkin quoting syntax.
+  Date/Author: 2026-03-27 / Codex.
+
 ## Outcomes & retrospective
 
-(To be completed.)
+- Added snapshot coverage for:
+  - `AccessibleReporter` stage/completion output in Unicode and ASCII themes.
+  - `AccessibleReporter` task-progress output in Unicode and ASCII themes.
+  - `render_summary_lines()` timing summaries in Unicode and ASCII themes.
+  - `OutputPrefs` semantic prefixes and spacing accessors in Unicode and ASCII
+    themes.
+- Added two `progress_output.feature` scenarios plus a reusable alignment step
+  asserting that matching stderr lines begin with the expected theme prefix.
+- Updated the user guide, design document, and roadmap to record the new
+  regression guard coverage.
+- Focused validation passed for:
+  - `cargo test --lib status::tests`
+  - `cargo test --lib status::timing::tests`
+  - `cargo test --lib output_prefs::tests`
+  - `cargo test --test bdd_tests progress_output`
+- Final repository-wide validation (`make check-fmt`, `make lint`,
+  `make test`, `make fmt`, `make markdownlint`, `make nixie`) completed
+  successfully after implementation.
 
 ## Context and orientation
 

--- a/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
+++ b/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
@@ -1,0 +1,662 @@
+# 3.12.2. Snapshot progress and status output for themes
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Netsuke's theme system (roadmap 3.12.1) introduced tokenized design tokens for
+symbols, spacing, and colours, and wired them through the reporter stack. The
+reporters (`AccessibleReporter`, `IndicatifReporter`, `VerboseTimingReporter`)
+now draw prefixes and indentation from a resolved `OutputPrefs` value, and unit
+tests assert individual prefixes and formatting helpers. However, there is no
+automated guarantee that the **full rendered output** of each reporter stays
+stable across code changes. A small drift in indentation width, a stray blank
+line, or a missing prefix could break visual alignment for users without any
+existing test failing.
+
+This change introduces `insta` snapshot tests that capture the complete,
+multi-line output of progress and status rendering for both the Unicode and
+ASCII themes. After the work is complete:
+
+1. Each reporter's rendering path has at least one snapshot per theme that
+   pins its exact output, so any drift in alignment, wrapping, or prefix
+   formatting fails the build.
+2. Snapshot tests cover the AccessibleReporter (stage announcements, task
+   progress, and completion), the VerboseTimingReporter (timing summaries), and
+   the output_prefs prefix/spacing accessors.
+3. BDD scenarios confirm end-to-end snapshot-level output correctness for both
+   `--theme unicode` and `--theme ascii` via the real binary, guarding against
+   regressions in the integration between theme resolution, localization, and
+   reporter rendering.
+4. `make check-fmt`, `make lint`, and `make test` pass.
+
+Observable success means a developer can change reporter formatting and receive
+an immediate, diff-friendly failure showing exactly which lines shifted rather
+than hunting through substring assertions.
+
+## Constraints
+
+- Do not modify the user-visible output format itself. This plan adds tests
+  that pin the current rendering; it does not change how output looks.
+- Do not add new crate dependencies. `insta` (with the `yaml` feature) is
+  already a dev-dependency in `Cargo.toml`.
+- Preserve the existing test infrastructure. New snapshot tests must
+  co-exist with the existing `rstest` unit tests and `rstest-bdd` BDD scenarios
+  without changing their assertions or structure.
+- Keep the 400-line file limit per AGENTS.md. If a new test file approaches
+  this limit, split it into a sibling module.
+- Do not suppress lints. If Clippy raises new warnings, fix them in the code.
+- The Fluent localization system produces invisible bidi isolate markers
+  (`U+2068`/`U+2069`). Snapshot tests must normalize these markers before
+  comparing, using the existing
+  `test_support::fluent::normalize_fluent_isolates` helper. This ensures
+  snapshots contain only human-visible characters and remain stable across
+  Fluent versions.
+- All snapshot names must be descriptive and stable. Use the pattern
+  `<reporter>_<theme>_<scenario>` (e.g.,
+  `accessible_unicode_stage_announcement`).
+- Use en-US locale for all snapshot tests. Locale-dependent rendering is
+  already validated by existing BDD scenarios; snapshot tests should pin a
+  single locale to keep snapshots deterministic.
+- Update `docs/users-guide.md` only if user-facing behaviour changes. Since
+  this plan adds regression tests without changing behaviour, the user guide
+  update will be limited to noting the existence of snapshot-based regression
+  guards in the theme documentation section if appropriate.
+- Mark roadmap item 3.12.2 done in `docs/roadmap.md` only after the full
+  implementation and validation are complete.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires more than 12 files changed or more than
+  600 net new lines, stop and escalate.
+- Dependencies: if a new crate dependency is required beyond the existing
+  `insta`, `rstest`, `rstest-bdd`, and `test_support`, stop and escalate.
+- Interface: if any public API signature in `src/status.rs`,
+  `src/status_timing.rs`, or `src/output_prefs.rs` must change to enable
+  snapshot capture, stop and escalate.
+- Iterations: if `make test` or `make lint` still fail after three focused
+  fix-and-rerun cycles, stop and document the blocking failures.
+- Ambiguity: if the normalized rendered output is non-deterministic across
+  runs (e.g., due to timing jitter or thread ordering), stop and investigate
+  before committing snapshots.
+
+## Risks
+
+- Risk: Fluent bidi isolate markers may leak into snapshots, causing them to
+  appear correct visually but differ at the byte level across environments.
+  Severity: medium Likelihood: high Mitigation: normalize all rendered strings
+  through `test_support::fluent::normalize_fluent_isolates` before passing them
+  to `insta::assert_snapshot!`. This is the established pattern in
+  `src/status_tests.rs` and `src/status_timing_tests.rs`.
+
+- Risk: `IndicatifReporter` writes to a real `MultiProgress` backed by stderr,
+  making its output difficult to capture deterministically for snapshots.
+  Severity: medium Likelihood: high Mitigation: do not attempt to snapshot
+  `IndicatifReporter` directly. Instead, snapshot the shared formatting helpers
+  (`stage_summary`, `task_progress_update`, `format_completion_line`) and the
+  `AccessibleReporter` (which accepts a `Vec<u8>` writer). The
+  `IndicatifReporter` integration is already covered by the existing BDD
+  scenarios that capture stderr from the real binary.
+
+- Risk: `rstest-bdd` feature file edits may not trigger recompilation.
+  Severity: low Likelihood: medium Mitigation: `touch tests/bdd_tests.rs`
+  before the final `make test` run.
+
+- Risk: snapshot files may cause merge conflicts when multiple developers work
+  on reporter formatting concurrently. Severity: low Likelihood: low
+  Mitigation: keep snapshot files small and named descriptively. Store them
+  under `src/snapshots/status/` to co-locate with the source modules they pin.
+
+- Risk: new test files or helpers in shared CLI modules may trigger
+  dead-code warnings from `build.rs` compilation. Severity: medium Likelihood:
+  low Mitigation: snapshot tests will live in existing test modules
+  (`src/status_tests.rs`, `src/status_timing_tests.rs`) or in dedicated sibling
+  files included via `#[path = ...]`. No new shared CLI helpers are expected.
+
+## Progress
+
+- [ ] Researched existing test infrastructure, reporter API surfaces, and
+      insta usage patterns.
+- [ ] Drafted this ExecPlan.
+- [ ] Stage A: Add insta snapshot tests for AccessibleReporter output.
+- [ ] Stage B: Add insta snapshot tests for timing summary rendering.
+- [ ] Stage C: Add insta snapshot tests for prefix and spacing accessors.
+- [ ] Stage D: Add BDD scenarios for full-output snapshot verification.
+- [ ] Stage E: Documentation, roadmap update, and final validation.
+
+## Surprises & discoveries
+
+(None yet.)
+
+## Decision log
+
+- Decision: snapshot the `AccessibleReporter` output rather than the
+  `IndicatifReporter` output for alignment regression testing. Rationale:
+  `AccessibleReporter` is generic over `Write + Send` and already supports a
+  `Vec<u8>` writer for test-time output capture (introduced in PR #272).
+  `IndicatifReporter` writes to a real `MultiProgress` with terminal drawing,
+  making deterministic capture impractical. The formatting helpers shared
+  between both reporters (`stage_label`, `stage_summary`,
+  `task_progress_update`, `format_completion_line`) can be snapshotted
+  directly. End-to-end `IndicatifReporter` behaviour is already covered by BDD
+  scenarios that capture stderr from the compiled binary. Date/Author:
+  2026-03-23 / Codex.
+
+- Decision: store snapshot files under `src/snapshots/status/` for status
+  reporter snapshots and `src/snapshots/output_prefs/` for prefix snapshots,
+  following the existing pattern used by `src/snapshots/diagnostic_json/`.
+  Rationale: co-locating snapshots with their source modules keeps the
+  relationship obvious and follows the established convention in
+  `src/diagnostic_json_tests.rs`. Date/Author: 2026-03-23 / Codex.
+
+- Decision: normalize Fluent bidi isolate markers before snapshotting rather
+  than using insta redactions. Rationale: the markers are invisible formatting
+  artefacts, not meaningful content. Stripping them produces snapshots that
+  match what a human sees in the terminal. The `normalize_fluent_isolates`
+  helper is already used throughout the test suite. Date/Author: 2026-03-23 /
+  Codex.
+
+- Decision: use `rstest` parameterized cases to generate snapshot tests for
+  both Unicode and ASCII themes from a single test function, with distinct
+  snapshot names per theme. Rationale: this avoids duplicating test logic while
+  producing separate, reviewable snapshot files for each theme. The pattern is
+  established in `src/output_prefs_tests.rs`. Date/Author: 2026-03-23 / Codex.
+
+## Outcomes & retrospective
+
+(To be completed.)
+
+## Context and orientation
+
+The following modules and files are relevant to this plan. A reader
+implementing the plan needs to understand each one.
+
+**Source modules (production code — read-only for this plan):**
+
+- `src/status.rs` (400 lines): defines `StatusReporter` trait,
+  `AccessibleReporter<W>`, `SilentReporter`, `IndicatifReporter`, and shared
+  formatting helpers `stage_label()`, `stage_summary()`,
+  `task_progress_update()`, `format_completion_line()`. The
+  `AccessibleReporter` accepts a generic `Write + Send` sink and can be
+  constructed with `with_writer(prefs, Vec::new())` for test-time output
+  capture.
+- `src/status_timing.rs` (211 lines): defines `VerboseTimingReporter`, the
+  internal `TimingState`, `CompletedStage`, and the public
+  `render_summary_lines(prefs, entries)` function that produces the multi-line
+  timing summary. The `VerboseTimingReporter::with_clock()` constructor accepts
+  a `Box<dyn Fn() -> Duration>` for deterministic time control.
+- `src/output_prefs.rs` (284 lines): defines `OutputPrefs` with
+  `error_prefix()`, `warning_prefix()`, `success_prefix()`, `info_prefix()`,
+  `timing_prefix()`, `task_indent()`, and `timing_indent()`. The
+  `resolve_from_theme_with()` function accepts a custom environment lookup for
+  test isolation.
+- `src/theme.rs` (295 lines): defines `ThemePreference` (Auto, Unicode,
+  Ascii), `DesignTokens`, `SymbolTokens`, `SpacingTokens`, `ColourTokens`,
+  `ResolvedTheme`, and `resolve_theme()`. The constant token sets
+  `UNICODE_SYMBOLS`, `ASCII_SYMBOLS`, and `SPACING` define the glyph and
+  spacing values.
+
+**Existing test modules (will be extended):**
+
+- `src/status_tests.rs` (~245 lines): unit tests for status formatting
+  helpers and `AccessibleReporter` output capture. Uses
+  `test_support::fluent::normalize_fluent_isolates` and an `en_us_localizer`
+  rstest fixture.
+- `src/status_timing_tests.rs` (~268 lines): unit tests for `TimingState`,
+  `render_summary_lines()`, and `VerboseTimingReporter` with `FakeClock`.
+- `src/output_prefs_tests.rs` (~193 lines): parameterized tests for
+  `resolve_with()`, `resolve_from_theme_with()`, prefix rendering, and spacing
+  accessors.
+
+**BDD test infrastructure:**
+
+- `tests/features/progress_output.feature` (170 lines): 17 scenarios
+  covering standard/accessible mode, theme prefixes, localization, verbose
+  timing, stream separation. Step definitions in
+  `tests/bdd/steps/progress_output.rs`.
+- `tests/bdd/fixtures/mod.rs`: `TestWorld` struct with `temp_dir`,
+  `ninja_env_guard`, `output_prefs`, `rendered_prefix`, and simulated
+  environment slots.
+- `tests/bdd/helpers/assertions.rs`: shared assertion helpers including
+  Fluent normalization.
+- `tests/bdd_tests.rs`: BDD test harness entry point (must be `touch`ed
+  when `.feature` files change).
+
+**Existing snapshot infrastructure:**
+
+- `Cargo.toml` dev-dependencies: `insta = { version = "1", features =
+  ["yaml"] }`.
+- `src/diagnostic_json_tests.rs`: existing `insta` snapshot usage pattern.
+  Uses `Settings::new()` with
+  `set_snapshot_path(concat!(env!( "CARGO_MANIFEST_DIR"), "/src/snapshots/diagnostic_json"))`.
+- `src/snapshots/diagnostic_json/`: contains one `.snap` file for the
+  manifest parse error diagnostic.
+- `tests/snapshots/ninja/`: contains two `.snap` files for Ninja generation.
+- `docs/snapshot-testing-in-netsuke-using-insta.md`: project guide for
+  snapshot testing with `insta`.
+
+**Test support crate:**
+
+- `test_support/src/fluent.rs`: `normalize_fluent_isolates(text: &str) ->
+  String` — strips `U+2068` and `U+2069` bidi isolate markers.
+- `test_support/src/localizer.rs`: `localizer_test_lock()` — returns a mutex
+  guard for exclusive localizer access during tests.
+
+**Key terms:**
+
+- Snapshot test: a test that captures the complete output of a function or
+  reporter as a string, saves it to a `.snap` file on disk, and fails if the
+  output changes in a subsequent run. The `.snap` file is committed to version
+  control.
+- Design token: a semantic value (symbol glyph, spacing string, colour
+  identifier) resolved from the active theme.
+- Fluent bidi isolate markers: invisible Unicode characters (`U+2068` first
+  strong isolate, `U+2069` pop directional isolate) that Fluent inserts around
+  interpolated values. These must be stripped before comparison.
+
+## Interfaces and dependencies
+
+No new public interfaces are introduced. The snapshot tests consume existing
+internal APIs:
+
+1. `AccessibleReporter::with_writer(prefs: OutputPrefs, writer: Vec<u8>)` —
+   captures output for snapshot comparison.
+2. `render_summary_lines(prefs: OutputPrefs, entries: &[CompletedStage])` —
+   produces timing summary lines for snapshot comparison.
+3. `OutputPrefs::error_prefix()`, `warning_prefix()`, `success_prefix()`,
+   `info_prefix()`, `timing_prefix()`, `task_indent()`, `timing_indent()` —
+   produce individual prefix and spacing strings.
+4. `resolve_from_theme_with(theme, no_emoji, mode, read_env)` — resolves
+   `OutputPrefs` with test-time environment injection.
+5. `insta::assert_snapshot!(name, content)` — pins content to a `.snap` file.
+6. `insta::Settings::new().set_snapshot_path(path)` — directs snapshot
+   storage to a specific directory.
+
+Snapshot storage layout after completion:
+
+```plaintext
+src/
+  snapshots/
+    status/
+      netsuke__status__tests__accessible_unicode_stage_and_completion.snap
+      netsuke__status__tests__accessible_ascii_stage_and_completion.snap
+      netsuke__status__tests__accessible_unicode_task_progress.snap
+      netsuke__status__tests__accessible_ascii_task_progress.snap
+    status_timing/
+      netsuke__status__timing__tests__timing_summary_unicode.snap
+      netsuke__status__timing__tests__timing_summary_ascii.snap
+    output_prefs/
+      netsuke__output_prefs__tests__all_prefixes_unicode.snap
+      netsuke__output_prefs__tests__all_prefixes_ascii.snap
+```
+
+The exact snapshot names will follow `insta`'s automatic naming convention
+(`<crate>__<module_path>__<test_name>`) but can be overridden with explicit
+first arguments to `assert_snapshot!` for clarity.
+
+## Plan of work
+
+### Stage A: Snapshot tests for AccessibleReporter output
+
+Add snapshot tests to `src/status_tests.rs` that capture the full rendered
+output of `AccessibleReporter` for both Unicode and ASCII themes. The tests
+will drive the reporter through a realistic sequence of stage announcements,
+task progress updates, and a completion message, then snapshot the accumulated
+`Vec<u8>` output.
+
+Create an `insta::Settings` helper that directs snapshots to
+`src/snapshots/status/`. Add two new test functions:
+
+1. A parameterized `rstest` test that exercises stage announcement and
+   completion. For each theme (Unicode, Ascii), it:
+   - Creates `OutputPrefs` via `resolve_from_theme_with(Some(theme), None,
+     OutputMode::Standard, |_| None)`.
+   - Constructs `AccessibleReporter::with_writer(prefs, Vec::new())`.
+   - Calls `report_stage()` for stages 1 through 6 with representative
+     descriptions.
+   - Calls `report_complete()` with `STATUS_TOOL_MANIFEST`.
+   - Extracts the writer contents, normalizes Fluent isolates, and passes the
+     result to `assert_snapshot!` with a theme-specific name.
+
+2. A parameterized `rstest` test that exercises task progress rendering. For
+   each theme, it:
+   - Creates the reporter as above.
+   - Calls `report_task_progress(1, 2, "cc -c src/a.c")` and
+     `report_task_progress(2, 2, "cc -c src/b.c")`.
+   - Snapshots the accumulated output.
+
+These tests will confirm that indentation, prefix symbols, and line structure
+are identical between themes except for the glyph set.
+
+If `src/status_tests.rs` approaches the 400-line limit after adding these
+tests, extract the snapshot tests into a dedicated
+`src/status_snapshot_tests.rs` file and include it via
+`#[path = "status_snapshot_tests.rs"] #[cfg(test)] mod snapshot_tests;` at the
+bottom of `src/status.rs`.
+
+Validation gate for Stage A:
+
+- `make check-fmt` passes.
+- `make lint` passes.
+- `cargo test status::tests` passes, including the new snapshot tests.
+- Snapshot files exist under `src/snapshots/status/` and are committed.
+- The Unicode and ASCII snapshots differ only in glyph characters, not in
+  spacing, indentation, or line count.
+
+### Stage B: Snapshot tests for timing summary rendering
+
+Add snapshot tests to `src/status_timing_tests.rs` that capture the complete
+output of `render_summary_lines()` for both themes. The tests will construct a
+`TimingState` with deterministic durations (using the existing `FakeClock`
+pattern or direct `Duration` values), call `render_summary_lines()`, join the
+result, normalize Fluent isolates, and snapshot.
+
+Create an `insta::Settings` helper that directs snapshots to
+`src/snapshots/status_timing/`.
+
+Add a parameterized test that, for each theme:
+
+- Creates `OutputPrefs` for Unicode or ASCII.
+- Builds a `TimingState` with three stages (reading manifest, parsing YAML,
+  expanding templates) and deterministic durations (12ms, 4ms, 7ms).
+- Calls `render_summary_lines(prefs, state.completed_stages())`.
+- Joins the lines with newlines, normalizes, and snapshots.
+
+This captures the timing header (with timing prefix), indented stage lines
+(with timing indent), and the total line, all in one snapshot.
+
+If `src/status_timing_tests.rs` approaches 400 lines, extract snapshot tests
+into `src/status_timing_snapshot_tests.rs`.
+
+Validation gate for Stage B:
+
+- `make check-fmt` passes.
+- `make lint` passes.
+- `cargo test status::timing::tests` passes, including the new snapshot tests.
+- Unicode and ASCII timing snapshots differ only in the timing prefix symbol.
+
+### Stage C: Snapshot tests for prefix and spacing accessors
+
+Add snapshot tests to `src/output_prefs_tests.rs` that capture all five
+semantic prefixes and both spacing accessors as a single multi-line snapshot
+per theme. This provides a compact regression guard for the entire token
+surface.
+
+Create an `insta::Settings` helper that directs snapshots to
+`src/snapshots/output_prefs/`.
+
+Add a parameterized test that, for each theme:
+
+- Creates `OutputPrefs` for Unicode or ASCII via `resolve_from_theme_with`.
+- Builds a multi-line string containing:
+
+  ```plaintext
+  error_prefix:   <value>
+  warning_prefix: <value>
+  success_prefix: <value>
+  info_prefix:    <value>
+  timing_prefix:  <value>
+  task_indent:    "<value>"
+  timing_indent:  "<value>"
+  ```
+
+- Snapshots the result.
+
+This captures prefix alignment and ensures that token changes surface as a
+single, readable diff.
+
+Validation gate for Stage C:
+
+- `make check-fmt` passes.
+- `make lint` passes.
+- `cargo test output_prefs::tests` passes, including the new snapshot tests.
+- Each snapshot file is human-readable and shows the complete token surface.
+
+### Stage D: BDD scenarios for full-output snapshot verification
+
+Add new BDD scenarios to `tests/features/progress_output.feature` that verify
+the full stderr output of a successful `manifest -` invocation for each theme.
+These scenarios go beyond the existing substring-contains assertions and check
+that the rendered output structure matches expectations.
+
+Add two new scenarios:
+
+1. "ASCII theme progress output is stable":
+   - Given a minimal Netsuke workspace
+   - When netsuke is run with arguments
+     `"--theme ascii --accessible true --progress true manifest -"`
+   - Then the command should succeed
+   - And stderr should contain "+ Success:"
+   - And stderr should contain "i Info:"
+   - And stderr should contain "Stage 1/6"
+   - And stderr should contain "Stage 6/6"
+   - And stderr lines containing "Info:" should all start with "i Info:"
+   - And stderr lines containing "Success:" should all start with "+ Success:"
+
+2. "Unicode theme progress output is stable":
+   - Given a minimal Netsuke workspace
+   - When netsuke is run with arguments
+     `"--theme unicode --accessible true --progress true manifest -"`
+   - Then the command should succeed
+   - And stderr should contain "✔ Success:"
+   - And stderr should contain "ℹ Info:"
+   - And stderr should contain "Stage 1/6"
+   - And stderr should contain "Stage 6/6"
+   - And stderr lines containing "Info:" should all start with "ℹ Info:"
+   - And stderr lines containing "Success:" should all start with "✔ Success:"
+
+These scenarios require new step definitions for prefix alignment assertions.
+Add a new step definition in `tests/bdd/steps/progress_output.rs`:
+
+<!-- markdownlint-disable MD013 -->
+
+- `#[then("stderr lines containing {pattern} should all start with {prefix}")]`
+
+<!-- markdownlint-enable MD013 -->
+
+This step iterates over stderr lines, finds lines containing the pattern, and
+asserts each starts with the expected prefix. This guards against alignment
+drift where a prefix symbol changes width but the surrounding whitespace does
+not adjust.
+
+If the step definition file approaches 400 lines, extract the assertion step
+into `tests/bdd/helpers/assertions.rs`.
+
+Validation gate for Stage D:
+
+- `touch tests/bdd_tests.rs && make test` passes.
+- The new BDD scenarios pass in isolation
+  (`cargo test --test bdd_tests progress_output`).
+- Existing BDD scenarios remain green.
+
+### Stage E: Documentation, roadmap update, and final validation
+
+Update documentation and mark the roadmap item complete.
+
+Required documentation changes:
+
+- `docs/users-guide.md`: add a sentence to the existing "Theme and
+  accessibility preferences" section noting that output alignment is
+  regression-tested via snapshots for both themes.
+- `docs/netsuke-design.md`: add a brief note to the testing strategy section
+  (if one exists) or the CLI output section recording that progress and status
+  output is snapshot-tested for alignment stability.
+- `docs/roadmap.md`: mark 3.12.2 sub-items done and the parent item done.
+
+Record any design decisions taken during implementation in this ExecPlan's
+Decision Log section.
+
+Final validation must include the project gates requested in the task, plus
+documentation quality assurance:
+
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `make fmt`
+- `PATH="/root/.bun/bin:$PATH" make markdownlint`
+- `make nixie`
+
+## Concrete steps
+
+All commands below run from the repository root:
+
+```sh
+cd /home/user/project
+```
+
+1. Verify the current baseline passes all gates before making changes.
+
+   ```sh
+   set -o pipefail && make check-fmt 2>&1 | tee /tmp/netsuke-3-12-2-baseline-fmt.log
+   set -o pipefail && make lint 2>&1 | tee /tmp/netsuke-3-12-2-baseline-lint.log
+   set -o pipefail && make test 2>&1 | tee /tmp/netsuke-3-12-2-baseline-test.log
+   ```
+
+   Expected: all three exit 0.
+
+2. Implement Stage A: add snapshot tests for AccessibleReporter.
+
+   Edit `src/status_tests.rs` (or create `src/status_snapshot_tests.rs` if
+   needed). Add the `insta` import and snapshot settings helper. Add
+   parameterized tests for Unicode and ASCII themes.
+
+   ```sh
+   cargo test --lib status::tests -- --nocapture 2>&1 | tee /tmp/netsuke-3-12-2-stage-a.log
+   ```
+
+   Expected: new snapshot tests create `.snap` files and pass.
+
+3. Implement Stage B: add snapshot tests for timing summary rendering.
+
+   Edit `src/status_timing_tests.rs` (or create a sibling file). Add
+   parameterized timing summary snapshot tests.
+
+   ```sh
+   cargo test --lib status::timing::tests -- --nocapture 2>&1 | tee /tmp/netsuke-3-12-2-stage-b.log
+   ```
+
+4. Implement Stage C: add snapshot tests for prefix and spacing accessors.
+
+   Edit `src/output_prefs_tests.rs`. Add parameterized prefix/spacing snapshot
+   tests.
+
+   ```sh
+   cargo test --lib output_prefs::tests -- --nocapture 2>&1 | tee /tmp/netsuke-3-12-2-stage-c.log
+   ```
+
+5. Implement Stage D: add BDD scenarios and step definitions.
+
+   Edit `tests/features/progress_output.feature` and
+   `tests/bdd/steps/progress_output.rs`. Add alignment assertion steps.
+
+   ```sh
+   touch tests/bdd_tests.rs
+   cargo test --test bdd_tests progress_output -- --nocapture 2>&1 | tee /tmp/netsuke-3-12-2-stage-d.log
+   ```
+
+6. Implement Stage E: update documentation and roadmap.
+
+   Edit `docs/users-guide.md`, `docs/netsuke-design.md`, and `docs/roadmap.md`.
+
+7. Run the full validation gates with logged output.
+
+   <!-- markdownlint-disable MD029 -->
+
+   1. `set -o pipefail && make check-fmt 2>&1 | tee /tmp/netsuke-3-12-2-check-fmt.log`
+   2. `set -o pipefail && make lint 2>&1 | tee /tmp/netsuke-3-12-2-lint.log`
+   3. `set -o pipefail && make test 2>&1 | tee /tmp/netsuke-3-12-2-test.log`
+   4. `set -o pipefail && make fmt 2>&1 | tee /tmp/netsuke-3-12-2-fmt.log`
+   5. `PATH="/root/.bun/bin:$PATH" make markdownlint 2>&1 | tee /tmp/ml.log`
+   6. `make nixie 2>&1 | tee /tmp/netsuke-3-12-2-nixie.log`
+
+   <!-- markdownlint-enable MD029 -->
+
+   Expected final signal:
+
+   ```plaintext
+   make check-fmt    # exits 0
+   make lint         # exits 0
+   make test         # exits 0
+   make markdownlint # exits 0
+   make nixie        # exits 0
+   ```
+
+8. Inspect scope before finalizing.
+
+   ```sh
+   git status --short
+   git diff --stat
+   ```
+
+   Only the intended test, snapshot, and documentation files for 3.12.2 should
+   remain modified.
+
+## Validation and acceptance
+
+Acceptance is behavioural, not structural.
+
+The milestone is done when all of the following are true:
+
+- Running `cargo test --lib status::tests` passes and includes snapshot tests
+  that pin `AccessibleReporter` output for both Unicode and ASCII themes.
+- Running `cargo test --lib status::timing::tests` passes and includes
+  snapshot tests that pin verbose timing summary output for both themes.
+- Running `cargo test --lib output_prefs::tests` passes and includes snapshot
+  tests that pin all five semantic prefixes and both spacing tokens for both
+  themes.
+- Running `cargo test --test bdd_tests progress_output` passes and includes
+  BDD scenarios that verify prefix alignment consistency for both themes.
+- The Unicode and ASCII snapshots for each reporter differ only in glyph
+  characters, not in spacing, indentation, or line count.
+- `make check-fmt`, `make lint`, and `make test` all pass.
+
+Quality criteria:
+
+- Tests: new `insta` snapshot tests and `rstest-bdd` BDD scenarios cover
+  Unicode and ASCII themes, happy paths (stage/task/completion rendering), and
+  alignment regression (prefix consistency across output lines).
+- Lint/typecheck: `make check-fmt` and `make lint` pass without new warnings.
+- Documentation: `docs/users-guide.md` notes snapshot regression coverage
+  for theme output. `docs/roadmap.md` marks 3.12.2 complete.
+
+Quality method:
+
+- `make check-fmt` verifies formatting.
+- `make lint` verifies Clippy compliance.
+- `make test` runs the full workspace test suite including new snapshots and
+  BDD scenarios.
+- `PATH="/root/.bun/bin:$PATH" make markdownlint` verifies documentation
+  formatting.
+- `make nixie` validates Mermaid diagrams.
+
+## Idempotence and recovery
+
+The planned edits are safe to repeat.
+
+- Snapshot tests are deterministic: given the same locale, theme, and duration
+  inputs, they produce byte-identical output.
+- If `insta` creates `.snap.new` files instead of updating `.snap` files, run
+  `cargo insta accept --all` to promote them (or delete `.snap.new` and re-run
+  to regenerate).
+- If BDD feature edits are not picked up, `touch tests/bdd_tests.rs` before
+  `make test`.
+- If a snapshot test fails unexpectedly, compare the `.snap` diff to
+  determine whether the change is intentional (update the snapshot) or a
+  regression (fix the code).
+- If `make fmt` rewrites unrelated Markdown files, inspect `git diff` and
+  restore only formatter-introduced changes outside the 3.12.2 scope.
+
+## Artifacts and notes
+
+Useful evidence to keep while implementing:
+
+- The first snapshot run output showing the created `.snap` files.
+- A side-by-side comparison of the Unicode and ASCII snapshots for
+  `AccessibleReporter` stage output, confirming identical structure.
+- The passing BDD scenario output for the new alignment assertions.
+- The final `git diff --stat` confirming the change stayed within scope.

--- a/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
+++ b/docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md
@@ -57,9 +57,11 @@ than hunting through substring assertions.
   `test_support::fluent::normalize_fluent_isolates` helper. This ensures
   snapshots contain only human-visible characters and remain stable across
   Fluent versions.
-- All snapshot names must be descriptive and stable. Use the pattern
-  `<reporter>_<theme>_<scenario>` (e.g.,
-  `accessible_unicode_stage_announcement`).
+- All snapshot names must be descriptive and stable. Use `insta`'s canonical
+  `<crate>__<module_path>__<test_name>` naming convention (e.g.,
+  `netsuke__status__tests__accessible_unicode_stage_and_completion`). When a
+  test needs per-theme variants, pass a theme-specific `snapshot_name` string
+  to `assert_snapshot!` so the final file still follows that convention.
 - Use en-US locale for all snapshot tests. Locale-dependent rendering is
   already validated by existing BDD scenarios; snapshot tests should pin a
   single locale to keep snapshots deterministic.
@@ -324,9 +326,10 @@ src/
       netsuke__output_prefs__tests__all_prefixes_ascii.snap
 ```
 
-The exact snapshot names will follow `insta`'s automatic naming convention
-(`<crate>__<module_path>__<test_name>`) but can be overridden with explicit
-first arguments to `assert_snapshot!` for clarity.
+The exact snapshot names will follow `insta`'s canonical naming convention
+(`<crate>__<module_path>__<test_name>`). Parameterized tests may pass explicit
+first arguments to `assert_snapshot!`, but those names should still expand to
+this same convention for consistency with the rest of the snapshot tree.
 
 ## Plan of work
 
@@ -532,11 +535,7 @@ documentation quality assurance:
 
 ## Concrete steps
 
-All commands below run from the repository root:
-
-```sh
-cd /home/user/project
-```
+All commands below run from the repository root.
 
 1. Verify the current baseline passes all gates before making changes.
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2090,7 +2090,10 @@ tokens to reporters through the `OutputPrefs` compatibility façade. This keeps
 reporter code focused on status semantics rather than glyph choice, preserves
 `no_emoji` as a legacy ASCII-forcing alias when no explicit theme is supplied,
 and gives later roadmap items a stable snapshot surface for validating ASCII
-and Unicode renderings without duplicating formatting rules.
+and Unicode renderings without duplicating formatting rules. Accessible
+reporter output, timing summaries, and the semantic prefix surface are guarded
+by `insta` snapshots so spacing, prefix alignment, and wrapping regressions
+fail with reviewable diffs instead of drifting silently.
 
 For screen readers: The following flowchart shows how the build script audits
 localization keys against English and Spanish Fluent bundles.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -305,9 +305,9 @@ library, and CLI ergonomics.
   - [x] Route reporter prefixes and spacing through resolved theme tokens.
   - [x] Add end-to-end theme coverage and documentation for ASCII/Unicode
         consistency.
-- [ ] 3.12.2. Snapshot progress and status output for themes.
-  - [ ] Cover unicode and ascii themes.
-  - [ ] Guard alignment and wrapping against regressions.
+- [x] 3.12.2. Snapshot progress and status output for themes.
+  - [x] Cover unicode and ascii themes.
+  - [x] Guard alignment and wrapping against regressions.
 - [ ] 3.12.3. Test output renderings across common terminals.
   - [ ] Test Windows Console, PowerShell, and xterm-compatible shells.
   - [ ] Document any conditional handling.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -804,6 +804,10 @@ conveyed solely by colour. The active theme swaps only the glyph set:
 - ASCII theme: `X Error:`, `! Warning:`, `+ Success:`, `i Info:`,
   `T Timing:`
 
+These theme-specific stage, task, completion, and timing renderings are also
+guarded by snapshot regression tests so alignment and prefix stability stay
+pinned for both Unicode and ASCII output.
+
 ### Exit Codes
 
 - `0`: Success.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod ninja_gen;
 pub mod output_mode;
 pub mod output_prefs;
 pub mod runner;
+#[cfg(test)]
+mod snapshot_test_support;
 pub mod status;
 pub mod stdlib;
 pub mod theme;

--- a/src/output_prefs_tests.rs
+++ b/src/output_prefs_tests.rs
@@ -3,8 +3,9 @@
 use super::*;
 use crate::cli_localization;
 use crate::localization::{self, LocalizerGuard};
+use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
 use anyhow::{Result, ensure};
-use insta::{Settings, assert_snapshot};
+use insta::assert_snapshot;
 use rstest::{fixture, rstest};
 use std::error::Error;
 use std::fmt;
@@ -33,15 +34,6 @@ fn fake_env<'a>(
         "NETSUKE_NO_EMOJI" => no_emoji_env.map(String::from),
         _ => None,
     }
-}
-
-fn snapshot_settings() -> Settings {
-    let mut settings = Settings::new();
-    settings.set_snapshot_path(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/snapshots/output_prefs"
-    ));
-    settings
 }
 
 #[rstest]
@@ -211,7 +203,7 @@ fn prefix_and_spacing_snapshot(
     #[case] snapshot_name: &str,
 ) -> Result<()> {
     let _localizer = en_us_localizer?;
-    let prefs = resolve_from_theme_with(Some(theme), None, OutputMode::Standard, |_| None);
+    let prefs = theme_prefs(theme);
     let rendered = normalize_fluent_isolates(&format!(
         concat!(
             "error_prefix:   {}\n",
@@ -231,7 +223,7 @@ fn prefix_and_spacing_snapshot(
         prefs.timing_indent(),
     ));
 
-    snapshot_settings().bind(|| {
+    snapshot_settings("output_prefs").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
     Ok(())

--- a/src/output_prefs_tests.rs
+++ b/src/output_prefs_tests.rs
@@ -4,10 +4,12 @@ use super::*;
 use crate::cli_localization;
 use crate::localization::{self, LocalizerGuard};
 use anyhow::{Result, ensure};
+use insta::{Settings, assert_snapshot};
 use rstest::{fixture, rstest};
 use std::error::Error;
 use std::fmt;
 use std::sync::{Arc, MutexGuard};
+use test_support::fluent::normalize_fluent_isolates;
 use test_support::localizer::localizer_test_lock;
 
 #[derive(Debug)]
@@ -31,6 +33,15 @@ fn fake_env<'a>(
         "NETSUKE_NO_EMOJI" => no_emoji_env.map(String::from),
         _ => None,
     }
+}
+
+fn snapshot_settings() -> Settings {
+    let mut settings = Settings::new();
+    settings.set_snapshot_path(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/snapshots/output_prefs"
+    ));
+    settings
 }
 
 #[rstest]
@@ -189,4 +200,39 @@ impl From<std::sync::PoisonError<MutexGuard<'static, ()>>> for EnUsLocalizerFixt
     fn from(err: std::sync::PoisonError<MutexGuard<'static, ()>>) -> Self {
         Self(err.to_string())
     }
+}
+
+#[rstest]
+#[case::unicode(crate::theme::ThemePreference::Unicode, "all_prefixes_unicode")]
+#[case::ascii(crate::theme::ThemePreference::Ascii, "all_prefixes_ascii")]
+fn prefix_and_spacing_snapshot(
+    en_us_localizer: Result<EnUsLocalizerFixture, EnUsLocalizerFixtureError>,
+    #[case] theme: crate::theme::ThemePreference,
+    #[case] snapshot_name: &str,
+) -> Result<()> {
+    let _localizer = en_us_localizer?;
+    let prefs = resolve_from_theme_with(Some(theme), None, OutputMode::Standard, |_| None);
+    let rendered = normalize_fluent_isolates(&format!(
+        concat!(
+            "error_prefix:   {}\n",
+            "warning_prefix: {}\n",
+            "success_prefix: {}\n",
+            "info_prefix:    {}\n",
+            "timing_prefix:  {}\n",
+            "task_indent:    {:?}\n",
+            "timing_indent:  {:?}"
+        ),
+        prefs.error_prefix(),
+        prefs.warning_prefix(),
+        prefs.success_prefix(),
+        prefs.info_prefix(),
+        prefs.timing_prefix(),
+        prefs.task_indent(),
+        prefs.timing_indent(),
+    ));
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!(snapshot_name, rendered);
+    });
+    Ok(())
 }

--- a/src/snapshot_test_support.rs
+++ b/src/snapshot_test_support.rs
@@ -1,0 +1,28 @@
+//! Shared helpers for snapshot-oriented unit tests.
+//!
+//! These helpers keep theme-based `OutputPrefs` resolution and snapshot-path
+//! setup consistent across multiple test modules.
+
+use insta::Settings;
+use std::path::PathBuf;
+
+use crate::output_mode::OutputMode;
+use crate::output_prefs::{OutputPrefs, resolve_from_theme_with};
+use crate::theme::ThemePreference;
+
+/// Build snapshot settings rooted at `src/snapshots/<subdir>`.
+pub(crate) fn snapshot_settings(subdir: &str) -> Settings {
+    let mut settings = Settings::new();
+    settings.set_snapshot_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("snapshots")
+            .join(subdir),
+    );
+    settings
+}
+
+/// Resolve explicit-theme preferences for deterministic snapshot tests.
+pub(crate) fn theme_prefs(theme: ThemePreference) -> OutputPrefs {
+    resolve_from_theme_with(Some(theme), None, OutputMode::Standard, |_| None)
+}

--- a/src/snapshots/output_prefs/netsuke__output_prefs__tests__all_prefixes_ascii.snap
+++ b/src/snapshots/output_prefs/netsuke__output_prefs__tests__all_prefixes_ascii.snap
@@ -1,0 +1,11 @@
+---
+source: src/output_prefs_tests.rs
+expression: rendered
+---
+error_prefix:   X Error:
+warning_prefix: ! Warning:
+success_prefix: + Success:
+info_prefix:    i Info:
+timing_prefix:  T Timing:
+task_indent:    "  "
+timing_indent:  "  "

--- a/src/snapshots/output_prefs/netsuke__output_prefs__tests__all_prefixes_unicode.snap
+++ b/src/snapshots/output_prefs/netsuke__output_prefs__tests__all_prefixes_unicode.snap
@@ -1,0 +1,11 @@
+---
+source: src/output_prefs_tests.rs
+expression: rendered
+---
+error_prefix:   ✖ Error:
+warning_prefix: ⚠ Warning:
+success_prefix: ✔ Success:
+info_prefix:    ℹ Info:
+timing_prefix:  ⏱ Timing:
+task_indent:    "  "
+timing_indent:  "  "

--- a/src/snapshots/status/netsuke__status__tests__accessible_ascii_stage_and_completion.snap
+++ b/src/snapshots/status/netsuke__status__tests__accessible_ascii_stage_and_completion.snap
@@ -1,0 +1,11 @@
+---
+source: src/status_tests.rs
+expression: rendered
+---
+i Info: Stage 1/6: Reading manifest file
+i Info: Stage 2/6: Parsing YAML document
+i Info: Stage 3/6: Expanding template directives
+i Info: Stage 4/6: Deserializing and rendering manifest values
+i Info: Stage 5/6: Building and validating dependency graph
+i Info: Stage 6/6: Synthesizing Ninja build plan
++ Success: Manifest complete.

--- a/src/snapshots/status/netsuke__status__tests__accessible_ascii_task_progress.snap
+++ b/src/snapshots/status/netsuke__status__tests__accessible_ascii_task_progress.snap
@@ -1,0 +1,6 @@
+---
+source: src/status_tests.rs
+expression: rendered
+---
+  Task 1/2: cc -c src/a.c
+  Task 2/2: cc -c src/b.c

--- a/src/snapshots/status/netsuke__status__tests__accessible_unicode_stage_and_completion.snap
+++ b/src/snapshots/status/netsuke__status__tests__accessible_unicode_stage_and_completion.snap
@@ -1,0 +1,11 @@
+---
+source: src/status_tests.rs
+expression: rendered
+---
+ℹ Info: Stage 1/6: Reading manifest file
+ℹ Info: Stage 2/6: Parsing YAML document
+ℹ Info: Stage 3/6: Expanding template directives
+ℹ Info: Stage 4/6: Deserializing and rendering manifest values
+ℹ Info: Stage 5/6: Building and validating dependency graph
+ℹ Info: Stage 6/6: Synthesizing Ninja build plan
+✔ Success: Manifest complete.

--- a/src/snapshots/status/netsuke__status__tests__accessible_unicode_task_progress.snap
+++ b/src/snapshots/status/netsuke__status__tests__accessible_unicode_task_progress.snap
@@ -1,0 +1,6 @@
+---
+source: src/status_tests.rs
+expression: rendered
+---
+  Task 1/2: cc -c src/a.c
+  Task 2/2: cc -c src/b.c

--- a/src/snapshots/status_timing/netsuke__status__timing__tests__timing_summary_ascii.snap
+++ b/src/snapshots/status_timing/netsuke__status__timing__tests__timing_summary_ascii.snap
@@ -1,0 +1,9 @@
+---
+source: src/status_timing_tests.rs
+expression: rendered
+---
+T Timing: Stage timing summary:
+  - Stage 1/6: Reading manifest file: 12ms
+  - Stage 2/6: Parsing YAML document: 4ms
+  - Stage 3/6: Expanding template directives: 7ms
+  Total pipeline time: 23ms

--- a/src/snapshots/status_timing/netsuke__status__timing__tests__timing_summary_unicode.snap
+++ b/src/snapshots/status_timing/netsuke__status__timing__tests__timing_summary_unicode.snap
@@ -1,0 +1,9 @@
+---
+source: src/status_timing_tests.rs
+expression: rendered
+---
+⏱ Timing: Stage timing summary:
+  - Stage 1/6: Reading manifest file: 12ms
+  - Stage 2/6: Parsing YAML document: 4ms
+  - Stage 3/6: Expanding template directives: 7ms
+  Total pipeline time: 23ms

--- a/src/status_tests.rs
+++ b/src/status_tests.rs
@@ -17,8 +17,9 @@ use super::*;
 use crate::cli_localization;
 use crate::localization::{self, LocalizerGuard};
 use crate::output_prefs;
+use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
 use anyhow::{Result, ensure};
-use insta::{Settings, assert_snapshot};
+use insta::assert_snapshot;
 use rstest::{fixture, rstest};
 use std::sync::{Arc, MutexGuard};
 use test_support::fluent::normalize_fluent_isolates;
@@ -26,21 +27,6 @@ use test_support::localizer::localizer_test_lock;
 
 fn test_prefs() -> crate::output_prefs::OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
-}
-
-fn snapshot_settings() -> Settings {
-    let mut settings = Settings::new();
-    settings.set_snapshot_path(concat!(env!("CARGO_MANIFEST_DIR"), "/src/snapshots/status"));
-    settings
-}
-
-fn theme_prefs(theme: crate::theme::ThemePreference) -> crate::output_prefs::OutputPrefs {
-    output_prefs::resolve_from_theme_with(
-        Some(theme),
-        None,
-        crate::output_mode::OutputMode::Standard,
-        |_| None,
-    )
 }
 
 fn stage6_message(reporter: &IndicatifReporter) -> String {
@@ -292,7 +278,7 @@ fn accessible_reporter_stage_and_completion_snapshot(
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let rendered = normalize_fluent_isolates(&String::from_utf8_lossy(&output));
 
-    snapshot_settings().bind(|| {
+    snapshot_settings("status").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
     Ok(())
@@ -320,7 +306,7 @@ fn accessible_reporter_task_progress_snapshot(
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let rendered = normalize_fluent_isolates(&String::from_utf8_lossy(&output));
 
-    snapshot_settings().bind(|| {
+    snapshot_settings("status").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
     Ok(())

--- a/src/status_tests.rs
+++ b/src/status_tests.rs
@@ -18,6 +18,7 @@ use crate::cli_localization;
 use crate::localization::{self, LocalizerGuard};
 use crate::output_prefs;
 use anyhow::{Result, ensure};
+use insta::{Settings, assert_snapshot};
 use rstest::{fixture, rstest};
 use std::sync::{Arc, MutexGuard};
 use test_support::fluent::normalize_fluent_isolates;
@@ -25,6 +26,21 @@ use test_support::localizer::localizer_test_lock;
 
 fn test_prefs() -> crate::output_prefs::OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
+}
+
+fn snapshot_settings() -> Settings {
+    let mut settings = Settings::new();
+    settings.set_snapshot_path(concat!(env!("CARGO_MANIFEST_DIR"), "/src/snapshots/status"));
+    settings
+}
+
+fn theme_prefs(theme: crate::theme::ThemePreference) -> crate::output_prefs::OutputPrefs {
+    output_prefs::resolve_from_theme_with(
+        Some(theme),
+        None,
+        crate::output_mode::OutputMode::Standard,
+        |_| None,
+    )
 }
 
 fn stage6_message(reporter: &IndicatifReporter) -> String {
@@ -240,5 +256,72 @@ fn completion_line_includes_success_prefix(
         line.starts_with(&success_prefix),
         "completion line should start with success prefix; line was: {line:?}, prefix was: {success_prefix:?}"
     );
+    Ok(())
+}
+
+#[rstest]
+#[case::unicode(
+    crate::theme::ThemePreference::Unicode,
+    "accessible_unicode_stage_and_completion"
+)]
+#[case::ascii(
+    crate::theme::ThemePreference::Ascii,
+    "accessible_ascii_stage_and_completion"
+)]
+fn accessible_reporter_stage_and_completion_snapshot(
+    en_us_localizer: Result<EnUsLocalizerFixture>,
+    #[case] theme: crate::theme::ThemePreference,
+    #[case] snapshot_name: &str,
+) -> Result<()> {
+    let _localizer = en_us_localizer?;
+    let prefs = theme_prefs(theme);
+    let reporter = AccessibleReporter::with_writer(prefs, Vec::new());
+
+    for stage in PipelineStage::ALL {
+        reporter.report_stage(
+            stage.index(),
+            PIPELINE_STAGE_TOTAL,
+            &stage.description(None),
+        );
+    }
+    reporter.report_complete(LocalizationKey::new(keys::STATUS_TOOL_MANIFEST));
+
+    let output = reporter
+        .writer
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let rendered = normalize_fluent_isolates(&String::from_utf8_lossy(&output));
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!(snapshot_name, rendered);
+    });
+    Ok(())
+}
+
+#[rstest]
+#[case::unicode(
+    crate::theme::ThemePreference::Unicode,
+    "accessible_unicode_task_progress"
+)]
+#[case::ascii(crate::theme::ThemePreference::Ascii, "accessible_ascii_task_progress")]
+fn accessible_reporter_task_progress_snapshot(
+    en_us_localizer: Result<EnUsLocalizerFixture>,
+    #[case] theme: crate::theme::ThemePreference,
+    #[case] snapshot_name: &str,
+) -> Result<()> {
+    let _localizer = en_us_localizer?;
+    let reporter = AccessibleReporter::with_writer(theme_prefs(theme), Vec::new());
+    reporter.report_task_progress(1, 2, "cc -c src/a.c");
+    reporter.report_task_progress(2, 2, "cc -c src/b.c");
+
+    let output = reporter
+        .writer
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let rendered = normalize_fluent_isolates(&String::from_utf8_lossy(&output));
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!(snapshot_name, rendered);
+    });
     Ok(())
 }

--- a/src/status_timing_tests.rs
+++ b/src/status_timing_tests.rs
@@ -1,18 +1,39 @@
 //! Tests for verbose timing summary support.
 
 use super::*;
+use crate::cli_localization;
+use crate::localization::{self, LocalizerGuard};
 use crate::output_prefs;
 use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
+use anyhow::Result;
 use insta::assert_snapshot;
 use rstest::{fixture, rstest};
 use std::collections::VecDeque;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, MutexGuard};
 use test_support::fluent::normalize_fluent_isolates;
+use test_support::localizer::localizer_test_lock;
 
 #[fixture]
 fn test_prefs() -> OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
+}
+
+struct EnUsLocalizerFixture {
+    _lock: MutexGuard<'static, ()>,
+    _guard: LocalizerGuard,
+}
+
+#[fixture]
+fn en_us_localizer() -> Result<EnUsLocalizerFixture> {
+    let lock = localizer_test_lock()
+        .map_err(|err| anyhow::anyhow!("failed to acquire localizer test lock: {err}"))?;
+    let localizer = Arc::from(cli_localization::build_localizer(Some("en-US")));
+    let guard = localization::set_localizer_for_tests(localizer);
+    Ok(EnUsLocalizerFixture {
+        _lock: lock,
+        _guard: guard,
+    })
 }
 
 #[derive(Debug)]
@@ -272,9 +293,11 @@ fn verbose_timing_reporter_suppresses_progress_updates_after_complete(test_prefs
 #[case::unicode(crate::theme::ThemePreference::Unicode, "timing_summary_unicode")]
 #[case::ascii(crate::theme::ThemePreference::Ascii, "timing_summary_ascii")]
 fn timing_summary_snapshot(
+    en_us_localizer: Result<EnUsLocalizerFixture>,
     #[case] theme: crate::theme::ThemePreference,
     #[case] snapshot_name: &str,
-) {
+) -> Result<()> {
+    let _localizer = en_us_localizer?;
     let total = StageNumber::new_unchecked(6);
     let mut state = TimingState::default();
     state.start_stage(
@@ -310,4 +333,6 @@ fn timing_summary_snapshot(
     snapshot_settings("status_timing").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
+
+    Ok(())
 }

--- a/src/status_timing_tests.rs
+++ b/src/status_timing_tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::output_prefs;
+use insta::{Settings, assert_snapshot};
 use rstest::{fixture, rstest};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -11,6 +12,24 @@ use test_support::fluent::normalize_fluent_isolates;
 #[fixture]
 fn test_prefs() -> OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
+}
+
+fn snapshot_settings() -> Settings {
+    let mut settings = Settings::new();
+    settings.set_snapshot_path(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/snapshots/status_timing"
+    ));
+    settings
+}
+
+fn theme_prefs(theme: crate::theme::ThemePreference) -> OutputPrefs {
+    output_prefs::resolve_from_theme_with(
+        Some(theme),
+        None,
+        crate::output_mode::OutputMode::Standard,
+        |_| None,
+    )
 }
 
 #[derive(Debug)]
@@ -264,4 +283,48 @@ fn verbose_timing_reporter_suppresses_progress_updates_after_complete(test_prefs
         final_counts.completions, 1,
         "completion should still be delegated"
     );
+}
+
+#[rstest]
+#[case::unicode(crate::theme::ThemePreference::Unicode, "timing_summary_unicode")]
+#[case::ascii(crate::theme::ThemePreference::Ascii, "timing_summary_ascii")]
+fn timing_summary_snapshot(
+    #[case] theme: crate::theme::ThemePreference,
+    #[case] snapshot_name: &str,
+) {
+    let total = StageNumber::new_unchecked(6);
+    let mut state = TimingState::default();
+    state.start_stage(
+        Duration::from_millis(0),
+        StageMarker {
+            current: StageNumber::new_unchecked(1),
+            total,
+        },
+        "Reading manifest file",
+    );
+    state.start_stage(
+        Duration::from_millis(12),
+        StageMarker {
+            current: StageNumber::new_unchecked(2),
+            total,
+        },
+        "Parsing YAML document",
+    );
+    state.start_stage(
+        Duration::from_millis(16),
+        StageMarker {
+            current: StageNumber::new_unchecked(3),
+            total,
+        },
+        "Expanding template directives",
+    );
+    state.finish(Duration::from_millis(23));
+
+    let rendered = normalize_fluent_isolates(
+        &render_summary_lines(theme_prefs(theme), state.completed_stages()).join("\n"),
+    );
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!(snapshot_name, rendered);
+    });
 }

--- a/src/status_timing_tests.rs
+++ b/src/status_timing_tests.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 use crate::output_prefs;
-use insta::{Settings, assert_snapshot};
+use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
+use insta::assert_snapshot;
 use rstest::{fixture, rstest};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -12,24 +13,6 @@ use test_support::fluent::normalize_fluent_isolates;
 #[fixture]
 fn test_prefs() -> OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
-}
-
-fn snapshot_settings() -> Settings {
-    let mut settings = Settings::new();
-    settings.set_snapshot_path(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/src/snapshots/status_timing"
-    ));
-    settings
-}
-
-fn theme_prefs(theme: crate::theme::ThemePreference) -> OutputPrefs {
-    output_prefs::resolve_from_theme_with(
-        Some(theme),
-        None,
-        crate::output_mode::OutputMode::Standard,
-        |_| None,
-    )
 }
 
 #[derive(Debug)]
@@ -324,7 +307,7 @@ fn timing_summary_snapshot(
         &render_summary_lines(theme_prefs(theme), state.completed_stages()).join("\n"),
     );
 
-    snapshot_settings().bind(|| {
+    snapshot_settings("status_timing").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
 }

--- a/tests/bdd/steps/progress_output.rs
+++ b/tests/bdd/steps/progress_output.rs
@@ -1,7 +1,8 @@
 //! Step definitions for progress-output scenarios that require fake Ninja output.
 
 use crate::bdd::fixtures::TestWorld;
-use anyhow::{Context, Result};
+use crate::bdd::helpers::assertions::normalize_fluent_isolates;
+use anyhow::{Context, Result, ensure};
 use std::fs;
 use std::path::{Path, PathBuf};
 use test_support::env::{SystemEnv, override_ninja_env};
@@ -129,4 +130,37 @@ fn fake_ninja_emits_stdout_output(world: &TestWorld) -> Result<()> {
             stderr_marker: Some("NINJA_STDERR_MARKER"),
         },
     )
+}
+
+#[rstest_bdd_macros::then("stderr lines containing {pattern} should all start with {prefix}")]
+fn stderr_lines_containing_pattern_should_start_with_prefix(
+    world: &TestWorld,
+    pattern: &str,
+    prefix: &str,
+) -> Result<()> {
+    let stderr = world
+        .command_stderr
+        .get()
+        .context("no stderr captured for progress output assertion")?;
+    let normalized_stderr = normalize_fluent_isolates(&stderr);
+    let normalized_pattern = normalize_fluent_isolates(pattern.trim_matches('"'));
+    let normalized_prefix = normalize_fluent_isolates(prefix.trim_matches('"'));
+    let matching_lines = normalized_stderr
+        .lines()
+        .filter(|line| line.contains(&normalized_pattern))
+        .collect::<Vec<_>>();
+
+    ensure!(
+        !matching_lines.is_empty(),
+        "expected stderr to contain at least one line matching '{pattern}'"
+    );
+
+    for line in matching_lines {
+        ensure!(
+            line.starts_with(&normalized_prefix),
+            "expected line '{line}' to start with '{prefix}'"
+        );
+    }
+
+    Ok(())
 }

--- a/tests/bdd/steps/progress_output.rs
+++ b/tests/bdd/steps/progress_output.rs
@@ -152,13 +152,13 @@ fn stderr_lines_containing_pattern_should_start_with_prefix(
 
     ensure!(
         !matching_lines.is_empty(),
-        "expected stderr to contain at least one line matching '{pattern}'"
+        "no normalized stderr lines contained pattern '{normalized_pattern}'"
     );
 
     for line in matching_lines {
         ensure!(
             line.starts_with(&normalized_prefix),
-            "expected line '{line}' to start with '{prefix}'"
+            "expected normalized stderr line '{line}' to start with '{normalized_prefix}'"
         );
     }
 

--- a/tests/features/progress_output.feature
+++ b/tests/features/progress_output.feature
@@ -62,6 +62,28 @@ Feature: Progress output
     And stderr should contain "T Timing:"
     And stderr should not contain "⏱ Timing:"
 
+  Scenario: ASCII theme progress output is stable
+    Given a minimal Netsuke workspace
+    When netsuke is run with arguments "--theme ascii --accessible true --progress true manifest -"
+    Then the command should succeed
+    And stderr should contain "+ Success:"
+    And stderr should contain "i Info:"
+    And stderr should contain "Stage 1/6"
+    And stderr should contain "Stage 6/6"
+    And stderr lines containing "Info:" should all start with "i Info:"
+    And stderr lines containing "Success:" should all start with "+ Success:"
+
+  Scenario: Unicode theme progress output is stable
+    Given a minimal Netsuke workspace
+    When netsuke is run with arguments "--theme unicode --accessible true --progress true manifest -"
+    Then the command should succeed
+    And stderr should contain "✔ Success:"
+    And stderr should contain "ℹ Info:"
+    And stderr should contain "Stage 1/6"
+    And stderr should contain "Stage 6/6"
+    And stderr lines containing "Info:" should all start with "ℹ Info:"
+    And stderr lines containing "Success:" should all start with "✔ Success:"
+
   Scenario: Stage summaries localize to Spanish with success prefix
     Given a minimal Netsuke workspace
     When netsuke is run with arguments "--accessible false --locale es-ES --progress true manifest -"


### PR DESCRIPTION
## Summary
- Adds insta-based snapshot tests to guard themed, multi-line outputs across Unicode and ASCII themes for progress, status, timing summaries, and output prefixes.
- Introduces test support utilities and expands tests to cover AccessibleReporter output, timing rendering, and OutputPrefs prefixes, all with deterministic en-US locale normalization.
- Extends BDD coverage with progress-output scenarios and new alignment assertions.
- Updates documentation and roadmap to reflect completed 3.12.2 snapshot testing work.

## Changes
- Adds docs/execplans/3-12-2-snapshot-progress-and-status-output-for-themes.md containing the complete ExecPlan for this work.
- Updates documentation to reflect snapshot-based guards:
  - docs/netsuke-design.md
  - docs/roadmap.md
  - docs/users-guide.md
- Adds test support utilities:
  - src/snapshot_test_support.rs (new)
- Expands test suites with snapshot tests (Unicode vs ASCII themes):
  - src/status_tests.rs (new snapshot tests for AccessibleReporter stage/completion and task progress)
  - src/status_timing_tests.rs (new snapshot tests for timing summary rendering)
  - src/output_prefs_tests.rs (new snapshot tests for all semantic prefixes and spacing accessors)
- Adds snapshot outputs in source tree:
  - src/snapshots/status/...
  - src/snapshots/status_timing/...
  - src/snapshots/output_prefs/...
- Enhances BDD tests infrastructure:
  - tests/bdd/steps/progress_output.rs (new assertion step for prefix alignment)
  - tests/features/progress_output.feature (new ASCII/Unicode progress-output scenarios)
- Connects snapshot settings to a subdirectory layout via snapshot_test_support helper, with per-module snapshot paths.
- Updates src/lib.rs to expose snapshot_test_support for tests.
- Updates tests to normalize Fluent bidi isolates before snapshot comparison.

## Rationale
- Full, multi-line rendering can drift subtly across changes. Snapshot-based guards provide diff-friendly, end-to-end verification without altering user-facing output.
- Localization is pinned to en-US for deterministic snapshots, with normalization of Fluent bidi isolates to avoid environment-induced drift.
- Stage-based approach ensures changes remain scoped and reviewable, while allowing expansion if needed.

## Plan overview
- Stage A: Snapshot tests for AccessibleReporter output (Unicode & ASCII)
  - Stage announcements, progress updates, and completion are captured and snapshotted.
- Stage B: Snapshot tests for timing summary rendering
  - Multi-line timing headers and per-stage lines are snapshotted for both themes.
- Stage C: Snapshot tests for prefix and spacing accessors
  - All semantic prefixes and spacing accessors are snapshotted per theme.
- Stage D: BDD scenarios for full-output snapshot verification
  - End-to-end manifest-like output guarded by snapshots for both themes.
- Stage E: Documentation, roadmap update, and final validation
  - Update docs and mark 3.12.2 as done in roadmap after validation.

## Validation gates
- make check-fmt passes
- make lint passes
- cargo test for status, timing, and output_prefs tests, including new snapshots
- Snapshot files are created under the intended directories and committed
- Fluent bidi isolate markers are normalized in snapshots

## Risks & mitigations
- Snapshot drift due to non-deterministic rendering: mitigated by en-US locale pinning and normalization of bidi isolates.
- Potential test file bloat: staged approach with per-theme snapshots and modular test files; refactor into separate modules if needed.
- New test files/helpers could trigger lint warnings: continue to reuse existing test patterns and helpers.

## Documentation & roadmap
- docs/users-guide.md: notes about snapshot regression coverage for theme output.
- docs/netsuke-design.md: notes that themed progress, status, and timing outputs are guarded by insta snapshots.
- docs/roadmap.md: marks 3.12.2 as done upon completion and validation.

## Acceptance criteria
- All staged tests produce deterministic snapshots for Unicode and ASCII themes.
- End-to-end BDD coverage aligns with snapshot expectations.
- All gates pass: formatting, linting, tests, and documentation updates.
- Snapshots live under src/snapshots/... aligned with existing conventions.

## What’s implemented vs what to expect
- Implemented: end-to-end insta snapshot tests for AccessibleReporter, timing summaries, and OutputPrefs prefixes across themes.
- Implemented: BDD alignment assertion for progress output lines.
- Implemented: per-theme snapshot storage and normalization helpers.
- Updated: documentation and roadmap to reflect completed item.

If you want me to adjust the title to be even shorter or tweak the body to emphasize specific files or test modules, I can refine further.

📎 **Task**: https://www.devboxer.com/task/a6f0b723-619e-4311-8f08-65d07d3774dc