### PR TITLE
Expose --config <PATH> and NETSUKE_CONFIG precedence (3.11.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ APP ?= netsuke
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
-MDLINT ?= $(HOME)/.bun/bin/markdownlint-cli2
+MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
 
 APP ?= netsuke
-CARGO ?= cargo
+CARGO ?= $(HOME)/.cargo/bin/cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
-MDLINT ?= markdownlint-cli2
+MDLINT ?= $(HOME)/.bun/bin/markdownlint-cli2
 NIXIE ?= nixie
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ MDLINT ?= $(HOME)/.bun/bin/markdownlint-cli2
 NIXIE ?= nixie
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 
+export PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(PATH)
+
 build: target/debug/$(APP) ## Build debug binary
 release: target/release/$(APP) ## Build release binary
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie
 
 APP ?= netsuke
-CARGO ?= $(HOME)/.cargo/bin/cargo
+CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 MDLINT ?= $(HOME)/.bun/bin/markdownlint-cli2

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -684,13 +684,14 @@ fn collect_diag_file_layers(cli: &Cli) -> Vec<MergeLayer<'static>>
 This mirrors the same resolution order for early diag-JSON evaluation. An
 explicit config path is resolved first and, when `load_layers_from_path()`
 succeeds, its layers are returned immediately. If that explicit load fails, the
-helper falls back to discovery rather than surfacing the error. Otherwise it
-uses the same `config_discovery(cli.directory.as_deref())` path as
-`push_file_layers()`, returns the first-pass file layers when the project file
-was already discovered, and only falls back to `project_scope_layers()` when
-the first pass missed the project `.netsuke.toml`. If the direct project load
-fails, the helper returns the first-pass layers instead of propagating the
-error.
+helper returns an empty vector and does not continue into automatic discovery,
+so an invalid explicit selector cannot inherit a discovered diagnostic
+preference. Without an explicit selector, the helper uses the same
+`config_discovery(cli.directory.as_deref())` path as `push_file_layers()`,
+returns the first-pass file layers when the project file was already
+discovered, and only falls back to `project_scope_layers()` when the first pass
+missed the project `.netsuke.toml`. If the direct project load fails, the
+helper returns the first-pass layers instead of propagating the error.
 
 ### Fluent key (`src/localization/keys.rs`)
 

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -127,19 +127,33 @@ Observable success means all of the following hold simultaneously:
 
 ## Progress
 
-- [ ] Stage A: add `--config` CLI field and wire it into discovery.
-- [ ] Stage B: support `NETSUKE_CONFIG` environment variable alongside legacy
+- [x] Stage A: add `--config` CLI field and wire it into discovery.
+- [x] Stage B: support `NETSUKE_CONFIG` environment variable alongside legacy
       `NETSUKE_CONFIG_PATH`.
-- [ ] Stage C: add Fluent localization keys and `build.rs` anchoring.
-- [ ] Stage D: add `rstest` integration tests for `--config` and
+- [x] Stage C: add Fluent localization keys and `build.rs` anchoring.
+- [x] Stage D: add `rstest` integration tests for `--config` and
       `NETSUKE_CONFIG`.
-- [ ] Stage E: add `rstest-bdd` behavioural tests.
-- [ ] Stage F: ship annotated sample config and update documentation.
-- [ ] Stage G: validation, roadmap update, and evidence capture.
+- [x] Stage E: add `rstest-bdd` behavioural tests.
+- [x] Stage F: ship annotated sample config and update documentation.
+- [x] Stage G: validation, roadmap update, and evidence capture.
 
 ## Surprises & discoveries
 
-(None yet — this section will be populated during implementation.)
+- Observation: a single `resolve_config_path()` helper in
+  `src/cli/config_merge.rs` cleanly keeps `merge_with_config()` and
+  `resolve_merged_diag_json()` aligned. This removed the old implicit reliance
+  on `ConfigDiscovery::env_var(...)` for explicit file selection and avoided
+  duplicating precedence logic. Date/Author: 2026-04-20 / implementation agent.
+
+- Observation: the existing BDD configuration-discovery steps were already
+  generic enough for `NETSUKE_CONFIG` and `--config`; only the feature file and
+  the generic isolated-CLI env cleanup list needed changes. Date/Author:
+  2026-04-20 / implementation agent.
+
+- Observation: explicit missing config files surface as file-layer merge
+  errors, so integration tests must inspect the full error chain or debug
+  output rather than only the top-level context string. Date/Author: 2026-04-20
+  / implementation agent.
 
 ## Decision log
 
@@ -172,9 +186,53 @@ Observable success means all of the following hold simultaneously:
   file path is specified before any directory change is applied. Date/Author:
   2026-04-16 / planning agent.
 
+- Decision: retire `ConfigDiscovery::env_var(...)` from Netsuke's internal
+  automatic-discovery helper and perform all explicit config-path selection in
+  `resolve_config_path()`. Rationale: once `NETSUKE_CONFIG`,
+  `NETSUKE_CONFIG_PATH`, and `--config` must share a single precedence ladder,
+  keeping the file-selection logic in one helper is simpler and prevents drift
+  between normal merging and early diag-JSON resolution. Date/Author:
+  2026-04-20 / implementation agent.
+
 ## Outcomes & retrospective
 
-(To be completed after implementation.)
+Implementation completed on 2026-04-20.
+
+Validation evidence:
+
+- `make fmt`
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `make markdownlint`
+- `make nixie`
+
+Key outcomes:
+
+- Added a visible `--config <FILE>` CLI flag on `Cli` as a parse-time-only
+  field (`#[serde(skip)]`), keeping it out of value merging.
+- Added `NETSUKE_CONFIG` as the documented environment-variable selector while
+  preserving `NETSUKE_CONFIG_PATH` as a lower-precedence legacy alias.
+- Centralized explicit config selection in
+  `src/cli/config_merge.rs::resolve_config_path()`, which now drives both full
+  merging and early `diag_json` resolution.
+- Added focused integration coverage in
+  `tests/cli_tests/config_selection.rs` for CLI/env precedence, missing-file
+  handling, and continued value-level precedence over the selected file.
+- Extended the configuration-discovery BDD feature with scenarios for
+  `--config`, `NETSUKE_CONFIG`, and precedence over the legacy alias.
+- Added `docs/sample-netsuke.toml` and updated the user guide, design
+  documentation, roadmap, and this ExecPlan to reflect the final contract.
+
+Retrospective:
+
+- The main implementation risk was not in Clap or OrthoConfig integration, but
+  in keeping file-selection precedence consistent across the normal merge path,
+  early diagnostic-mode resolution, integration tests, and BDD harness.
+  Centralizing the logic in a single helper avoided that drift.
+- The existing BDD support was already flexible enough for the new env var and
+  most of the CLI coverage, so the behavioural delta stayed smaller than the
+  plan first suggested.
 
 ## Context and orientation
 

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -1,0 +1,682 @@
+# 3.11.3. Expose `--config <path>` and `NETSUKE_CONFIG`
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+After this work, a Netsuke user can point the tool at an arbitrary
+configuration file in two new, visible ways:
+
+1. A CLI flag: `netsuke --config /path/to/config.toml build`
+2. An environment variable: `NETSUKE_CONFIG=/path/to/config.toml netsuke build`
+
+Both surfaces bypass automatic discovery and load the specified file directly.
+The existing `NETSUKE_CONFIG_PATH` environment variable continues to work as a
+silent alias for backward compatibility, but `NETSUKE_CONFIG` becomes the
+documented, user-facing name.
+
+The repository also ships an annotated sample configuration file at
+`docs/sample-netsuke.toml` that documents every supported key, so users have a
+starting point without reading source code.
+
+Observable success means all of the following hold simultaneously:
+
+- `netsuke --config /tmp/custom.toml build` loads the custom file instead of
+  the discovered one.
+- `NETSUKE_CONFIG=/tmp/custom.toml netsuke build` does the same.
+- The legacy `NETSUKE_CONFIG_PATH` still works when `NETSUKE_CONFIG` is not
+  set.
+- When both are set, `NETSUKE_CONFIG` takes precedence over
+  `NETSUKE_CONFIG_PATH`.
+- `netsuke --help` shows the `--config` flag with localised help text.
+- `docs/sample-netsuke.toml` is a valid, parsable config file with comments
+  explaining every key.
+- `make check-fmt`, `make lint`, and `make test` all pass.
+- The roadmap entry 3.11.3 is checked off.
+
+## Constraints
+
+- Keep `Cli` as the concrete clap and OrthoConfig merge root. Do not
+  restructure the derive hierarchy.
+- Preserve backward compatibility with `NETSUKE_CONFIG_PATH`. Removing it
+  would break existing CI pipelines and user workflows.
+- Preserve the standard precedence ladder: defaults < config files <
+  environment variables < CLI flags. The `--config` flag is a file-selection
+  mechanism, not a value-level override: it selects which file to load, but the
+  file's values still sit below environment and CLI in the precedence chain.
+- Keep all source files below the 400-line limit per `AGENTS.md`.
+- Keep all new user-facing strings localizable via Fluent. Update both
+  `en-US` and `es-ES` bundles.
+- Add `build.rs` symbol anchors for any new public helpers.
+- Do not use OrthoConfig's built-in `discovery(...)` attribute on the `Cli`
+  struct. Netsuke manages its own discovery through `config_discovery()` in
+  `src/cli/config_merge.rs` because OrthoConfig's `compose_layers()` returns
+  only the first found file, and Netsuke's two-pass approach is needed for
+  correct project-over-user precedence. The new `--config` flag must integrate
+  with this custom discovery path, not replace it.
+- The `--config` flag must use a long-form argument only. The short `-c` is
+  not assigned because `-C` (uppercase) is already taken by `--directory` and
+  the visual similarity would cause confusion.
+- Mark roadmap item 3.11.3 done only after all validation gates pass.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires more than 16 files changed or more than
+  700 net new lines, stop and escalate before proceeding.
+- Interface: if the change requires altering the signature of
+  `merge_with_config` or `resolve_merged_diag_json` in a way that breaks
+  existing callers, stop and escalate.
+- Dependencies: if a new external crate dependency is required, stop and
+  escalate.
+- Iterations: if `make lint` or `make test` still fail after three focused
+  fix-and-rerun cycles within a single stage, stop, document the blocker, and
+  escalate.
+- Ambiguity: if the interaction between `--config`, `NETSUKE_CONFIG`, and
+  `NETSUKE_CONFIG_PATH` creates an unresolvable precedence conflict, stop and
+  present options with trade-offs.
+
+## Risks
+
+- Risk: adding a `--config` field to the `Cli` struct may interact with
+  OrthoConfig's hidden `--config-path` flag, creating a clap conflict or
+  ambiguity. Severity: medium. Likelihood: medium. Mitigation: OrthoConfig's
+  hidden `--config-path` is only injected when the struct uses
+  `discovery(...)`, which Netsuke does not. Netsuke's `Cli` already manages its
+  own discovery externally, so adding a plain `config: Option<PathBuf>` field
+  should not collide. Verify during Stage A by running `netsuke --help` and
+  confirming no duplicate flags.
+
+- Risk: the `cli_overrides_from_matches` function strips fields not
+  explicitly set on the command line. A new `config` field must be handled
+  correctly there — it should be stripped from value-level overrides because it
+  is a meta-field (selects which file to load), not a config preference.
+  Severity: high. Likelihood: high. Mitigation: add `"config"` to the exclusion
+  list in `cli_overrides_from_matches` during Stage B.
+
+- Risk: the `config` field will be serialized by `sanitize_value` and included
+  in the merge pipeline if not handled carefully. Because it is a file
+  selector, not a preference, including it in the merged `Cli` output would be
+  confusing and could cause issues if the merged struct is re-serialized.
+  Severity: medium. Likelihood: high. Mitigation: mark the field with
+  `#[serde(skip)]` so it does not participate in OrthoConfig serialization.
+  Keep it as a clap-only, parse-time field.
+
+- Risk: backward compatibility between `NETSUKE_CONFIG` and
+  `NETSUKE_CONFIG_PATH` could create confusion if both are set to different
+  files. Severity: low. Likelihood: low. Mitigation: define a clear precedence:
+  `--config` (CLI) > `NETSUKE_CONFIG` (env) > `NETSUKE_CONFIG_PATH` (env,
+  legacy). Document this in the user guide.
+
+- Risk: the new `--config` flag could be passed alongside `-C` /
+  `--directory`, creating ambiguity about which directory anchors the config
+  path. Severity: low. Likelihood: medium. Mitigation: `--config` accepts an
+  absolute or relative path resolved against the process working directory (not
+  `-C`). This matches the semantics of `NETSUKE_CONFIG_PATH` and avoids
+  surprising interactions. Document this clearly.
+
+- Risk: new Fluent keys need both `en-US` and `es-ES` translations or the
+  build-time audit will fail. Severity: high. Likelihood: high. Mitigation: add
+  keys to both bundles in Stage C. Use a reasonable Spanish translation (or a
+  close English fallback with a `TODO(l10n)` comment if unsure) and verify with
+  `make lint`.
+
+## Progress
+
+- [ ] Stage A: add `--config` CLI field and wire it into discovery.
+- [ ] Stage B: support `NETSUKE_CONFIG` environment variable alongside legacy
+      `NETSUKE_CONFIG_PATH`.
+- [ ] Stage C: add Fluent localization keys and `build.rs` anchoring.
+- [ ] Stage D: add `rstest` integration tests for `--config` and
+      `NETSUKE_CONFIG`.
+- [ ] Stage E: add `rstest-bdd` behavioural tests.
+- [ ] Stage F: ship annotated sample config and update documentation.
+- [ ] Stage G: validation, roadmap update, and evidence capture.
+
+## Surprises & discoveries
+
+(None yet — this section will be populated during implementation.)
+
+## Decision log
+
+- Decision: use a plain `config: Option<PathBuf>` field on `Cli` with
+  `#[serde(skip)]` rather than OrthoConfig's
+  `discovery(config_cli_long = "config", config_cli_visible = true)` attribute.
+  Rationale: Netsuke's two-pass discovery in `config_merge.rs` is required for
+  correct project-over-user file precedence. OrthoConfig's built-in
+  `compose_layers()` returns only the first found file and cannot express this.
+  Introducing the `discovery(...)` attribute would replace Netsuke's custom
+  pipeline, and the interaction between a `discovery()`-generated flag and the
+  existing manual `config_discovery()` builder is untested and risky. A plain
+  clap field avoids the coupling. Date/Author: 2026-04-16 / planning agent.
+
+- Decision: keep `NETSUKE_CONFIG_PATH` as a silent backward-compatible alias.
+  Rationale: CI pipelines may already use it. Removing it would be a breaking
+  change for no user benefit. The new `NETSUKE_CONFIG` env var takes precedence
+  when both are set. Date/Author: 2026-04-16 / planning agent.
+
+- Decision: `--config` uses long-form only (no `-c` short flag).
+  Rationale: `-C` (uppercase) is already assigned to `--directory`. A lowercase
+  `-c` for a different flag would cause visual confusion, particularly in
+  documentation and error messages. Long-form `--config` is unambiguous.
+  Date/Author: 2026-04-16 / planning agent.
+
+- Decision: `--config` path is resolved against the process working
+  directory, not the `-C` directory. Rationale: this matches the existing
+  `NETSUKE_CONFIG_PATH` semantics and the user's shell expectations. The `-C`
+  flag re-anchors project-scope discovery and manifest lookup, but the config
+  file path is specified before any directory change is applied. Date/Author:
+  2026-04-16 / planning agent.
+
+## Outcomes & retrospective
+
+(To be completed after implementation.)
+
+## Context and orientation
+
+Read these files in order before changing code.
+
+1. `src/cli/mod.rs` — the `Cli` struct (lines 40–142). This is the clap
+   parser and OrthoConfig merge root. It defines the current `CONFIG_ENV_VAR`
+   constant (`"NETSUKE_CONFIG_PATH"`) and the `ENV_PREFIX` constant
+   (`"NETSUKE_"`). The new `config` field will be added here.
+
+2. `src/cli/config_merge.rs` — the merge pipeline. The key functions are:
+
+   - `config_discovery(directory)` (line 38): builds a `ConfigDiscovery`
+     using `CONFIG_ENV_VAR`. This function must be updated to also accept an
+     explicit config path from `--config`.
+   - `push_file_layers(composer, errors, directory)` (line 176): two-pass
+     file discovery. When an explicit config path is provided, this function
+     should load that file directly and skip all discovery.
+   - `collect_diag_file_layers(directory)` (line 111): mirrors
+     `push_file_layers` for early diag-JSON resolution. Must also honour
+     `--config`.
+   - `merge_with_config(cli, matches)` (line 264): the top-level merge
+     entry point. The `cli.config` field is read here to decide whether to
+     use explicit loading or discovery.
+
+3. `src/cli/config.rs` — the `CliConfig` typed view. The `config` field does
+   NOT belong here because it is a file selector, not a runtime preference.
+
+4. `src/cli_l10n.rs` — localization helpers. `flag_help_key()` (line 122)
+   maps argument IDs to Fluent keys. A new mapping for `"config"` must be added.
+
+5. `src/localization/keys.rs` — Fluent key constants. A new key
+   `CLI_FLAG_CONFIG_HELP` must be added.
+
+6. `locales/en-US/messages.ftl` and `locales/es-ES/messages.ftl` — Fluent
+   bundles. New messages for the `--config` flag help text.
+
+7. `build.rs` — symbol anchoring. If any new public helper is exposed from
+   `src/cli/mod.rs` or `src/cli/config_merge.rs`, a `const _` anchor must be
+   added.
+
+8. `tests/cli_tests/config_discovery.rs` — existing integration tests for
+   config discovery. New tests for `--config` and `NETSUKE_CONFIG` will be
+   added here or in a neighbouring file.
+
+9. `tests/features/configuration_discovery.feature` and
+   `tests/bdd/steps/configuration_discovery.rs` — existing BDD coverage for
+   config discovery. New scenarios will extend this feature file.
+
+10. `docs/users-guide.md` (lines 543–630) — user-facing configuration
+    documentation. Must be updated to describe `--config` and
+    `NETSUKE_CONFIG`.
+
+11. `docs/netsuke-design.md` (lines 2030–2111) — design decisions section
+    8.4. Must be updated to record the new config override surface.
+
+12. `docs/roadmap.md` (lines 296–298) — roadmap item 3.11.3. Must be marked
+    done after all gates pass.
+
+## Plan of work
+
+### Stage A. Add `--config` CLI field and wire it into discovery
+
+Add a new `config: Option<PathBuf>` field to the `Cli` struct in
+`src/cli/mod.rs`. This field:
+
+- accepts a file path via `--config <PATH>`;
+- is marked `#[serde(skip)]` so it does not participate in OrthoConfig
+  serialization or merging (it is a meta-field, not a preference);
+- is excluded from the override detection in `cli_overrides_from_matches`
+  by virtue of `#[serde(skip)]` (serde-skipped fields do not appear in the
+  serialized JSON, so they cannot leak into the merge pipeline);
+- has localised help text via the existing localization infrastructure.
+
+Update the default impl for `Cli` to set `config: None`.
+
+Then, update the merge pipeline in `src/cli/config_merge.rs`:
+
+1. Add a new constant: `const CONFIG_ENV_VAR_NEW: &str = "NETSUKE_CONFIG";`
+   (or rename the semantics — see below).
+
+2. Create a helper `fn resolve_config_path(cli: &Cli) -> Option<PathBuf>`
+   that implements the precedence: `cli.config` (from `--config`) >
+   `NETSUKE_CONFIG` env var > `NETSUKE_CONFIG_PATH` env var > `None` (use
+   discovery). This helper reads environment variables directly
+   (`std::env::var_os`) because the env-var layer in the merge pipeline is for
+   preference values, not for file selection.
+
+3. Update `config_discovery()` to accept an `Option<&Path>` for the explicit
+   config path. When `Some`, skip `ConfigDiscovery` entirely and load the file
+   directly via `load_config_file_as_chain`.
+
+4. Update `push_file_layers()` to call `resolve_config_path` and, when a
+   path is returned, load that single file instead of running two-pass
+   discovery. When the explicit path does not exist or fails to parse,
+   propagate the error rather than falling back to discovery — the user
+   explicitly requested this file.
+
+5. Update `collect_diag_file_layers()` with the same explicit-path logic
+   so `resolve_merged_diag_json` honours `--config` and `NETSUKE_CONFIG`.
+
+6. Update `merge_with_config()` — the existing code passes
+   `cli.directory.as_deref()` into `push_file_layers`. Now also pass the
+   resolved config path. The function signature of `push_file_layers` will gain
+   an `explicit_config: Option<&Path>` parameter.
+
+Acceptance for Stage A:
+
+- `cargo check` succeeds.
+- `netsuke --help` shows the `--config` flag (with English help text as a
+  placeholder until Stage C).
+- `netsuke --config /nonexistent.toml build` reports an error about the
+  missing file rather than falling back to discovery.
+- `netsuke --config <valid-config> build` loads the specified file.
+
+### Stage B. Support `NETSUKE_CONFIG` environment variable
+
+Update `resolve_config_path()` to check `NETSUKE_CONFIG` before
+`NETSUKE_CONFIG_PATH`. The full precedence for file selection is:
+
+```plaintext
+--config <PATH>   (CLI flag, highest)
+NETSUKE_CONFIG    (env var, new user-facing name)
+NETSUKE_CONFIG_PATH  (env var, legacy silent alias)
+automatic discovery  (lowest, two-pass project > user)
+```
+
+Update the `has_explicit_config` checks in `push_file_layers` and
+`collect_diag_file_layers` to also check `NETSUKE_CONFIG`. Currently these
+check `CONFIG_ENV_VAR` (`NETSUKE_CONFIG_PATH`); they must now check both env
+vars and the CLI field.
+
+Acceptance for Stage B:
+
+- `NETSUKE_CONFIG=/tmp/custom.toml netsuke build` uses the custom file.
+- `NETSUKE_CONFIG_PATH=/tmp/legacy.toml netsuke build` still works.
+- When both are set to different files, `NETSUKE_CONFIG` wins.
+- `cargo check` succeeds.
+
+### Stage C. Fluent localization keys and `build.rs` anchoring
+
+1. Add a new key constant in `src/localization/keys.rs`:
+
+   ```rust
+   CLI_FLAG_CONFIG_HELP => "cli.flag.config.help",
+   ```
+
+2. Add the Fluent message to `locales/en-US/messages.ftl`:
+
+   ```ftl
+   cli.flag.config.help = Path to a configuration file, bypassing automatic discovery.
+   ```
+
+3. Add the Fluent message to `locales/es-ES/messages.ftl`:
+
+   ```ftl
+   cli.flag.config.help = Ruta a un archivo de configuración, omitiendo la detección automática.
+   ```
+
+4. Update `flag_help_key()` in `src/cli_l10n.rs` to map `"config"` to
+   `keys::CLI_FLAG_CONFIG_HELP`.
+
+5. If `resolve_config_path` or any other new helper is made `pub` and
+   used from `build.rs`-compiled modules, add a `const _` symbol anchor in
+   `build.rs::assert_symbols_linked()`. If the helpers remain `pub(super)` or
+   private to `config_merge.rs`, no anchor is needed.
+
+Acceptance for Stage C:
+
+- `make lint` passes (including `cargo doc` and the build-time Fluent
+  audit).
+- `netsuke --help` shows the `--config` flag with localised English text.
+
+### Stage D. `rstest` integration tests
+
+Add integration tests in `tests/cli_tests/config_discovery.rs` (or a
+neighbouring file if the 400-line limit is reached). Tests should follow the
+existing pattern: acquire `EnvLock`, create temp directories, write config
+files, parse with `parse_with_localizer_from`, merge with `merge_with_config`,
+and assert on the merged `Cli` struct.
+
+Test cases:
+
+1. `config_flag_loads_specified_file` — write a custom config file with a
+   distinctive theme, pass `--config <path>`, assert theme matches.
+
+2. `config_flag_skips_project_discovery` — place a project `.netsuke.toml`
+   in the current directory with theme `ascii`, pass `--config` pointing to a
+   file with theme `unicode`, assert `unicode` wins.
+
+3. `config_flag_with_nonexistent_file_produces_error` — pass `--config`
+   pointing to a path that does not exist, assert the merge returns an error.
+
+4. `netsuke_config_env_loads_specified_file` — set `NETSUKE_CONFIG` to a
+   custom file, parse without `--config`, assert the custom file is loaded.
+
+5. `netsuke_config_env_takes_precedence_over_legacy` — set
+   `NETSUKE_CONFIG` to file A and `NETSUKE_CONFIG_PATH` to file B (with
+   different themes), assert file A wins.
+
+6. `config_flag_takes_precedence_over_netsuke_config_env` — set
+   `NETSUKE_CONFIG` to file A, pass `--config` pointing to file B, assert file
+   B wins.
+
+7. `config_flag_values_still_overridden_by_env_and_cli_preferences` —
+   custom config sets theme `ascii`, env sets `NETSUKE_THEME=unicode`, assert
+   theme is `unicode` (the file is loaded, but preference-level env vars still
+   override preference values from the file).
+
+Use `rstest` parameterization where appropriate. Use `EnvVarGuard` for all
+environment mutations. Use `CwdGuard` if changing working directory.
+
+Acceptance for Stage D:
+
+- `cargo test --test cli_tests -- config` runs the new tests and they pass.
+- Tests are deterministic and do not interfere with parallel execution.
+
+### Stage E. `rstest-bdd` behavioural tests
+
+Extend `tests/features/configuration_discovery.feature` with new scenarios that
+prove user-observable behaviour:
+
+```gherkin
+Scenario: Explicit config file overrides project discovery
+  Given a temporary workspace
+  And a project config file ".netsuke.toml" with theme "ascii"
+  And a custom config file "custom.toml" with theme "unicode"
+  When the CLI is parsed with "--config custom.toml"
+  Then parsing succeeds
+  And the theme preference is "unicode"
+
+Scenario: NETSUKE_CONFIG environment variable selects config file
+  Given a temporary workspace
+  And a project config file ".netsuke.toml" with theme "ascii"
+  And a custom config file "override.toml" with theme "unicode"
+  And the environment variable "NETSUKE_CONFIG" points to "override.toml"
+  When the CLI is parsed with no additional arguments
+  Then parsing succeeds
+  And the theme preference is "unicode"
+
+Scenario: NETSUKE_CONFIG takes precedence over NETSUKE_CONFIG_PATH
+  Given a temporary workspace
+  And a custom config file "new.toml" with theme "unicode"
+  And a custom config file "legacy.toml" with theme "ascii"
+  And the environment variable "NETSUKE_CONFIG" points to "new.toml"
+  And the environment variable "NETSUKE_CONFIG_PATH" points to "legacy.toml"
+  When the CLI is parsed with no additional arguments
+  Then parsing succeeds
+  And the theme preference is "unicode"
+
+Scenario: CLI config flag takes precedence over NETSUKE_CONFIG
+  Given a temporary workspace
+  And a custom config file "cli.toml" with theme "unicode"
+  And a custom config file "env.toml" with theme "ascii"
+  And the environment variable "NETSUKE_CONFIG" points to "env.toml"
+  When the CLI is parsed with "--config cli.toml"
+  Then parsing succeeds
+  And the theme preference is "unicode"
+```
+
+Add or extend step definitions in `tests/bdd/steps/configuration_discovery.rs`
+as needed. The existing `write_config_file` helper and
+`custom_config_with_theme` step should work for most scenarios. The
+`When the CLI is parsed with "--config custom.toml"` step needs to resolve
+`custom.toml` relative to the temp workspace directory before passing to the
+parser — update the existing When step to handle `--config` arguments that
+reference filenames in the workspace.
+
+Acceptance for Stage E:
+
+- `cargo test --test bdd_tests configuration_discovery` runs all scenarios
+  (old and new) and they pass.
+- Scenarios read as user stories, not as unit tests in Gherkin clothing.
+
+### Stage F. Annotated sample config and documentation updates
+
+1. Create `docs/sample-netsuke.toml` — an annotated sample configuration
+   file that documents every supported key. Use TOML comments (`#`) to explain
+   each field, its default value, and valid options. The file must be parsable
+   by Netsuke (all values should be valid defaults or commented out). Structure
+   it by section: general, build behaviour, output preferences, network policy.
+
+   Example structure:
+
+   ```toml
+   # Netsuke sample configuration
+   #
+   # Place this file at .netsuke.toml in your project root, or point
+   # to it with --config or NETSUKE_CONFIG.
+
+   # Enable verbose diagnostic logging and timing summaries.
+   # verbose = false
+
+   # Locale for CLI messages (e.g., "en-US", "es-ES").
+   # locale = "en-US"
+
+   # CLI theme preset: "auto", "unicode", or "ascii".
+   # theme = "auto"
+
+   # ... (all other fields)
+   ```
+
+2. Update `docs/users-guide.md`:
+
+   - In the "Configuration and Localization" section (around line 543), add
+     documentation for `--config <PATH>` and `NETSUKE_CONFIG`.
+   - Document the full config override precedence:
+     `--config` > `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH` > automatic
+     discovery.
+   - Mention the sample config file and where to find it.
+   - Ensure the existing `NETSUKE_CONFIG_PATH` documentation is preserved
+     but de-emphasised as a legacy alias.
+
+3. Update `docs/netsuke-design.md` section 8.4:
+
+   - Record the config override surface design decision.
+   - Document the interaction between `--config`, `NETSUKE_CONFIG`, and
+     `NETSUKE_CONFIG_PATH`.
+
+4. Run `make fmt` and `make markdownlint` after documentation changes.
+
+Acceptance for Stage F:
+
+- `netsuke --config docs/sample-netsuke.toml build` does not error on
+  config parsing (the sample file should be valid or entirely commented out).
+- `make markdownlint` passes.
+- `make nixie` passes (if any Mermaid diagrams were added or changed).
+- A user can learn how to use `--config` and `NETSUKE_CONFIG` by reading
+  only the user guide.
+
+### Stage G. Validation, roadmap update, and evidence capture
+
+1. Run all validation gates using `tee` and `set -o pipefail`:
+
+   ```sh
+   set -o pipefail && make fmt 2>&1 | tee /tmp/3-11-3-make-fmt.log
+   set -o pipefail && make check-fmt 2>&1 | tee /tmp/3-11-3-check-fmt.log
+   set -o pipefail && make lint 2>&1 | tee /tmp/3-11-3-make-lint.log
+   set -o pipefail && make test 2>&1 | tee /tmp/3-11-3-make-test.log
+   set -o pipefail && make markdownlint 2>&1 | tee /tmp/3-11-3-markdownlint.log
+   set -o pipefail && make nixie 2>&1 | tee /tmp/3-11-3-make-nixie.log
+   ```
+
+2. Review log files for truncated output, not just exit codes.
+
+3. Mark roadmap item 3.11.3 done in `docs/roadmap.md`.
+
+4. Update the `Progress`, `Outcomes & Retrospective`, and
+   `Surprises & Discoveries` sections of this ExecPlan.
+
+Acceptance for Stage G:
+
+- All six validation commands exit with status 0.
+- Roadmap item 3.11.3 is checked off.
+- This ExecPlan status is updated to COMPLETE.
+
+## Interfaces and dependencies
+
+### New field on `Cli` (`src/cli/mod.rs`)
+
+```rust
+/// Path to a configuration file, bypassing automatic discovery.
+///
+/// When specified, Netsuke loads this file instead of searching for
+/// `.netsuke.toml` in project and user scopes. The file path is resolved
+/// against the process working directory.
+#[arg(long, value_name = "PATH")]
+#[serde(skip)]
+#[ortho_config(skip_cli)]
+pub config: Option<PathBuf>,
+```
+
+The `#[serde(skip)]` annotation prevents the field from being serialized into
+the JSON value that feeds the merge pipeline. The `#[ortho_config (skip_cli)]`
+annotation (matching the existing `command` field pattern) prevents OrthoConfig
+from trying to merge this field across layers.
+
+### Config path resolution helper (`src/cli/config_merge.rs`)
+
+```rust
+/// Resolve the effective explicit config file path.
+///
+/// Precedence: `--config` CLI flag > `NETSUKE_CONFIG` env var >
+/// `NETSUKE_CONFIG_PATH` env var > `None` (use automatic discovery).
+fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
+    if let Some(ref path) = cli.config {
+        return Some(path.clone());
+    }
+    if let Some(val) = std::env::var_os("NETSUKE_CONFIG") {
+        if !val.is_empty() {
+            return Some(PathBuf::from(val));
+        }
+    }
+    if let Some(val) = std::env::var_os(CONFIG_ENV_VAR) {
+        if !val.is_empty() {
+            return Some(PathBuf::from(val));
+        }
+    }
+    None
+}
+```
+
+### Updated `push_file_layers` signature
+
+```rust
+fn push_file_layers(
+    composer: &mut MergeComposer,
+    errors: &mut Vec<Arc<ortho_config::OrthoError>>,
+    directory: Option<&Path>,
+    explicit_config: Option<&Path>,
+)
+```
+
+When `explicit_config` is `Some`, the function loads that single file via
+`load_config_file_as_chain` and pushes the resulting layers. It does not run
+`config_discovery()` or the second-pass project-scope loader. When the file
+does not exist or fails to parse, the error is pushed to `errors`.
+
+### Updated `collect_diag_file_layers` signature
+
+```rust
+fn collect_diag_file_layers(
+    directory: Option<&Path>,
+    explicit_config: Option<&Path>,
+) -> Vec<MergeLayer<'static>>
+```
+
+Mirrors the `push_file_layers` change for early diag-JSON resolution.
+
+### Fluent key (`src/localization/keys.rs`)
+
+```rust
+CLI_FLAG_CONFIG_HELP => "cli.flag.config.help",
+```
+
+### Localization mapping (`src/cli_l10n.rs`, in `flag_help_key`)
+
+```rust
+"config" => Some(keys::CLI_FLAG_CONFIG_HELP),
+```
+
+## Validation and acceptance
+
+Quality criteria (what "done" means):
+
+- Tests: `make test` passes the full workspace suite, including at least 7
+  new integration tests and 4 new BDD scenarios.
+- Lint: `make lint` passes with zero warnings.
+- Format: `make check-fmt` passes.
+- Markdown: `make markdownlint` passes.
+- Mermaid: `make nixie` passes.
+- Sample config: `docs/sample-netsuke.toml` parses without errors.
+- Docs: the user guide documents `--config`, `NETSUKE_CONFIG`, the full
+  precedence chain, and the sample config file.
+
+Quality method (how we check):
+
+```sh
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/3-11-3-check-fmt.log
+set -o pipefail && make lint 2>&1 | tee /tmp/3-11-3-make-lint.log
+set -o pipefail && make test 2>&1 | tee /tmp/3-11-3-make-test.log
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/3-11-3-markdownlint.log
+set -o pipefail && make nixie 2>&1 | tee /tmp/3-11-3-make-nixie.log
+```
+
+## Idempotence and recovery
+
+All stages are safe to re-run. Config file writes are idempotent (write the
+same content). Test execution is stateless. Environment variable mutations are
+protected by `EnvLock` and `EnvVarGuard` RAII guards.
+
+If a stage fails partway through, fix the issue and re-run from the start of
+that stage. No rollback is needed because no destructive operations are
+performed.
+
+## Artifacts and notes
+
+### File change summary (expected)
+
+New files:
+
+- `docs/sample-netsuke.toml` — annotated sample configuration file.
+
+Modified files:
+
+- `src/cli/mod.rs` — add `config: Option<PathBuf>` field; update `Default`
+  impl.
+- `src/cli/config_merge.rs` — add `resolve_config_path`; update
+  `push_file_layers`, `collect_diag_file_layers`, and `merge_with_config` to
+  honour explicit config paths.
+- `src/cli_l10n.rs` — add `"config"` mapping in `flag_help_key`.
+- `src/localization/keys.rs` — add `CLI_FLAG_CONFIG_HELP` key.
+- `locales/en-US/messages.ftl` — add `cli.flag.config.help` message.
+- `locales/es-ES/messages.ftl` — add `cli.flag.config.help` message.
+- `tests/cli_tests/config_discovery.rs` (or new neighbour) — add 7+
+  integration tests.
+- `tests/features/configuration_discovery.feature` — add 4 BDD scenarios.
+- `tests/bdd/steps/configuration_discovery.rs` — extend step definitions if
+  needed.
+- `docs/users-guide.md` — document `--config` and `NETSUKE_CONFIG`.
+- `docs/netsuke-design.md` — record design decision in section 8.4.
+- `docs/roadmap.md` — mark 3.11.3 done.
+- `build.rs` — add symbol anchor if new public helpers are exposed.
+- `src/cli/config_merge_tests.rs` — add unit tests for `resolve_config_path`
+  and updated `push_file_layers`.

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -155,6 +155,26 @@ Observable success means all of the following hold simultaneously:
   output rather than only the top-level context string. Date/Author: 2026-04-20
   / implementation agent.
 
+- Observation: the new integration coverage in
+  `tests/cli_tests/config_selection.rs` accumulated repeated process-level test
+  setup (`EnvLock`, temporary directories, sandboxed user scope, and working
+  directory changes). A small file-local `ConfigTestHarness` keeps those tests
+  under the project's readability thresholds without changing behaviour.
+  Date/Author: 2026-04-21 / implementation agent.
+
+- Observation: for test harnesses that both `chdir` into a temporary
+  directory and own that directory, struct field order matters because Rust
+  drops fields in reverse declaration order. The cwd-restoration guard must be
+  declared after the temporary directories so it drops first during teardown.
+  Date/Author: 2026-04-21 / implementation agent.
+
+- Observation: the `cli_tests` integration target was still flaky when the
+  new `ConfigTestHarness` tests passed relative `--config custom.toml` paths
+  under the full parallel suite. Using the helper's returned absolute paths in
+  the flag-based tests removed that cwd sensitivity while preserving the
+  precedence behaviour under test. Date/Author: 2026-04-21 / implementation
+  agent.
+
 ## Decision log
 
 - Decision: use a plain `config: Option<PathBuf>` field on `Cli` with
@@ -198,6 +218,8 @@ Observable success means all of the following hold simultaneously:
 
 Implementation completed on 2026-04-20.
 
+Follow-on maintenance completed on 2026-04-21.
+
 Validation evidence:
 
 - `make fmt`
@@ -219,6 +241,12 @@ Key outcomes:
 - Added focused integration coverage in
   `tests/cli_tests/config_selection.rs` for CLI/env precedence, missing-file
   handling, and continued value-level precedence over the selected file.
+- Refactored `tests/cli_tests/config_selection.rs` to use a local
+  `ConfigTestHarness`, removing duplicated environment and working-directory
+  setup while preserving the existing test names, assertions, and merge calls.
+- Fixed a separate cwd teardown hazard in
+  `tests/cli_tests/merge.rs::resolve_merged_diag_json_handles_malformed_project_config`
+   so the full integration suite remains stable after the harness refactor.
 - Extended the configuration-discovery BDD feature with scenarios for
   `--config`, `NETSUKE_CONFIG`, and precedence over the legacy alias.
 - Added `docs/sample-netsuke.toml` and updated the user guide, design

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -417,7 +417,7 @@ Acceptance for Stage B:
 3. Add the Fluent message to `locales/es-ES/messages.ftl`:
 
    ```ftl
-   cli.flag.config.help = Ruta a un archivo de configuración, omitiendo la detección automática.
+   cli.flag.config.help = Ruta de configuración; omite la detección automática.
    ```
 
 4. Update `flag_help_key()` in `src/cli_l10n.rs` to map `"config"` to
@@ -624,42 +624,28 @@ Acceptance for Stage G:
 ```rust
 /// Path to a configuration file, bypassing automatic discovery.
 ///
-/// When specified, Netsuke loads this file instead of searching for
-/// `.netsuke.toml` in project and user scopes. The file path is resolved
-/// against the process working directory.
-#[arg(long, value_name = "PATH")]
+/// When specified, Netsuke loads this file before automatic discovery and
+/// skips the layered project/user search.
+#[arg(long, value_name = "FILE")]
 #[serde(skip)]
-#[ortho_config(skip_cli)]
 pub config: Option<PathBuf>,
 ```
 
-The `#[serde(skip)]` annotation prevents the field from being serialized into
-the JSON value that feeds the merge pipeline. The `#[ortho_config (skip_cli)]`
-annotation (matching the existing `command` field pattern) prevents OrthoConfig
-from trying to merge this field across layers.
+The `#[serde(skip)]` annotation prevents the field from being serialised into
+the JSON value that feeds the merge pipeline.
 
 ### Config path resolution helper (`src/cli/config_merge.rs`)
 
 ```rust
 /// Resolve the effective explicit config file path.
 ///
-/// Precedence: `--config` CLI flag > `NETSUKE_CONFIG` env var >
-/// `NETSUKE_CONFIG_PATH` env var > `None` (use automatic discovery).
+/// Precedence: `--config` > `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`.
+/// Empty environment values are ignored.
 fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
-    if let Some(ref path) = cli.config {
-        return Some(path.clone());
-    }
-    if let Some(val) = std::env::var_os("NETSUKE_CONFIG") {
-        if !val.is_empty() {
-            return Some(PathBuf::from(val));
-        }
-    }
-    if let Some(val) = std::env::var_os(CONFIG_ENV_VAR) {
-        if !val.is_empty() {
-            return Some(PathBuf::from(val));
-        }
-    }
-    None
+    cli.config
+        .clone()
+        .or_else(|| env_config_path(CONFIG_ENV_VAR))
+        .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
 }
 ```
 
@@ -669,26 +655,42 @@ fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
 fn push_file_layers(
     composer: &mut MergeComposer,
     errors: &mut Vec<Arc<ortho_config::OrthoError>>,
-    directory: Option<&Path>,
-    explicit_config: Option<&Path>,
+    cli: &Cli,
 )
 ```
 
-When `explicit_config` is `Some`, the function loads that single file via
-`load_config_file_as_chain` and pushes the resulting layers. It does not run
-`config_discovery()` or the second-pass project-scope loader. When the file
-does not exist or fails to parse, the error is pushed to `errors`.
+The helper resolves an explicit config path internally with
+`resolve_config_path(cli)`. When a path is present, it loads that file via
+`load_layers_from_path()`, pushes every layer in the returned chain, and stops.
+If the file does not exist or fails to parse, the resulting error is appended
+to `errors` and discovery does not continue.
+
+Without an explicit path, `push_file_layers()` runs `config_discovery()` using
+`cli.directory.as_deref()` to anchor project-root discovery. It appends
+`compose_layers()` required errors unconditionally, appends optional errors
+only when no file layers were found, and pushes every discovered layer onto the
+composer. If the first pass did not include the project `.netsuke.toml`, the
+helper performs a direct second-pass load via `project_scope_layers()`. That
+second pass uses the same directory anchor, or the current working directory
+when `-C/--directory` was not supplied. Any project-scope parse or extends
+error from that direct load is appended to `errors`.
 
 ### Updated `collect_diag_file_layers` signature
 
 ```rust
-fn collect_diag_file_layers(
-    directory: Option<&Path>,
-    explicit_config: Option<&Path>,
-) -> Vec<MergeLayer<'static>>
+fn collect_diag_file_layers(cli: &Cli) -> Vec<MergeLayer<'static>>
 ```
 
-Mirrors the `push_file_layers` change for early diag-JSON resolution.
+This mirrors the same resolution order for early diag-JSON evaluation. An
+explicit config path is resolved first and, when `load_layers_from_path()`
+succeeds, its layers are returned immediately. If that explicit load fails, the
+helper falls back to discovery rather than surfacing the error. Otherwise it
+uses the same `config_discovery(cli.directory.as_deref())` path as
+`push_file_layers()`, returns the first-pass file layers when the project file
+was already discovered, and only falls back to `project_scope_layers()` when
+the first pass missed the project `.netsuke.toml`. If the direct project load
+fails, the helper returns the first-pass layers instead of propagating the
+error.
 
 ### Fluent key (`src/localization/keys.rs`)
 

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -164,8 +164,8 @@ Observable success means all of the following hold simultaneously:
 
 - Observation: for test harnesses that both `chdir` into a temporary
   directory and own that directory, struct field order matters because Rust
-  drops fields in reverse declaration order. The cwd-restoration guard must be
-  declared after the temporary directories so it drops first during teardown.
+  drops fields in declaration order. The cwd-restoration guard must be
+  declared before the temporary directories so it drops first during teardown.
   Date/Author: 2026-04-21 / implementation agent.
 
 - Observation: the `cli_tests` integration target was still flaky when the
@@ -267,24 +267,26 @@ Retrospective:
 Read these files in order before changing code.
 
 1. `src/cli/mod.rs` — the `Cli` struct (lines 40–142). This is the clap
-   parser and OrthoConfig merge root. It defines the current `CONFIG_ENV_VAR`
-   constant (`"NETSUKE_CONFIG_PATH"`) and the `ENV_PREFIX` constant
-   (`"NETSUKE_"`). The new `config` field will be added here.
+   parser and OrthoConfig merge root. It defines both config constants:
+   `CONFIG_ENV_VAR` (`"NETSUKE_CONFIG"`) and `CONFIG_ENV_VAR_LEGACY`
+   (`"NETSUKE_CONFIG_PATH"`), plus `ENV_PREFIX` (`"NETSUKE_"`).
 
 2. `src/cli/config_merge.rs` — the merge pipeline. The key functions are:
 
-   - `config_discovery(directory)` (line 38): builds a `ConfigDiscovery`
-     using `CONFIG_ENV_VAR`. This function must be updated to also accept an
-     explicit config path from `--config`.
-   - `push_file_layers(composer, errors, directory)` (line 176): two-pass
-     file discovery. When an explicit config path is provided, this function
-     should load that file directly and skip all discovery.
-   - `collect_diag_file_layers(directory)` (line 111): mirrors
-     `push_file_layers` for early diag-JSON resolution. Must also honour
-     `--config`.
-   - `merge_with_config(cli, matches)` (line 264): the top-level merge
-     entry point. The `cli.config` field is read here to decide whether to
-     use explicit loading or discovery.
+   - `resolve_config_path(cli)` (line 50): applies the precedence
+     `--config` > `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH` and returns the
+     explicit config path when set.
+   - `config_discovery(directory)` (line 38): builds a `ConfigDiscovery` rooted
+     at `netsuke`, with `-C/--directory` forwarded via `cli.directory` as the
+     optional project-root anchor.
+   - `push_file_layers(composer, errors, cli)` (line 226): uses `resolve_config_path(cli)`.
+     When a path is found, it loads that single file and skips discovery; otherwise,
+     it runs the two-pass discovery path.
+   - `collect_diag_file_layers(cli)` (line 141): uses the same `&Cli` driven
+     `resolve_config_path(cli)` path before discovery so diagnostic-json
+     resolution honours explicit selection.
+   - `merge_with_config(cli, matches)` (line 315): reads selection through
+     `resolve_config_path(cli)` and delegates to `push_file_layers` with `&Cli`.
 
 3. `src/cli/config.rs` — the `CliConfig` typed view. The `config` field does
    NOT belong here because it is a file selector, not a runtime preference.
@@ -337,35 +339,17 @@ Add a new `config: Option<PathBuf>` field to the `Cli` struct in
 
 Update the default impl for `Cli` to set `config: None`.
 
-Then, update the merge pipeline in `src/cli/config_merge.rs`:
+Then, align the merge pipeline in `src/cli/config_merge.rs` with the landed
+`resolve_config_path(cli)` contract:
 
-1. Add a new constant: `const CONFIG_ENV_VAR_NEW: &str = "NETSUKE_CONFIG";`
-   (or rename the semantics — see below).
-
-2. Create a helper `fn resolve_config_path(cli: &Cli) -> Option<PathBuf>`
-   that implements the precedence: `cli.config` (from `--config`) >
-   `NETSUKE_CONFIG` env var > `NETSUKE_CONFIG_PATH` env var > `None` (use
-   discovery). This helper reads environment variables directly
-   (`std::env::var_os`) because the env-var layer in the merge pipeline is for
-   preference values, not for file selection.
-
-3. Update `config_discovery()` to accept an `Option<&Path>` for the explicit
-   config path. When `Some`, skip `ConfigDiscovery` entirely and load the file
-   directly via `load_config_file_as_chain`.
-
-4. Update `push_file_layers()` to call `resolve_config_path` and, when a
-   path is returned, load that single file instead of running two-pass
-   discovery. When the explicit path does not exist or fails to parse,
-   propagate the error rather than falling back to discovery — the user
-   explicitly requested this file.
-
-5. Update `collect_diag_file_layers()` with the same explicit-path logic
-   so `resolve_merged_diag_json` honours `--config` and `NETSUKE_CONFIG`.
-
-6. Update `merge_with_config()` — the existing code passes
-   `cli.directory.as_deref()` into `push_file_layers`. Now also pass the
-   resolved config path. The function signature of `push_file_layers` will gain
-   an `explicit_config: Option<&Path>` parameter.
+1. `resolve_config_path(cli)` applies precedence as `--config` >
+   `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`, before discovery.
+2. `push_file_layers(composer, errors, cli)` and
+   `collect_diag_file_layers(cli)` both call `resolve_config_path(cli)` directly.
+   When a path is selected they load that file only, bypassing discovery.
+3. `merge_with_config(cli, matches)` reads selection through `resolve_config_path(cli)`
+   and delegates to `push_file_layers` with the same `&Cli` pipeline, so all
+   config entry points resolve explicit selectors the same way.
 
 Acceptance for Stage A:
 
@@ -388,10 +372,10 @@ NETSUKE_CONFIG_PATH  (env var, legacy silent alias)
 automatic discovery  (lowest, two-pass project > user)
 ```
 
-Update the `has_explicit_config` checks in `push_file_layers` and
-`collect_diag_file_layers` to also check `NETSUKE_CONFIG`. Currently these
-check `CONFIG_ENV_VAR` (`NETSUKE_CONFIG_PATH`); they must now check both env
-vars and the CLI field.
+Update `push_file_layers()` and `collect_diag_file_layers()` to rely on
+`resolve_config_path(cli)` for explicit config selection. When that helper
+returns a path, the selected file is loaded directly and discovery is skipped;
+otherwise these functions continue with the two-pass discovery flow.
 
 Acceptance for Stage B:
 
@@ -643,7 +627,8 @@ the JSON value that feeds the merge pipeline.
 /// Empty environment values are ignored.
 fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
     cli.config
-        .clone()
+        .as_ref()
+        .map(PathBuf::from)
         .or_else(|| env_config_path(CONFIG_ENV_VAR))
         .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
 }

--- a/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
+++ b/docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md
@@ -33,7 +33,7 @@ Observable success means all of the following hold simultaneously:
   set.
 - When both are set, `NETSUKE_CONFIG` takes precedence over
   `NETSUKE_CONFIG_PATH`.
-- `netsuke --help` shows the `--config` flag with localised help text.
+- `netsuke --help` shows the `--config` flag with localized help text.
 - `docs/sample-netsuke.toml` is a valid, parsable config file with comments
   explaining every key.
 - `make check-fmt`, `make lint`, and `make test` all pass.
@@ -164,8 +164,8 @@ Observable success means all of the following hold simultaneously:
 
 - Observation: for test harnesses that both `chdir` into a temporary
   directory and own that directory, struct field order matters because Rust
-  drops fields in declaration order. The cwd-restoration guard must be
-  declared before the temporary directories so it drops first during teardown.
+  drops fields in declaration order. The cwd-restoration guard must be declared
+  before the temporary directories so it drops first during teardown.
   Date/Author: 2026-04-21 / implementation agent.
 
 - Observation: the `cli_tests` integration target was still flaky when the
@@ -279,7 +279,8 @@ Read these files in order before changing code.
    - `config_discovery(directory)` (line 38): builds a `ConfigDiscovery` rooted
      at `netsuke`, with `-C/--directory` forwarded via `cli.directory` as the
      optional project-root anchor.
-   - `push_file_layers(composer, errors, cli)` (line 226): uses `resolve_config_path(cli)`.
+   - `push_file_layers(composer, errors, cli)` (line 226): uses
+     `resolve_config_path(cli)`.
      When a path is found, it loads that single file and skips discovery; otherwise,
      it runs the two-pass discovery path.
    - `collect_diag_file_layers(cli)` (line 141): uses the same `&Cli` driven
@@ -335,7 +336,7 @@ Add a new `config: Option<PathBuf>` field to the `Cli` struct in
 - is excluded from the override detection in `cli_overrides_from_matches`
   by virtue of `#[serde(skip)]` (serde-skipped fields do not appear in the
   serialized JSON, so they cannot leak into the merge pipeline);
-- has localised help text via the existing localization infrastructure.
+- has localized help text via the existing localization infrastructure.
 
 Update the default impl for `Cli` to set `config: None`.
 
@@ -345,9 +346,11 @@ Then, align the merge pipeline in `src/cli/config_merge.rs` with the landed
 1. `resolve_config_path(cli)` applies precedence as `--config` >
    `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`, before discovery.
 2. `push_file_layers(composer, errors, cli)` and
-   `collect_diag_file_layers(cli)` both call `resolve_config_path(cli)` directly.
-   When a path is selected they load that file only, bypassing discovery.
-3. `merge_with_config(cli, matches)` reads selection through `resolve_config_path(cli)`
+   `collect_diag_file_layers(cli)` both call `resolve_config_path(cli)`
+   directly. When a path is selected they load that file only, bypassing
+   discovery.
+3. `merge_with_config(cli, matches)` reads selection through
+   `resolve_config_path(cli)`
    and delegates to `push_file_layers` with the same `&Cli` pipeline, so all
    config entry points resolve explicit selectors the same way.
 
@@ -416,7 +419,7 @@ Acceptance for Stage C:
 
 - `make lint` passes (including `cargo doc` and the build-time Fluent
   audit).
-- `netsuke --help` shows the `--config` flag with localised English text.
+- `netsuke --help` shows the `--config` flag with localized English text.
 
 ### Stage D. `rstest` integration tests
 
@@ -556,7 +559,7 @@ Acceptance for Stage E:
      discovery.
    - Mention the sample config file and where to find it.
    - Ensure the existing `NETSUKE_CONFIG_PATH` documentation is preserved
-     but de-emphasised as a legacy alias.
+     but de-emphasized as a legacy alias.
 
 3. Update `docs/netsuke-design.md` section 8.4:
 
@@ -615,7 +618,7 @@ Acceptance for Stage G:
 pub config: Option<PathBuf>,
 ```
 
-The `#[serde(skip)]` annotation prevents the field from being serialised into
+The `#[serde(skip)]` annotation prevents the field from being serialized into
 the JSON value that feeds the merge pipeline.
 
 ### Config path resolution helper (`src/cli/config_merge.rs`)

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2034,29 +2034,30 @@ applies `Cli::with_default_command` after parsing so invoking `netsuke` with no
 explicit command still triggers a build. Configuration is layered with
 OrthoConfig (defaults, configuration files, environment variables, then CLI
 overrides) while treating clap defaults as absent so file or environment values
-are not masked. Configuration discovery honours `NETSUKE_CONFIG_PATH` and the
-standard OrthoConfig search order; environment variables use the `NETSUKE_`
-prefix with `__` as a nesting separator. CLI help and clap errors are localized
-via Fluent resources; locale resolution is handled in
-`src/locale_resolution.rs` with the precedence `--locale` -> `NETSUKE_LOCALE`
--> configuration `locale` -> system default. System locale strings are
-normalized by stripping encoding suffixes (such as `.UTF-8`), removing variant
-suffixes (such as `@latin`), and replacing underscores with hyphens before
-validation. English plus Spanish catalogues ship in `locales/`; unsupported
-locales fall back to `en-US`. Runtime diagnostics (for example manifest
-parsing, stdlib template errors, and runner failures) use the same Fluent
-localizer so the locale selection is consistent across user-facing output. A
-build-time audit in `build.rs` validates that all referenced Fluent message
-keys exist in the bundled catalogues, ensuring missing strings fail CI before
-release. CLI execution and dispatch live in `src/runner.rs`, keeping `main.rs`
-focused on parsing. Process management, Ninja invocation, argument redaction,
-and the temporary file helpers reside in `src/runner/process.rs`, allowing the
-runner entry point to delegate low-level concerns. The working directory flag
-mirrors Ninja's `-C` option but is resolved internally: Netsuke runs Ninja with
-a configured working directory and resolves relative output paths (for example
-`build --emit` and `manifest`) under the same directory so behaviour matches a
-real directory change. Error scenarios are validated using clap's `ErrorKind`
-enumeration in unit tests and via Cucumber steps for behavioural coverage.
+are not masked. Explicit config selection respects `-C/--directory` for
+project-root discovery, and the precedence is `--config` > `NETSUKE_CONFIG` >
+legacy `NETSUKE_CONFIG_PATH`. Environment variables use the `NETSUKE_` prefix
+with `__` as a nesting separator. CLI help and clap errors are localized via
+Fluent resources; locale resolution is handled in `src/locale_resolution.rs`
+with the precedence `--locale` -> `NETSUKE_LOCALE` -> configuration `locale` ->
+system default. System locale strings are normalized by stripping encoding
+suffixes (such as `.UTF-8`), removing variant suffixes (such as `@latin`), and
+replacing underscores with hyphens before validation. English plus Spanish
+catalogues ship in `locales/`; unsupported locales fall back to `en-US`.
+Runtime diagnostics (for example manifest parsing, stdlib template errors, and
+runner failures) use the same Fluent localizer so the locale selection is
+consistent across user-facing output. A build-time audit in `build.rs`
+validates that all referenced Fluent message keys exist in the bundled
+catalogues, ensuring missing strings fail CI before release. CLI execution and
+dispatch live in `src/runner.rs`, keeping `main.rs` focused on parsing. Process
+management, Ninja invocation, argument redaction, and the temporary file
+helpers reside in `src/runner/process.rs`, allowing the runner entry point to
+delegate low-level concerns. The working directory flag mirrors Ninja's `-C`
+option but is resolved internally: Netsuke runs Ninja with a configured working
+directory and resolves relative output paths (for example `build --emit` and
+`manifest`) under the same directory so behaviour matches a real directory
+change. Error scenarios are validated using clap's `ErrorKind` enumeration in
+unit tests and via Cucumber steps for behavioural coverage.
 
 Real-time stage reporting now uses a six-stage model in `src/status.rs` backed
 by `indicatif::MultiProgress` for standard terminals. The reporter keeps one
@@ -2204,7 +2205,8 @@ override the merged result, ensuring explicit user intent always wins.
 1. **Explicit override**: the first configured selector from this list:
    `--config <PATH>`, `NETSUKE_CONFIG`, `NETSUKE_CONFIG_PATH`. This allows
    users to point to any arbitrary configuration file path, bypassing automatic
-   discovery entirely. `NETSUKE_CONFIG_PATH` remains supported as a
+   discovery entirely while still respecting the project-root anchor supplied
+   by `-C/--directory`. `NETSUKE_CONFIG_PATH` remains supported as a
    backward-compatible alias, but `NETSUKE_CONFIG` is the documented
    environment variable going forward.
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2034,9 +2034,9 @@ applies `Cli::with_default_command` after parsing so invoking `netsuke` with no
 explicit command still triggers a build. Configuration is layered with
 OrthoConfig (defaults, configuration files, environment variables, then CLI
 overrides) while treating clap defaults as absent so file or environment values
-are not masked. Explicit config selection respects `-C/--directory` for
-project-root discovery, and the precedence is `--config` > `NETSUKE_CONFIG` >
-legacy `NETSUKE_CONFIG_PATH`. Environment variables use the `NETSUKE_` prefix
+are not masked. Explicit config selection is resolved before discovery with
+precedence `--config` > `NETSUKE_CONFIG` > legacy `NETSUKE_CONFIG_PATH`; `-C/--directory`
+only affects project-root discovery. Environment variables use the `NETSUKE_` prefix
 with `__` as a nesting separator. CLI help and clap errors are localized via
 Fluent resources; locale resolution is handled in `src/locale_resolution.rs`
 with the precedence `--locale` -> `NETSUKE_LOCALE` -> configuration `locale` ->
@@ -2202,13 +2202,11 @@ override earlier ones—meaning project-scope has highest precedence among file
 layers. After file layers are merged, environment variables and CLI arguments
 override the merged result, ensuring explicit user intent always wins.
 
-1. **Explicit override**: the first configured selector from this list:
-   `--config <PATH>`, `NETSUKE_CONFIG`, `NETSUKE_CONFIG_PATH`. This allows
-   users to point to any arbitrary configuration file path, bypassing automatic
-   discovery entirely while still respecting the project-root anchor supplied
-   by `-C/--directory`. `NETSUKE_CONFIG_PATH` remains supported as a
-   backward-compatible alias, but `NETSUKE_CONFIG` is the documented
-   environment variable going forward.
+1. **Explicit override**: `--config <PATH>`, `NETSUKE_CONFIG`, and
+   `NETSUKE_CONFIG_PATH` are evaluated in that precedence order before
+   discovery. These explicit selectors bypass automatic discovery and ignore the
+   project-root anchor supplied by `-C/--directory`. `NETSUKE_CONFIG_PATH`
+   remains a backward-compatible alias of `NETSUKE_CONFIG`.
 
 2. **Project scope**: Configuration files in the current working directory (or
    the directory specified via `-C/--directory`):
@@ -2245,7 +2243,7 @@ directory.
 **Layer merge precedence** (lowest to highest):
 
 1. Application defaults (hardcoded in `Cli::default()`)
-2. Discovered configuration file (project or user scope, as above)
+2. Selected configuration file layer (explicit or discovered)
 3. Environment variables (prefixed with `NETSUKE_`, e.g., `NETSUKE_JOBS=4`)
 4. Command-line arguments (e.g., `--jobs 8`)
 
@@ -2261,17 +2259,18 @@ manual flag repetition.
   override, relying on OrthoConfig's platform-specific defaults for standard
   directory resolution.
 - The `merge_with_config()` function in `src/cli/config_merge.rs` orchestrates
-  the full layer composition: it calls `config_discovery()` to obtain file
-  layers, merges them with defaults, adds environment variables via Figment,
-  and finally applies CLI overrides extracted from `ArgMatches`.
+  the full layer composition: it resolves selection through
+  `resolve_config_path()`, calls `push_file_layers()` to load layers, merges them
+  with defaults, adds environment variables via Figment, and finally applies CLI
+  overrides extracted from `ArgMatches`.
 - Configuration files use TOML format by default. JSON5 (`.json`, `.json5`) and
   YAML (`.yaml`, `.yml`) formats are supported when the corresponding Cargo
   features are enabled.
-- Explicit config selection is handled outside OrthoConfig's built-in
-  discovery override surface because Netsuke needs its custom two-pass
-  project-over-user merge behaviour for automatic discovery. The selected file
-  still participates in the normal precedence ladder: defaults < file <
-  environment < CLI flags.
+- Explicit config selection is handled outside OrthoConfig's built-in discovery
+  override surface so Netsuke keeps its custom two-pass project-over-user merge
+  behaviour for automatic discovery. If an explicit selector is set, the selected
+  file is loaded directly and bypasses discovery, but still participates in the
+  normal precedence ladder: defaults < file < environment < CLI.
 - Relative paths passed to `--config` are resolved against the process current
   working directory, not the `-C/--directory` anchor. This keeps config-file
   selection aligned with normal shell path semantics while `-C` continues to

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2185,9 +2185,10 @@ flowchart LR
 Netsuke configuration discovery is implemented through OrthoConfig's
 `ConfigDiscovery` builder in `src/cli/config_merge.rs`. The
 `config_discovery()` helper constructs a discovery instance rooted at
-application name `"netsuke"`, honours the `NETSUKE_CONFIG_PATH` environment
-variable as an explicit override, and adjusts project-root discovery when the
-`-C/--directory` flag is supplied.
+application name `"netsuke"` and adjusts project-root discovery when the
+`-C/--directory` flag is supplied. Explicit file selection is handled before
+discovery by `resolve_config_path()`, which applies the precedence `--config` >
+`NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`.
 
 #### Discovery scopes and layered merging
 
@@ -2200,9 +2201,12 @@ override earlier ones—meaning project-scope has highest precedence among file
 layers. After file layers are merged, environment variables and CLI arguments
 override the merged result, ensuring explicit user intent always wins.
 
-1. **Explicit override**: `NETSUKE_CONFIG_PATH` environment variable, if set.
-   This allows users to point to any arbitrary configuration file path,
-   bypassing automatic discovery entirely.
+1. **Explicit override**: the first configured selector from this list:
+   `--config <PATH>`, `NETSUKE_CONFIG`, `NETSUKE_CONFIG_PATH`. This allows
+   users to point to any arbitrary configuration file path, bypassing automatic
+   discovery entirely. `NETSUKE_CONFIG_PATH` remains supported as a
+   backward-compatible alias, but `NETSUKE_CONFIG` is the documented
+   environment variable going forward.
 
 2. **Project scope**: Configuration files in the current working directory (or
    the directory specified via `-C/--directory`):
@@ -2261,10 +2265,15 @@ manual flag repetition.
 - Configuration files use TOML format by default. JSON5 (`.json`, `.json5`) and
   YAML (`.yaml`, `.yml`) formats are supported when the corresponding Cargo
   features are enabled.
-- The current implementation uses `NETSUKE_CONFIG_PATH` for the override
-  environment variable. Roadmap item 3.11.3 plans to expose a visible
-  `--config` CLI flag and rename the environment variable to `NETSUKE_CONFIG`
-  for improved user ergonomics.
+- Explicit config selection is handled outside OrthoConfig's built-in
+  discovery override surface because Netsuke needs its custom two-pass
+  project-over-user merge behaviour for automatic discovery. The selected file
+  still participates in the normal precedence ladder: defaults < file <
+  environment < CLI flags.
+- Relative paths passed to `--config` are resolved against the process current
+  working directory, not the `-C/--directory` anchor. This keeps config-file
+  selection aligned with normal shell path semantics while `-C` continues to
+  scope project discovery and manifest lookup.
 
 ### 8.5 Manual Pages
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2191,6 +2191,66 @@ application name `"netsuke"` and adjusts project-root discovery when the
 discovery by `resolve_config_path()`, which applies the precedence `--config` >
 `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`.
 
+**Figure: Explicit Config Selector Resolution** — This diagram shows how
+Netsuke chooses the configuration file before automatic discovery. Netsuke first
+checks `--config`, then `NETSUKE_CONFIG`, then `NETSUKE_CONFIG_PATH`. The first
+explicit selector found is loaded directly; if that file is missing or invalid,
+Netsuke reports the explicit-file error instead of falling back to discovery.
+Only when no explicit selector is present does Netsuke run two-pass config
+discovery and then proceed with the merged configuration.
+
+```mermaid
+flowchart TD
+  Start([Start netsuke invocation])
+  HasCliConfig{CLI flag
+  --config set?}
+  HasEnvConfig{Env NETSUKE_CONFIG
+  set?}
+  HasEnvConfigPath{Env NETSUKE_CONFIG_PATH
+  set?}
+  UseCliConfig[[Use CLI --config path
+  as config file]]
+  UseEnvConfig[[Use NETSUKE_CONFIG path
+  as config file]]
+  UseEnvConfigPath[[Use NETSUKE_CONFIG_PATH path
+  as config file]]
+  RunDiscovery[[Run two-pass
+  config discovery]]
+  LoadConfig[[Load selected config
+  into merge pipeline]]
+  ErrorMissing[[Error: explicit config
+  file missing or invalid]]
+
+  Start --> HasCliConfig
+  HasCliConfig -- Yes --> UseCliConfig
+  HasCliConfig -- No --> HasEnvConfig
+
+  HasEnvConfig -- Yes --> UseEnvConfig
+  HasEnvConfig -- No --> HasEnvConfigPath
+
+  HasEnvConfigPath -- Yes --> UseEnvConfigPath
+  HasEnvConfigPath -- No --> RunDiscovery
+
+  UseCliConfig --> CheckCliFile{File exists
+  and parses?}
+  CheckCliFile -- Yes --> LoadConfig
+  CheckCliFile -- No --> ErrorMissing
+
+  UseEnvConfig --> CheckEnvFile{File exists
+  and parses?}
+  CheckEnvFile -- Yes --> LoadConfig
+  CheckEnvFile -- No --> ErrorMissing
+
+  UseEnvConfigPath --> CheckEnvPathFile{File exists
+  and parses?}
+  CheckEnvPathFile -- Yes --> LoadConfig
+  CheckEnvPathFile -- No --> ErrorMissing
+
+  RunDiscovery --> LoadConfig
+  LoadConfig --> End([Proceed with merged config])
+  ErrorMissing --> End
+```
+
 #### Discovery scopes and layered merging
 
 Configuration discovery searches multiple scopes and composes all discovered

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2035,29 +2035,29 @@ explicit command still triggers a build. Configuration is layered with
 OrthoConfig (defaults, configuration files, environment variables, then CLI
 overrides) while treating clap defaults as absent so file or environment values
 are not masked. Explicit config selection is resolved before discovery with
-precedence `--config` > `NETSUKE_CONFIG` > legacy `NETSUKE_CONFIG_PATH`; `-C/--directory`
-only affects project-root discovery. Environment variables use the `NETSUKE_` prefix
-with `__` as a nesting separator. CLI help and clap errors are localized via
-Fluent resources; locale resolution is handled in `src/locale_resolution.rs`
-with the precedence `--locale` -> `NETSUKE_LOCALE` -> configuration `locale` ->
-system default. System locale strings are normalized by stripping encoding
-suffixes (such as `.UTF-8`), removing variant suffixes (such as `@latin`), and
-replacing underscores with hyphens before validation. English plus Spanish
-catalogues ship in `locales/`; unsupported locales fall back to `en-US`.
-Runtime diagnostics (for example manifest parsing, stdlib template errors, and
-runner failures) use the same Fluent localizer so the locale selection is
-consistent across user-facing output. A build-time audit in `build.rs`
-validates that all referenced Fluent message keys exist in the bundled
-catalogues, ensuring missing strings fail CI before release. CLI execution and
-dispatch live in `src/runner.rs`, keeping `main.rs` focused on parsing. Process
-management, Ninja invocation, argument redaction, and the temporary file
-helpers reside in `src/runner/process.rs`, allowing the runner entry point to
-delegate low-level concerns. The working directory flag mirrors Ninja's `-C`
-option but is resolved internally: Netsuke runs Ninja with a configured working
-directory and resolves relative output paths (for example `build --emit` and
-`manifest`) under the same directory so behaviour matches a real directory
-change. Error scenarios are validated using clap's `ErrorKind` enumeration in
-unit tests and via Cucumber steps for behavioural coverage.
+precedence `--config` > `NETSUKE_CONFIG` > legacy `NETSUKE_CONFIG_PATH`;
+`-C/--directory` only affects project-root discovery. Environment variables use
+the `NETSUKE_` prefix with `__` as a nesting separator. CLI help and clap
+errors are localized via Fluent resources; locale resolution is handled in
+`src/locale_resolution.rs` with the precedence `--locale` -> `NETSUKE_LOCALE`
+-> configuration `locale` -> system default. System locale strings are
+normalized by stripping encoding suffixes (such as `.UTF-8`), removing variant
+suffixes (such as `@latin`), and replacing underscores with hyphens before
+validation. English plus Spanish catalogues ship in `locales/`; unsupported
+locales fall back to `en-US`. Runtime diagnostics (for example manifest
+parsing, stdlib template errors, and runner failures) use the same Fluent
+localizer so the locale selection is consistent across user-facing output. A
+build-time audit in `build.rs` validates that all referenced Fluent message
+keys exist in the bundled catalogues, ensuring missing strings fail CI before
+release. CLI execution and dispatch live in `src/runner.rs`, keeping `main.rs`
+focused on parsing. Process management, Ninja invocation, argument redaction,
+and the temporary file helpers reside in `src/runner/process.rs`, allowing the
+runner entry point to delegate low-level concerns. The working directory flag
+mirrors Ninja's `-C` option but is resolved internally: Netsuke runs Ninja with
+a configured working directory and resolves relative output paths (for example
+`build --emit` and `manifest`) under the same directory so behaviour matches a
+real directory change. Error scenarios are validated using clap's `ErrorKind`
+enumeration in unit tests and via Cucumber steps for behavioural coverage.
 
 Real-time stage reporting now uses a six-stage model in `src/status.rs` backed
 by `indicatif::MultiProgress` for standard terminals. The reporter keeps one
@@ -2204,8 +2204,8 @@ override the merged result, ensuring explicit user intent always wins.
 
 1. **Explicit override**: `--config <PATH>`, `NETSUKE_CONFIG`, and
    `NETSUKE_CONFIG_PATH` are evaluated in that precedence order before
-   discovery. These explicit selectors bypass automatic discovery and ignore the
-   project-root anchor supplied by `-C/--directory`. `NETSUKE_CONFIG_PATH`
+   discovery. These explicit selectors bypass automatic discovery and ignore
+   the project-root anchor supplied by `-C/--directory`. `NETSUKE_CONFIG_PATH`
    remains a backward-compatible alias of `NETSUKE_CONFIG`.
 
 2. **Project scope**: Configuration files in the current working directory (or
@@ -2260,17 +2260,18 @@ manual flag repetition.
   directory resolution.
 - The `merge_with_config()` function in `src/cli/config_merge.rs` orchestrates
   the full layer composition: it resolves selection through
-  `resolve_config_path()`, calls `push_file_layers()` to load layers, merges them
-  with defaults, adds environment variables via Figment, and finally applies CLI
-  overrides extracted from `ArgMatches`.
+  `resolve_config_path()`, calls `push_file_layers()` to load layers, merges
+  them with defaults, adds environment variables via Figment, and finally
+  applies CLI overrides extracted from `ArgMatches`.
 - Configuration files use TOML format by default. JSON5 (`.json`, `.json5`) and
   YAML (`.yaml`, `.yml`) formats are supported when the corresponding Cargo
   features are enabled.
 - Explicit config selection is handled outside OrthoConfig's built-in discovery
   override surface so Netsuke keeps its custom two-pass project-over-user merge
-  behaviour for automatic discovery. If an explicit selector is set, the selected
-  file is loaded directly and bypasses discovery, but still participates in the
-  normal precedence ladder: defaults < file < environment < CLI.
+  behaviour for automatic discovery. If an explicit selector is set, the
+  selected file is loaded directly and bypasses discovery, but still
+  participates in the normal precedence ladder: defaults < file < environment <
+  CLI.
 - Relative paths passed to `--config` are resolved against the process current
   working directory, not the `-C/--directory` anchor. This keeps config-file
   selection aligned with normal shell path semantics while `-C` continues to

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -293,9 +293,9 @@ library, and CLI ergonomics.
   - [x] Add integration tests for each precedence tier. See
     [ortho-config-users-guide.md](ortho-config-users-guide.md) and
     `tests/cli_tests/config_discovery.rs`.
-- [ ] 3.11.3. Expose `--config <path>` and `NETSUKE_CONFIG`.
-  - [ ] Select alternative config files.
-  - [ ] Ship annotated sample configs in documentation.
+- [x] 3.11.3. Expose `--config <path>` and `NETSUKE_CONFIG`.
+  - [x] Select alternative config files.
+  - [x] Ship annotated sample configs in documentation.
 - [ ] 3.11.4. Add regression tests for OrthoConfig precedence ladder.
   - [ ] Test defaults < file < env < CLI precedence. See
     [ortho-config-users-guide.md](ortho-config-users-guide.md).

--- a/docs/sample-netsuke.toml
+++ b/docs/sample-netsuke.toml
@@ -1,0 +1,63 @@
+# Sample Netsuke configuration
+#
+# Copy this file to `.netsuke.toml` in a project root, or point Netsuke at it
+# with `--config /path/to/file.toml` or `NETSUKE_CONFIG=/path/to/file.toml`.
+#
+# All settings below are commented out so the file is valid as-is. Uncomment
+# only the keys you want to change.
+
+# Path to the manifest file to use instead of `Netsukefile`.
+# file = "Netsukefile"
+
+# Number of parallel build jobs. Valid range: 1-64.
+# jobs = 8
+
+# Enable verbose diagnostics and timing summaries.
+# verbose = true
+
+# Locale for CLI messages, for example `en-US` or `es-ES`.
+# locale = "en-US"
+
+# Force accessible output mode on or off.
+# accessible = true
+
+# Suppress emoji glyphs in output.
+# no_emoji = false
+
+# Theme preset: `auto`, `unicode`, or `ascii`.
+# theme = "auto"
+
+# Colour output policy: `auto`, `always`, or `never`.
+# colour_policy = "auto"
+
+# Force standard stage and task progress summaries on or off.
+# progress = true
+
+# Spinner mode: `enabled` or `disabled`.
+# spinner_mode = "enabled"
+
+# Emit machine-readable diagnostics on stderr.
+# diag_json = false
+
+# Diagnostic output format: `human` or `json`.
+# output_format = "human"
+
+# Default build targets when the CLI does not name any targets.
+# default_targets = ["fmt", "lint", "test"]
+
+# Additional URL schemes allowed for the `fetch` helper.
+# fetch_allow_scheme = ["https"]
+
+# Hostnames allowed when `fetch_default_deny = true`.
+# Supports wildcards such as `*.example.com`.
+# fetch_allow_host = ["example.com", "*.example.com"]
+
+# Hostnames that are always blocked.
+# Supports wildcards such as `*.example.com`.
+# fetch_block_host = ["metadata.internal"]
+
+# Deny all fetch hosts by default and allow only the declared allowlist.
+# fetch_default_deny = false
+
+# CLI-only controls such as `--config`, `--directory`, and subcommands are not
+# read from config files.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -548,10 +548,17 @@ command-line flags.
 
 #### Configuration file discovery
 
-Configuration files are discovered using OrthoConfig. When
-`NETSUKE_CONFIG_PATH` is set, it points to a single file and bypasses all
-automatic discovery. Otherwise, Netsuke searches for configuration in three
-scopes:
+Configuration files are discovered using OrthoConfig unless you select an
+explicit file. Netsuke honours these file-selection inputs in precedence order:
+
+- `--config <PATH>`
+- `NETSUKE_CONFIG=<PATH>`
+- `NETSUKE_CONFIG_PATH=<PATH>` (legacy alias)
+- Automatic discovery
+
+When one of the explicit selectors is set, Netsuke loads only that file and
+skips automatic discovery. Otherwise, Netsuke searches for configuration in
+three scopes:
 
 - **Project scope** — `.netsuke.toml` in the current working directory
   (or the directory specified by `-C` / `--directory`).
@@ -571,6 +578,10 @@ the project file overrides the same field from user or system files, user-scope
 settings override system-scope, and fields set only in lower-precedence files
 are still applied.
 
+The explicit config path is resolved against the shell's current working
+directory, not the `-C` / `--directory` project anchor. The directory flag only
+changes where project-scope discovery and manifest lookup begin.
+
 #### Directory flag and project anchoring
 
 The `-C <DIR>` / `--directory <DIR>` flag re-anchors project-scope discovery to
@@ -584,6 +595,10 @@ netsuke -C /path/to/project build
 
 With the flag, only `/path/to/project/.netsuke.toml` is considered for
 project-scope discovery; user-scope discovery is unaffected.
+
+For a documented starting point, see
+[`docs/sample-netsuke.toml`](sample-netsuke.toml), which annotates every
+supported config-file key.
 
 #### Environment variables
 

--- a/locales/en-US/messages.ftl
+++ b/locales/en-US/messages.ftl
@@ -7,6 +7,7 @@ cli.usage = { $usage }
 # Root-level flag help text.
 cli.flag.file.help = Path to the Netsuke manifest file to use.
 cli.flag.directory.help = Run as if started in this directory.
+cli.flag.config.help = Path to a configuration file, bypassing automatic discovery.
 cli.flag.jobs.help = Set the number of parallel build jobs.
 cli.flag.verbose.help = Enable verbose diagnostic logging and completion timing summaries.
 cli.flag.locale.help = Locale tag for CLI copy (for example: en-US, es-ES).

--- a/locales/es-ES/messages.ftl
+++ b/locales/es-ES/messages.ftl
@@ -7,6 +7,7 @@ cli.usage = { $usage }
 # Texto de ayuda para opciones globales.
 cli.flag.file.help = Ruta al archivo de manifiesto Netsuke.
 cli.flag.directory.help = Ejecutar como si se iniciara en este directorio.
+cli.flag.config.help = Ruta a un archivo de configuración, omitiendo la detección automática.
 cli.flag.jobs.help = Número de trabajos de compilación en paralelo.
 cli.flag.verbose.help = Habilitar registro de diagnóstico detallado y resúmenes de tiempo al completar.
 cli.flag.locale.help = Etiqueta de idioma para la CLI (por ejemplo: en-US, es-ES).

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -207,20 +207,30 @@ pub fn resolve_merged_diag_json(cli: &Cli, matches: &ArgMatches) -> bool {
 /// Implements "project scope > user scope" by running a second direct load of
 /// the project-scope file when first-pass discovery did not include it and no
 /// explicit config path is active.
+///
+/// Drain a layer-load result onto `composer`, recording any error.
+fn push_layers_result(
+    composer: &mut MergeComposer,
+    errors: &mut Vec<Arc<ortho_config::OrthoError>>,
+    result: Result<Vec<MergeLayer<'static>>, Arc<ortho_config::OrthoError>>,
+) {
+    match result {
+        Ok(layers) => {
+            for layer in layers {
+                composer.push_layer(layer);
+            }
+        }
+        Err(err) => errors.push(err),
+    }
+}
+
 fn push_file_layers(
     composer: &mut MergeComposer,
     errors: &mut Vec<Arc<ortho_config::OrthoError>>,
     cli: &Cli,
 ) {
     if let Some(path) = resolve_config_path(cli) {
-        match load_layers_from_path(&path) {
-            Ok(layers) => {
-                for layer in layers {
-                    composer.push_layer(layer);
-                }
-            }
-            Err(err) => errors.push(err),
-        }
+        push_layers_result(composer, errors, load_layers_from_path(&path));
         return;
     }
 
@@ -242,14 +252,11 @@ fn push_file_layers(
     }
 
     if !first_pass_found_project {
-        match project_scope_layers(cli.directory.as_deref()) {
-            Ok(layers) => {
-                for layer in layers {
-                    composer.push_layer(layer);
-                }
-            }
-            Err(err) => errors.push(err),
-        }
+        push_layers_result(
+            composer,
+            errors,
+            project_scope_layers(cli.directory.as_deref()),
+        );
     }
 }
 

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -49,8 +49,7 @@ fn env_config_path(var_name: &str) -> Option<PathBuf> {
 
 fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
     cli.config
-        .as_ref()
-        .map(PathBuf::from)
+        .clone()
         .or_else(|| env_config_path(CONFIG_ENV_VAR))
         .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
 }

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -133,10 +133,10 @@ fn diag_json_from_layer(value: &serde_json::Value) -> Option<bool> {
 ///
 /// Mirrors the two-pass logic of [`push_file_layers`] without a `MergeComposer`.
 ///
-/// If project-scope layer loading fails, this function falls back to the first-pass
-/// layers (global and user configs) rather than propagating an error. An explicit
-/// explicit config path will also cause the function to return early with the
-/// selected file only.
+/// If project-scope layer loading fails, this function falls back to the
+/// first-pass layers (global and user configs) rather than propagating an
+/// error. An explicit config path returns the selected file's layers, or an
+/// empty set when the selected file cannot be loaded.
 fn collect_diag_file_layers(cli: &Cli) -> Vec<MergeLayer<'static>> {
     if let Some(path) = resolve_config_path(cli) {
         return load_layers_from_path(&path).unwrap_or_default();

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -9,17 +9,18 @@ use ortho_config::declarative::LayerComposition;
 use ortho_config::figment::{Figment, providers::Env};
 use ortho_config::uncased::Uncased;
 use ortho_config::{
-    ConfigDiscovery, LocalizationArgs, MergeComposer, MergeLayer, OrthoMergeExt, OrthoResult,
-    load_config_file_as_chain, sanitize_value,
+    ConfigDiscovery, LocalizationArgs, MergeComposer, MergeLayer, OrthoError, OrthoMergeExt,
+    OrthoResult, load_config_file_as_chain, sanitize_value,
 };
 use std::borrow::Cow;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::localization::{self, keys};
 
 use super::config::OutputFormat;
-use super::{CONFIG_ENV_VAR, Cli, ENV_PREFIX, validation_message};
+use super::{CONFIG_ENV_VAR, CONFIG_ENV_VAR_LEGACY, Cli, ENV_PREFIX, validation_message};
 
 /// Return the default manifest filename when none is provided.
 pub(super) fn default_manifest_path() -> PathBuf {
@@ -31,16 +32,44 @@ fn env_provider() -> Env {
     Env::prefixed(ENV_PREFIX)
 }
 
-/// Build the single-pass discovery used when `NETSUKE_CONFIG_PATH` is set.
-///
-/// When the env var is present `compose_layers` will find it first and return
-/// immediately, so project-vs-user ordering is irrelevant.
+/// Build the automatic discovery used when no explicit config path is set.
 fn config_discovery(directory: Option<&Path>) -> ConfigDiscovery {
-    let mut builder = ConfigDiscovery::builder("netsuke").env_var(CONFIG_ENV_VAR);
+    let mut builder = ConfigDiscovery::builder("netsuke");
     if let Some(dir) = directory {
         builder = builder.clear_project_roots().add_project_root(dir);
     }
     builder.build()
+}
+
+fn env_config_path(var_name: &str) -> Option<PathBuf> {
+    std::env::var_os(var_name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
+    cli.config
+        .clone()
+        .or_else(|| env_config_path(CONFIG_ENV_VAR))
+        .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
+}
+
+fn load_layers_from_path(path: &Path) -> OrthoResult<Vec<MergeLayer<'static>>> {
+    match load_config_file_as_chain(path) {
+        Ok(Some(chain)) => Ok(chain
+            .values
+            .into_iter()
+            .map(|(value, layer_path)| MergeLayer::file(Cow::Owned(value), Some(layer_path)))
+            .collect()),
+        Ok(None) => Err(Arc::new(OrthoError::File {
+            path: path.to_path_buf(),
+            source: Box::new(io::Error::new(
+                io::ErrorKind::NotFound,
+                "explicit configuration file not found",
+            )),
+        })),
+        Err(err) => Err(err),
+    }
 }
 
 /// Return the expected project-scope config file path as a string, if
@@ -106,21 +135,26 @@ fn diag_json_from_layer(value: &serde_json::Value) -> Option<bool> {
 ///
 /// If project-scope layer loading fails, this function falls back to the first-pass
 /// layers (global and user configs) rather than propagating an error. An explicit
-/// `NETSUKE_CONFIG_PATH` environment variable override will also cause the function
-/// to return early with the first-pass layers only.
-fn collect_diag_file_layers(directory: Option<&Path>) -> Vec<MergeLayer<'static>> {
-    let discovery = config_discovery(directory);
+/// explicit config path will also cause the function to return early with the
+/// selected file only.
+fn collect_diag_file_layers(cli: &Cli) -> Vec<MergeLayer<'static>> {
+    if let Some(path) = resolve_config_path(cli)
+        && let Ok(layers) = load_layers_from_path(&path)
+    {
+        return layers;
+    }
+
+    let discovery = config_discovery(cli.directory.as_deref());
     let file_layers = discovery.compose_layers().value;
-    let project_file = project_scope_file_str(directory);
+    let project_file = project_scope_file_str(cli.directory.as_deref());
     let first_pass_found_project = file_layers.iter().any(|l| {
         l.path()
             .is_some_and(|p| project_file.as_deref() == Some(p.as_str()))
     });
-    let has_explicit_config = std::env::var_os(CONFIG_ENV_VAR).is_some_and(|v| !v.is_empty());
-    if first_pass_found_project || has_explicit_config {
+    if first_pass_found_project {
         file_layers
     } else {
-        match project_scope_layers(directory) {
+        match project_scope_layers(cli.directory.as_deref()) {
             Ok(project_layers) => file_layers.into_iter().chain(project_layers).collect(),
             Err(_) => file_layers,
         }
@@ -148,7 +182,7 @@ fn diag_json_from_matches(cli: &Cli, matches: &ArgMatches, discovered: bool) -> 
 pub fn resolve_merged_diag_json(cli: &Cli, matches: &ArgMatches) -> bool {
     let mut diag_json = Cli::default().diag_json;
 
-    let layers = collect_diag_file_layers(cli.directory.as_deref());
+    let layers = collect_diag_file_layers(cli);
     for layer in layers {
         let layer_value = layer.into_value();
         if let Some(layer_diag_json) = diag_json_from_layer(&layer_value) {
@@ -172,20 +206,32 @@ pub fn resolve_merged_diag_json(cli: &Cli, matches: &ArgMatches) -> bool {
 ///
 /// Implements "project scope > user scope" by running a second direct load of
 /// the project-scope file when first-pass discovery did not include it and no
-/// explicit config-path override is active.
+/// explicit config path is active.
 fn push_file_layers(
     composer: &mut MergeComposer,
     errors: &mut Vec<Arc<ortho_config::OrthoError>>,
-    directory: Option<&Path>,
+    cli: &Cli,
 ) {
-    let discovery = config_discovery(directory);
+    if let Some(path) = resolve_config_path(cli) {
+        match load_layers_from_path(&path) {
+            Ok(layers) => {
+                for layer in layers {
+                    composer.push_layer(layer);
+                }
+            }
+            Err(err) => errors.push(err),
+        }
+        return;
+    }
+
+    let discovery = config_discovery(cli.directory.as_deref());
     let mut file_layers = discovery.compose_layers();
     errors.append(&mut file_layers.required_errors);
     if file_layers.value.is_empty() {
         errors.append(&mut file_layers.optional_errors);
     }
 
-    let project_file = project_scope_file_str(directory);
+    let project_file = project_scope_file_str(cli.directory.as_deref());
     let first_pass_found_project = file_layers.value.iter().any(|l| {
         l.path()
             .is_some_and(|p| project_file.as_deref() == Some(p.as_str()))
@@ -195,9 +241,8 @@ fn push_file_layers(
         composer.push_layer(layer);
     }
 
-    let has_explicit_config = std::env::var_os(CONFIG_ENV_VAR).is_some_and(|v| !v.is_empty());
-    if !first_pass_found_project && !has_explicit_config {
-        match project_scope_layers(directory) {
+    if !first_pass_found_project {
+        match project_scope_layers(cli.directory.as_deref()) {
             Ok(layers) => {
                 for layer in layers {
                     composer.push_layer(layer);
@@ -271,7 +316,7 @@ pub fn merge_with_config(cli: &Cli, matches: &ArgMatches) -> OrthoResult<Cli> {
         Err(err) => errors.push(err),
     }
 
-    push_file_layers(&mut composer, &mut errors, cli.directory.as_deref());
+    push_file_layers(&mut composer, &mut errors, cli);
 
     let env_provider = env_provider()
         .map(|key| Uncased::new(key.as_str().to_ascii_uppercase()))

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -49,7 +49,8 @@ fn env_config_path(var_name: &str) -> Option<PathBuf> {
 
 fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
     cli.config
-        .clone()
+        .as_ref()
+        .map(PathBuf::from)
         .or_else(|| env_config_path(CONFIG_ENV_VAR))
         .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
 }

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -138,10 +138,8 @@ fn diag_json_from_layer(value: &serde_json::Value) -> Option<bool> {
 /// explicit config path will also cause the function to return early with the
 /// selected file only.
 fn collect_diag_file_layers(cli: &Cli) -> Vec<MergeLayer<'static>> {
-    if let Some(path) = resolve_config_path(cli)
-        && let Ok(layers) = load_layers_from_path(&path)
-    {
-        return layers;
+    if let Some(path) = resolve_config_path(cli) {
+        return load_layers_from_path(&path).unwrap_or_default();
     }
 
     let discovery = config_discovery(cli.directory.as_deref());

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -47,9 +47,14 @@ fn env_config_path(var_name: &str) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+#[expect(
+    clippy::option_as_ref_cloned,
+    reason = "make cloning the selected config path explicit"
+)]
 fn resolve_config_path(cli: &Cli) -> Option<PathBuf> {
     cli.config
-        .clone()
+        .as_ref()
+        .cloned()
         .or_else(|| env_config_path(CONFIG_ENV_VAR))
         .or_else(|| env_config_path(CONFIG_ENV_VAR_LEGACY))
 }

--- a/src/cli/config_merge.rs
+++ b/src/cli/config_merge.rs
@@ -200,12 +200,6 @@ pub fn resolve_merged_diag_json(cli: &Cli, matches: &ArgMatches) -> bool {
     diag_json_from_matches(cli, matches, diag_json)
 }
 
-/// Push all config-file layers onto `composer` in the correct precedence order.
-///
-/// Implements "project scope > user scope" by running a second direct load of
-/// the project-scope file when first-pass discovery did not include it and no
-/// explicit config path is active.
-///
 /// Drain a layer-load result onto `composer`, recording any error.
 fn push_layers_result(
     composer: &mut MergeComposer,
@@ -222,6 +216,14 @@ fn push_layers_result(
     }
 }
 
+/// Push all config-file layers onto `composer` in the correct precedence order.
+///
+/// When an explicit config path is active (`--config`, `NETSUKE_CONFIG`, or
+/// `NETSUKE_CONFIG_PATH`) only that file is loaded and automatic discovery is
+/// skipped.  When no explicit selector is active the function runs two-pass
+/// discovery: a combined project-and-user discovery pass, followed by a
+/// second direct load of the project-scope file when the first pass did not
+/// include it.  This ensures "project scope > user scope" layering.
 fn push_file_layers(
     composer: &mut MergeComposer,
     errors: &mut Vec<Arc<ortho_config::OrthoError>>,

--- a/src/cli/config_merge_tests.rs
+++ b/src/cli/config_merge_tests.rs
@@ -290,3 +290,120 @@ fn push_file_layers_pushes_expected_layer_count(
         "unexpected number of layers pushed"
     );
 }
+
+// -----------------------------------------------------------------------
+// env_config_path
+// -----------------------------------------------------------------------
+
+#[test]
+fn env_config_path_returns_none_when_var_unset() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _guard = EnvVarGuard::remove("__NETSUKE_TEST_VAR");
+    assert!(env_config_path("__NETSUKE_TEST_VAR").is_none());
+}
+
+#[test]
+fn env_config_path_returns_none_when_var_empty() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _guard = EnvVarGuard::set("__NETSUKE_TEST_VAR", std::ffi::OsStr::new(""));
+    assert!(env_config_path("__NETSUKE_TEST_VAR").is_none());
+}
+
+#[test]
+fn env_config_path_returns_path_when_var_set() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _guard = EnvVarGuard::set("__NETSUKE_TEST_VAR", std::ffi::OsStr::new("/tmp/foo.toml"));
+    let result = env_config_path("__NETSUKE_TEST_VAR");
+    assert_eq!(result, Some(std::path::PathBuf::from("/tmp/foo.toml")));
+}
+
+// -----------------------------------------------------------------------
+// resolve_config_path
+// -----------------------------------------------------------------------
+
+#[test]
+fn resolve_config_path_cli_wins_over_env() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
+    let _legacy_guard = EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY);
+    let cli = Cli {
+        config: Some(std::path::PathBuf::from("/cli/path.toml")),
+        ..Cli::default()
+    };
+    assert_eq!(
+        resolve_config_path(&cli),
+        Some(std::path::PathBuf::from("/cli/path.toml")),
+        "cli.config should take precedence over CONFIG_ENV_VAR"
+    );
+}
+
+#[test]
+fn resolve_config_path_env_wins_over_legacy() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
+    let _legacy_guard = EnvVarGuard::set(
+        CONFIG_ENV_VAR_LEGACY,
+        std::ffi::OsStr::new("/legacy/path.toml"),
+    );
+    let cli = Cli::default();
+    assert_eq!(
+        resolve_config_path(&cli),
+        Some(std::path::PathBuf::from("/env/path.toml")),
+        "CONFIG_ENV_VAR should take precedence over CONFIG_ENV_VAR_LEGACY"
+    );
+}
+
+#[test]
+fn resolve_config_path_legacy_used_when_primary_absent() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _env_guard = EnvVarGuard::remove(CONFIG_ENV_VAR);
+    let _legacy_guard = EnvVarGuard::set(
+        CONFIG_ENV_VAR_LEGACY,
+        std::ffi::OsStr::new("/legacy/path.toml"),
+    );
+    let cli = Cli::default();
+    assert_eq!(
+        resolve_config_path(&cli),
+        Some(std::path::PathBuf::from("/legacy/path.toml")),
+        "CONFIG_ENV_VAR_LEGACY should be used when primary env var absent"
+    );
+}
+
+#[test]
+fn resolve_config_path_returns_none_when_all_absent() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _env_guard = EnvVarGuard::remove(CONFIG_ENV_VAR);
+    let _legacy_guard = EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY);
+    let cli = Cli::default();
+    assert!(
+        resolve_config_path(&cli).is_none(),
+        "should return None when no selector is active"
+    );
+}
+
+#[test]
+fn resolve_config_path_cli_wins_over_both_env_vars() {
+    use test_support::env_lock::EnvLock;
+    let _lock = EnvLock::acquire();
+    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
+    let _legacy_guard = EnvVarGuard::set(
+        CONFIG_ENV_VAR_LEGACY,
+        std::ffi::OsStr::new("/legacy/path.toml"),
+    );
+    let cli = Cli {
+        config: Some(std::path::PathBuf::from("/cli/path.toml")),
+        ..Cli::default()
+    };
+    assert_eq!(
+        resolve_config_path(&cli),
+        Some(std::path::PathBuf::from("/cli/path.toml")),
+        "cli.config should win over both env vars"
+    );
+}

--- a/src/cli/config_merge_tests.rs
+++ b/src/cli/config_merge_tests.rs
@@ -8,6 +8,13 @@ use serde_json::json;
 use tempfile::tempdir;
 use test_support::{CwdGuard, EnvVarGuard};
 
+fn cli_with_directory(directory: &std::path::Path) -> Cli {
+    Cli {
+        directory: Some(directory.to_path_buf()),
+        ..Cli::default()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // is_empty_value
 // ---------------------------------------------------------------------------
@@ -156,7 +163,7 @@ fn project_scope_layers_returns_one_layer_when_file_present() {
 ///
 /// Returns (`EnvLock`, `project_dir`, `fake_home`, `env_guards`) where `env_guards`
 /// isolate `HOME` and platform-specific config paths (`XDG_CONFIG_HOME` on Unix,
-/// `APPDATA`/`LOCALAPPDATA` on Windows) and remove `CONFIG_ENV_VAR`.
+/// `APPDATA`/`LOCALAPPDATA` on Windows) and remove explicit config selectors.
 #[cfg(test)]
 #[fixture]
 fn isolated_config_env() -> anyhow::Result<(
@@ -175,6 +182,7 @@ fn isolated_config_env() -> anyhow::Result<(
         EnvVarGuard::set("HOME", fake_home.path().as_os_str()),
         EnvVarGuard::set("XDG_CONFIG_HOME", fake_home.path().as_os_str()),
         EnvVarGuard::remove(CONFIG_ENV_VAR),
+        EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY),
     ];
 
     #[cfg(windows)]
@@ -183,6 +191,7 @@ fn isolated_config_env() -> anyhow::Result<(
         EnvVarGuard::set("APPDATA", fake_home.path().as_os_str()),
         EnvVarGuard::set("LOCALAPPDATA", fake_home.path().as_os_str()),
         EnvVarGuard::remove(CONFIG_ENV_VAR),
+        EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY),
     ];
 
     Ok((lock, dir, fake_home, guards))
@@ -208,7 +217,8 @@ fn collect_diag_file_layers_handles_project_file_presence(
             .expect("write config");
     }
 
-    let layers = collect_diag_file_layers(Some(dir.path()));
+    let cli = cli_with_directory(dir.path());
+    let layers = collect_diag_file_layers(&cli);
 
     if expect_empty {
         ensure!(layers.is_empty(), "expected no layers when file absent");
@@ -270,7 +280,9 @@ fn push_file_layers_pushes_expected_layer_count(
     #[cfg(windows)]
     let _local_appdata_guard = EnvVarGuard::set("LOCALAPPDATA", fake_home.path().as_os_str());
     let _config_guard = EnvVarGuard::remove(CONFIG_ENV_VAR);
-    push_file_layers(&mut composer, &mut errors, Some(dir.path()));
+    let _legacy_config_guard = EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY);
+    let cli = cli_with_directory(dir.path());
+    push_file_layers(&mut composer, &mut errors, &cli);
     assert!(errors.is_empty(), "no required errors expected");
     assert_eq!(
         composer.layers().len(),

--- a/src/cli/config_merge_tests.rs
+++ b/src/cli/config_merge_tests.rs
@@ -6,7 +6,7 @@ use clap::CommandFactory;
 use rstest::{fixture, rstest};
 use serde_json::json;
 use tempfile::tempdir;
-use test_support::{CwdGuard, EnvVarGuard};
+use test_support::{CwdGuard, EnvVarGuard, env_lock::EnvLock};
 
 fn cli_with_directory(directory: &std::path::Path) -> Cli {
     Cli {
@@ -324,60 +324,59 @@ fn env_config_path_returns_path_when_var_set() {
 // resolve_config_path
 // -----------------------------------------------------------------------
 
-#[test]
-fn resolve_config_path_cli_wins_over_env() {
-    use test_support::env_lock::EnvLock;
+#[rstest]
+#[case::cli_wins_over_env(
+    (Some("/env/path.toml"), None),
+    Some("/cli/path.toml"),
+    Some("/cli/path.toml"),
+    "cli.config should take precedence over CONFIG_ENV_VAR"
+)]
+#[case::env_wins_over_legacy(
+    (Some("/env/path.toml"), Some("/legacy/path.toml")),
+    None,
+    Some("/env/path.toml"),
+    "CONFIG_ENV_VAR should take precedence over CONFIG_ENV_VAR_LEGACY"
+)]
+#[case::legacy_used_when_primary_absent(
+    (None, Some("/legacy/path.toml")),
+    None,
+    Some("/legacy/path.toml"),
+    "CONFIG_ENV_VAR_LEGACY should be used when primary env var absent"
+)]
+#[case::cli_wins_over_both_env_vars(
+    (Some("/env/path.toml"), Some("/legacy/path.toml")),
+    Some("/cli/path.toml"),
+    Some("/cli/path.toml"),
+    "cli.config should win over both env vars"
+)]
+fn resolve_config_path_precedence(
+    #[case] env_vars: (Option<&'static str>, Option<&'static str>),
+    #[case] cli_config: Option<&'static str>,
+    #[case] expected: Option<&'static str>,
+    #[case] msg: &'static str,
+) {
     let _lock = EnvLock::acquire();
-    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
-    let _legacy_guard = EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY);
+    let _env_guard = env_vars.0.map_or_else(
+        || EnvVarGuard::remove(CONFIG_ENV_VAR),
+        |v| EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new(v)),
+    );
+    let _legacy_guard = env_vars.1.map_or_else(
+        || EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY),
+        |v| EnvVarGuard::set(CONFIG_ENV_VAR_LEGACY, std::ffi::OsStr::new(v)),
+    );
     let cli = Cli {
-        config: Some(std::path::PathBuf::from("/cli/path.toml")),
+        config: cli_config.map(std::path::PathBuf::from),
         ..Cli::default()
     };
     assert_eq!(
         resolve_config_path(&cli),
-        Some(std::path::PathBuf::from("/cli/path.toml")),
-        "cli.config should take precedence over CONFIG_ENV_VAR"
-    );
-}
-
-#[test]
-fn resolve_config_path_env_wins_over_legacy() {
-    use test_support::env_lock::EnvLock;
-    let _lock = EnvLock::acquire();
-    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
-    let _legacy_guard = EnvVarGuard::set(
-        CONFIG_ENV_VAR_LEGACY,
-        std::ffi::OsStr::new("/legacy/path.toml"),
-    );
-    let cli = Cli::default();
-    assert_eq!(
-        resolve_config_path(&cli),
-        Some(std::path::PathBuf::from("/env/path.toml")),
-        "CONFIG_ENV_VAR should take precedence over CONFIG_ENV_VAR_LEGACY"
-    );
-}
-
-#[test]
-fn resolve_config_path_legacy_used_when_primary_absent() {
-    use test_support::env_lock::EnvLock;
-    let _lock = EnvLock::acquire();
-    let _env_guard = EnvVarGuard::remove(CONFIG_ENV_VAR);
-    let _legacy_guard = EnvVarGuard::set(
-        CONFIG_ENV_VAR_LEGACY,
-        std::ffi::OsStr::new("/legacy/path.toml"),
-    );
-    let cli = Cli::default();
-    assert_eq!(
-        resolve_config_path(&cli),
-        Some(std::path::PathBuf::from("/legacy/path.toml")),
-        "CONFIG_ENV_VAR_LEGACY should be used when primary env var absent"
+        expected.map(std::path::PathBuf::from),
+        "{msg}",
     );
 }
 
 #[test]
 fn resolve_config_path_returns_none_when_all_absent() {
-    use test_support::env_lock::EnvLock;
     let _lock = EnvLock::acquire();
     let _env_guard = EnvVarGuard::remove(CONFIG_ENV_VAR);
     let _legacy_guard = EnvVarGuard::remove(CONFIG_ENV_VAR_LEGACY);
@@ -385,25 +384,5 @@ fn resolve_config_path_returns_none_when_all_absent() {
     assert!(
         resolve_config_path(&cli).is_none(),
         "should return None when no selector is active"
-    );
-}
-
-#[test]
-fn resolve_config_path_cli_wins_over_both_env_vars() {
-    use test_support::env_lock::EnvLock;
-    let _lock = EnvLock::acquire();
-    let _env_guard = EnvVarGuard::set(CONFIG_ENV_VAR, std::ffi::OsStr::new("/env/path.toml"));
-    let _legacy_guard = EnvVarGuard::set(
-        CONFIG_ENV_VAR_LEGACY,
-        std::ffi::OsStr::new("/legacy/path.toml"),
-    );
-    let cli = Cli {
-        config: Some(std::path::PathBuf::from("/cli/path.toml")),
-        ..Cli::default()
-    };
-    assert_eq!(
-        resolve_config_path(&cli),
-        Some(std::path::PathBuf::from("/cli/path.toml")),
-        "cli.config should win over both env vars"
     );
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,7 +25,8 @@ use validation::configure_validation_parsers;
 
 /// Maximum number of jobs accepted by the CLI.
 const MAX_JOBS: usize = 64;
-const CONFIG_ENV_VAR: &str = "NETSUKE_CONFIG_PATH";
+const CONFIG_ENV_VAR: &str = "NETSUKE_CONFIG";
+const CONFIG_ENV_VAR_LEGACY: &str = "NETSUKE_CONFIG_PATH";
 const ENV_PREFIX: &str = "NETSUKE_";
 
 fn validation_message(
@@ -52,6 +53,11 @@ pub struct Cli {
     /// This affects manifest lookup, output paths, and config discovery.
     #[arg(short = 'C', long, value_name = "DIR")]
     pub directory: Option<PathBuf>,
+
+    /// Path to a configuration file, bypassing automatic discovery.
+    #[arg(long, value_name = "FILE")]
+    #[serde(skip)]
+    pub config: Option<PathBuf>,
 
     /// Set the number of parallel build jobs.
     ///
@@ -160,6 +166,7 @@ impl Default for Cli {
         Self {
             file: default_manifest_path(),
             directory: None,
+            config: None,
             jobs: None,
             verbose: false,
             locale: None,

--- a/src/cli_l10n.rs
+++ b/src/cli_l10n.rs
@@ -124,6 +124,7 @@ fn flag_help_key(arg_id: &str, subcommand_name: Option<&str>) -> Option<&'static
         None => match arg_id {
             "file" => Some(keys::CLI_FLAG_FILE_HELP),
             "directory" => Some(keys::CLI_FLAG_DIRECTORY_HELP),
+            "config" => Some(keys::CLI_FLAG_CONFIG_HELP),
             "jobs" => Some(keys::CLI_FLAG_JOBS_HELP),
             "verbose" => Some(keys::CLI_FLAG_VERBOSE_HELP),
             "locale" => Some(keys::CLI_FLAG_LOCALE_HELP),

--- a/src/localization/keys.rs
+++ b/src/localization/keys.rs
@@ -14,6 +14,7 @@ define_keys! {
     CLI_USAGE => "cli.usage",
     CLI_FLAG_FILE_HELP => "cli.flag.file.help",
     CLI_FLAG_DIRECTORY_HELP => "cli.flag.directory.help",
+    CLI_FLAG_CONFIG_HELP => "cli.flag.config.help",
     CLI_FLAG_JOBS_HELP => "cli.flag.jobs.help",
     CLI_FLAG_VERBOSE_HELP => "cli.flag.verbose.help",
     CLI_FLAG_LOCALE_HELP => "cli.flag.locale.help",

--- a/tests/bdd/steps/cli_parsing.rs
+++ b/tests/bdd/steps/cli_parsing.rs
@@ -46,6 +46,7 @@ fn isolated_cli_environment(world: &TestWorld) -> Result<()> {
 
     // Clear all NETSUKE_* environment variables to prevent interference
     let netsuke_vars = [
+        "NETSUKE_CONFIG",
         "NETSUKE_CONFIG_PATH",
         "NETSUKE_THEME",
         "NETSUKE_LOCALE",

--- a/tests/cli_tests/config_discovery.rs
+++ b/tests/cli_tests/config_discovery.rs
@@ -37,7 +37,7 @@ impl Drop for CwdGuard {
 #[rstest]
 fn project_scope_config_discovered_automatically() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_dir = tempdir().context("create temporary project directory")?;
     let project_config = temp_dir.path().join(".netsuke.toml");
 
@@ -80,6 +80,7 @@ jobs = 8
         merged.jobs == Some(8),
         "project config jobs should be discovered"
     );
+    drop(cwd_guard);
     Ok(())
 }
 
@@ -110,7 +111,7 @@ fn assert_user_config_applied(merged: &netsuke::cli::Cli) -> Result<()> {
 #[rstest]
 fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
     let temp_home = tempdir().context("create temporary home directory")?;
 
@@ -141,14 +142,16 @@ fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
         .context("merge with user config")?
         .with_default_command();
 
-    assert_user_config_applied(&merged)
+    let result = assert_user_config_applied(&merged);
+    drop(cwd_guard);
+    result
 }
 
 #[cfg(windows)]
 #[rstest]
 fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
     let temp_appdata = tempdir().context("create temporary APPDATA directory")?;
 
@@ -179,7 +182,9 @@ fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
         .context("merge with user config")?
         .with_default_command();
 
-    assert_user_config_applied(&merged)
+    let result = assert_user_config_applied(&merged);
+    drop(cwd_guard);
+    result
 }
 
 /// Project config TOML used by both Unix and Windows precedence test variants.
@@ -214,7 +219,7 @@ fn assert_project_precedence_applied(merged: &netsuke::cli::Cli) -> Result<()> {
 #[rstest]
 fn project_config_takes_precedence_over_user_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
 
     let temp_project = tempdir().context("create temporary project directory")?;
     let temp_home = tempdir().context("create temporary home directory")?;
@@ -251,14 +256,16 @@ fn project_config_takes_precedence_over_user_config() -> Result<()> {
         .context("merge configs")?
         .with_default_command();
 
-    assert_project_precedence_applied(&merged)
+    let result = assert_project_precedence_applied(&merged);
+    drop(cwd_guard);
+    result
 }
 
 #[cfg(windows)]
 #[rstest]
 fn project_config_takes_precedence_over_user_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
 
     let temp_project = tempdir().context("create temporary project directory")?;
     let temp_appdata = tempdir().context("create temporary APPDATA directory")?;
@@ -295,13 +302,15 @@ fn project_config_takes_precedence_over_user_config() -> Result<()> {
         .context("merge configs")?
         .with_default_command();
 
-    assert_project_precedence_applied(&merged)
+    let result = assert_project_precedence_applied(&merged);
+    drop(cwd_guard);
+    result
 }
 
 #[rstest]
 fn environment_variables_override_discovered_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
 
     // Write project-scope config
@@ -344,13 +353,14 @@ output_format = "human"
         merged.output_format == Some(OutputFormat::Human),
         "project config value should apply when no env override exists"
     );
+    drop(cwd_guard);
     Ok(())
 }
 
 #[rstest]
 fn cli_flags_override_environment_and_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
 
     // Write project-scope config
@@ -409,6 +419,7 @@ output_format = "human"
         merged.colour_policy == Some(ColourPolicy::Always),
         "environment colour_policy should apply when CLI does not override"
     );
+    drop(cwd_guard);
     Ok(())
 }
 
@@ -417,7 +428,7 @@ output_format = "human"
 #[case("--directory")]
 fn directory_flag_anchors_project_discovery_to_specified_dir(#[case] flag: &str) -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_outer = tempdir().context("create outer directory")?;
     let temp_project = temp_outer.path().join("project");
     fs::create_dir(&temp_project).context("create project subdirectory")?;
@@ -458,13 +469,14 @@ jobs = 6
         merged.jobs == Some(6),
         "config values from directory flag should be applied"
     );
+    drop(cwd_guard);
     Ok(())
 }
 
 #[rstest]
 fn config_path_env_var_bypasses_automatic_discovery() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create project directory")?;
     let temp_custom = tempdir().context("create custom config directory")?;
 
@@ -518,6 +530,7 @@ colour_policy = "always"
         merged.colour_policy == Some(ColourPolicy::Always),
         "custom config colour_policy should be applied"
     );
+    drop(cwd_guard);
     Ok(())
 }
 
@@ -573,7 +586,7 @@ fn assert_list_fields_appended(merged: &netsuke::cli::Cli) -> Result<()> {
 #[rstest]
 fn list_fields_append_across_discovered_config_env_and_cli() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create project directory")?;
 
     // Write project config with default_targets
@@ -610,5 +623,7 @@ fetch_allow_scheme = ["https"]
         .context("merge with list appending")?
         .with_default_command();
 
-    assert_list_fields_appended(&merged)
+    let result = assert_list_fields_appended(&merged);
+    drop(cwd_guard);
+    result
 }

--- a/tests/cli_tests/config_discovery.rs
+++ b/tests/cli_tests/config_discovery.rs
@@ -53,6 +53,7 @@ jobs = 8
     .context("write project .netsuke.toml")?;
 
     // Clear env vars that could interfere
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _locale_guard = EnvVarGuard::remove("NETSUKE_LOCALE");
@@ -127,6 +128,7 @@ fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
     let _xdg_config_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg_config_home.as_os_str());
     let _xdg_config_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
     // Clear other env vars
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -166,6 +168,7 @@ fn user_scope_config_discovered_when_no_project_config() -> Result<()> {
     // Set APPDATA to fake directory (Windows)
     let _appdata_guard = EnvVarGuard::set("APPDATA", temp_appdata.path().as_os_str());
     // Clear other env vars
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -242,6 +245,7 @@ fn project_config_takes_precedence_over_user_config() -> Result<()> {
     let _home_guard = EnvVarGuard::set("HOME", temp_home.path().as_os_str());
     let _xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", temp_xdg_home.path().as_os_str());
     let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -288,6 +292,7 @@ fn project_config_takes_precedence_over_user_config() -> Result<()> {
 
     let _appdata_guard = EnvVarGuard::set("APPDATA", temp_appdata.path().as_os_str());
     let _localappdata_guard = EnvVarGuard::remove("LOCALAPPDATA");
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -326,6 +331,7 @@ output_format = "human"
     .context("write project .netsuke.toml")?;
 
     // Set environment variables that should override the file
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", OsStr::new("unicode"));
     let _jobs_guard = EnvVarGuard::set("NETSUKE_JOBS", OsStr::new("12"));
@@ -377,6 +383,7 @@ output_format = "human"
     .context("write project .netsuke.toml")?;
 
     // Set environment variables
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", OsStr::new("unicode"));
     let _jobs_guard = EnvVarGuard::set("NETSUKE_JOBS", OsStr::new("8"));
@@ -447,6 +454,7 @@ jobs = 6
     // Stay in outer directory but use directory flag to point to project
     std::env::set_current_dir(&temp_outer).context("change to outer directory")?;
 
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -503,6 +511,7 @@ colour_policy = "always"
     )
     .context("write custom config")?;
 
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::set("NETSUKE_CONFIG_PATH", custom_config.as_os_str());
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
     let _jobs_guard = EnvVarGuard::remove("NETSUKE_JOBS");
@@ -600,6 +609,7 @@ fetch_allow_scheme = ["https"]
     )
     .context("write project .netsuke.toml with lists")?;
 
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     // Set single-value environment variables for list fields
     let _targets_guard = EnvVarGuard::set("NETSUKE_DEFAULT_TARGETS", OsStr::new("test"));

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -1,0 +1,227 @@
+//! Integration tests for explicit configuration file selection.
+//!
+//! These tests cover the visible `--config` flag and `NETSUKE_CONFIG`
+//! environment variable, plus compatibility with the legacy
+//! `NETSUKE_CONFIG_PATH` override.
+
+use anyhow::{Context, Result, ensure};
+use netsuke::cli_localization;
+use netsuke::theme::ThemePreference;
+use rstest::rstest;
+use std::ffi::OsStr;
+use std::fs;
+use std::sync::Arc;
+use tempfile::tempdir;
+use test_support::{EnvVarGuard, env_lock::EnvLock};
+
+/// RAII guard that restores the process working directory on drop.
+struct CwdGuard(std::path::PathBuf);
+
+impl CwdGuard {
+    fn acquire() -> Result<Self> {
+        Ok(Self(
+            std::env::current_dir().context("capture current working directory")?,
+        ))
+    }
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        drop(std::env::set_current_dir(&self.0));
+    }
+}
+
+fn parse_and_merge(args: &[&str]) -> Result<netsuke::cli::Cli> {
+    let localizer = Arc::from(cli_localization::build_localizer(None));
+    let (cli, matches) = netsuke::cli::parse_with_localizer_from(args, &localizer)
+        .context("parse CLI for config selection test")?;
+    netsuke::cli::merge_with_config(&cli, &matches)
+        .context("merge CLI with selected config")?
+        .with_default_command()
+        .pipe(Ok)
+}
+
+trait Pipe: Sized {
+    fn pipe<T>(self, f: impl FnOnce(Self) -> T) -> T {
+        f(self)
+    }
+}
+
+impl<T> Pipe for T {}
+
+fn sandbox_user_scope(home: &tempfile::TempDir) -> Result<(EnvVarGuard, EnvVarGuard, EnvVarGuard)> {
+    let xdg_config_home = home.path().join(".config");
+    fs::create_dir_all(&xdg_config_home).context("create sandboxed XDG config home")?;
+    Ok((
+        EnvVarGuard::set("HOME", home.path().as_os_str()),
+        EnvVarGuard::set("XDG_CONFIG_HOME", xdg_config_home.as_os_str()),
+        EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new("")),
+    ))
+}
+
+#[rstest]
+fn config_flag_loads_specified_file() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
+
+    let custom = project.path().join("custom.toml");
+    fs::write(&custom, "theme = \"unicode\"\n").context("write explicit config file")?;
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    ensure!(
+        merged.theme == Some(ThemePreference::Unicode),
+        "explicit --config file should be loaded"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn config_flag_skips_project_discovery() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+
+    fs::write(project.path().join(".netsuke.toml"), "theme = \"ascii\"\n")
+        .context("write project config")?;
+    fs::write(project.path().join("custom.toml"), "theme = \"unicode\"\n")
+        .context("write custom config")?;
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    ensure!(
+        merged.theme == Some(ThemePreference::Unicode),
+        "explicit --config should bypass discovered project config"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn config_flag_with_nonexistent_file_produces_error() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let error = parse_and_merge(&["netsuke", "--config", "missing.toml"])
+        .expect_err("missing explicit config file should fail");
+    let message = format!("{error:?}");
+    ensure!(
+        message.contains("missing.toml"),
+        "error should mention the missing explicit config path, got {message}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn netsuke_config_env_loads_specified_file() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+
+    let custom = project.path().join("env.toml");
+    fs::write(&custom, "theme = \"unicode\"\n").context("write NETSUKE_CONFIG file")?;
+    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", custom.as_os_str());
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged = parse_and_merge(&["netsuke"])?;
+    ensure!(
+        merged.theme == Some(ThemePreference::Unicode),
+        "NETSUKE_CONFIG should load the selected config file"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn netsuke_config_env_takes_precedence_over_legacy() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+
+    let new_config = project.path().join("new.toml");
+    let legacy_config = project.path().join("legacy.toml");
+    fs::write(&new_config, "theme = \"unicode\"\n").context("write NETSUKE_CONFIG file")?;
+    fs::write(&legacy_config, "theme = \"ascii\"\n").context("write legacy config file")?;
+    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", new_config.as_os_str());
+    let _legacy_guard = EnvVarGuard::set("NETSUKE_CONFIG_PATH", legacy_config.as_os_str());
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged = parse_and_merge(&["netsuke"])?;
+    ensure!(
+        merged.theme == Some(ThemePreference::Unicode),
+        "NETSUKE_CONFIG should win over NETSUKE_CONFIG_PATH"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn config_flag_takes_precedence_over_netsuke_config_env() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+
+    let cli_config = project.path().join("cli.toml");
+    let env_config = project.path().join("env.toml");
+    fs::write(&cli_config, "theme = \"unicode\"\n").context("write CLI-selected config")?;
+    fs::write(&env_config, "theme = \"ascii\"\n").context("write env-selected config")?;
+    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", env_config.as_os_str());
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged = parse_and_merge(&["netsuke", "--config", "cli.toml"])?;
+    ensure!(
+        merged.theme == Some(ThemePreference::Unicode),
+        "--config should win over NETSUKE_CONFIG"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn config_flag_values_still_overridden_by_env_and_cli_preferences() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let _cwd_guard = CwdGuard::acquire()?;
+    let project = tempdir().context("create project directory")?;
+    let home = tempdir().context("create fake home directory")?;
+    let _user_scope = sandbox_user_scope(&home)?;
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", "unicode");
+
+    let custom = project.path().join("custom.toml");
+    fs::write(&custom, "theme = \"ascii\"\n").context("write explicit config file")?;
+    std::env::set_current_dir(project.path()).context("change to project directory")?;
+
+    let merged_with_cli_override =
+        parse_and_merge(&["netsuke", "--config", "custom.toml", "--theme", "ascii"])?;
+    ensure!(
+        merged_with_cli_override.theme == Some(ThemePreference::Ascii),
+        "CLI preference values should still override environment and selected config"
+    );
+
+    let merged_with_env_override = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    ensure!(
+        merged_with_env_override.theme == Some(ThemePreference::Unicode),
+        "environment preference values should still override the selected config"
+    );
+    Ok(())
+}

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result, ensure};
 use netsuke::cli_localization;
 use netsuke::theme::ThemePreference;
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use std::ffi::OsStr;
 use std::fs;
 use std::sync::Arc;
@@ -94,47 +94,201 @@ impl ConfigTestHarness {
     }
 }
 
+#[fixture]
+fn config_harness() -> Result<ConfigTestHarness> {
+    ConfigTestHarness::setup()
+}
+
+#[derive(Clone, Copy)]
+struct ConfigFile {
+    name: &'static str,
+    content: &'static str,
+}
+
+impl ConfigFile {
+    const fn new(name: &'static str, content: &'static str) -> Self {
+        Self { name, content }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ConfigSelectionCase {
+    project_config: Option<ConfigFile>,
+    cli_config: Option<ConfigFile>,
+    env_config: Option<ConfigFile>,
+    legacy_config: Option<ConfigFile>,
+    env_theme: Option<&'static str>,
+    cli_theme: Option<&'static str>,
+    expected_theme: ThemePreference,
+    message: &'static str,
+}
+
+impl ConfigSelectionCase {
+    const fn new(expected_theme: ThemePreference, message: &'static str) -> Self {
+        Self {
+            project_config: None,
+            cli_config: None,
+            env_config: None,
+            legacy_config: None,
+            env_theme: None,
+            cli_theme: None,
+            expected_theme,
+            message,
+        }
+    }
+
+    const fn with_project_config(mut self, config: ConfigFile) -> Self {
+        self.project_config = Some(config);
+        self
+    }
+
+    const fn with_cli_config(mut self, config: ConfigFile) -> Self {
+        self.cli_config = Some(config);
+        self
+    }
+
+    const fn with_env_config(mut self, config: ConfigFile) -> Self {
+        self.env_config = Some(config);
+        self
+    }
+
+    const fn with_legacy_config(mut self, config: ConfigFile) -> Self {
+        self.legacy_config = Some(config);
+        self
+    }
+
+    const fn with_env_theme(mut self, theme: &'static str) -> Self {
+        self.env_theme = Some(theme);
+        self
+    }
+
+    const fn with_cli_theme(mut self, theme: &'static str) -> Self {
+        self.cli_theme = Some(theme);
+        self
+    }
+}
+
+fn write_optional_config(
+    harness: &ConfigTestHarness,
+    config: Option<ConfigFile>,
+) -> Result<Option<String>> {
+    config
+        .map(|file| {
+            harness
+                .write_config(file.name, file.content)
+                .map(|path| path.to_string_lossy().into_owned())
+        })
+        .transpose()
+}
+
 #[rstest]
-fn config_flag_loads_specified_file() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
+#[case::config_flag_loads_specified_file(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "explicit --config file should be loaded",
+    )
+    .with_cli_config(ConfigFile::new("custom.toml", "theme = \"unicode\"\n")),
+)]
+#[case::config_flag_skips_project_discovery(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "explicit --config should bypass discovered project config",
+    )
+    .with_project_config(ConfigFile::new(".netsuke.toml", "theme = \"ascii\"\n"))
+    .with_cli_config(ConfigFile::new("custom.toml", "theme = \"unicode\"\n")),
+)]
+#[case::netsuke_config_env_loads_specified_file(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "NETSUKE_CONFIG should load the selected config file",
+    )
+    .with_env_config(ConfigFile::new("env.toml", "theme = \"unicode\"\n")),
+)]
+#[case::netsuke_config_env_takes_precedence_over_legacy(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "NETSUKE_CONFIG should win over NETSUKE_CONFIG_PATH",
+    )
+    .with_env_config(ConfigFile::new("new.toml", "theme = \"unicode\"\n"))
+    .with_legacy_config(ConfigFile::new("legacy.toml", "theme = \"ascii\"\n")),
+)]
+#[case::config_flag_takes_precedence_over_netsuke_config_env(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "--config should win over NETSUKE_CONFIG",
+    )
+    .with_cli_config(ConfigFile::new("cli.toml", "theme = \"unicode\"\n"))
+    .with_env_config(ConfigFile::new("env.toml", "theme = \"ascii\"\n")),
+)]
+#[case::config_flag_values_still_overridden_by_cli_preferences(
+    ConfigSelectionCase::new(
+        ThemePreference::Ascii,
+        "CLI preference values should still override environment and selected config",
+    )
+    .with_cli_config(ConfigFile::new("custom.toml", "theme = \"ascii\"\n"))
+    .with_env_theme("unicode")
+    .with_cli_theme("ascii"),
+)]
+#[case::config_flag_values_still_overridden_by_env_preferences(
+    ConfigSelectionCase::new(
+        ThemePreference::Unicode,
+        "environment preference values should still override the selected config",
+    )
+    .with_cli_config(ConfigFile::new("custom.toml", "theme = \"ascii\"\n"))
+    .with_env_theme("unicode"),
+)]
+fn config_selection_precedence_cases(
+    config_harness: Result<ConfigTestHarness>,
+    #[case] case: ConfigSelectionCase,
+) -> Result<()> {
+    let h = config_harness?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
 
-    let custom_path = h.write_config("custom.toml", "theme = \"unicode\"\n")?;
-    let custom_arg = custom_path.to_string_lossy().into_owned();
+    let _project_config = write_optional_config(&h, case.project_config)?;
+    let cli_config = write_optional_config(&h, case.cli_config)?;
+    let env_config = write_optional_config(&h, case.env_config)?;
+    let legacy_config = write_optional_config(&h, case.legacy_config)?;
 
-    let merged = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
+    let mut env_guards = Vec::new();
+    if let Some(path) = env_config.as_deref() {
+        env_guards.push(EnvVarGuard::set("NETSUKE_CONFIG", path));
+    }
+    if let Some(path) = legacy_config.as_deref() {
+        env_guards.push(EnvVarGuard::set("NETSUKE_CONFIG_PATH", path));
+    }
+    if let Some(theme) = case.env_theme {
+        env_guards.push(EnvVarGuard::set("NETSUKE_THEME", theme));
+    }
+
+    let mut args = vec![String::from("netsuke")];
+    if let Some(path) = cli_config {
+        args.push(String::from("--config"));
+        args.push(path);
+    }
+    if let Some(theme) = case.cli_theme {
+        args.push(String::from("--theme"));
+        args.push(String::from(theme));
+    }
+
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let merged = parse_and_merge(&arg_refs)?;
     ensure!(
-        merged.theme == Some(ThemePreference::Unicode),
-        "explicit --config file should be loaded"
+        merged.theme == Some(case.expected_theme),
+        "{}",
+        case.message
     );
     let _project_root = h.project.path();
+    drop(env_guards);
     Ok(())
 }
 
 #[rstest]
-fn config_flag_skips_project_discovery() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
-    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
-    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-
-    let _project_config = h.write_config(".netsuke.toml", "theme = \"ascii\"\n")?;
-    let custom_path = h.write_config("custom.toml", "theme = \"unicode\"\n")?;
-    let custom_arg = custom_path.to_string_lossy().into_owned();
-
-    let merged = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
-    ensure!(
-        merged.theme == Some(ThemePreference::Unicode),
-        "explicit --config should bypass discovered project config"
-    );
-    let _project_root = h.project.path();
-    Ok(())
-}
-
-#[rstest]
-fn config_flag_with_nonexistent_file_produces_error() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
+fn config_flag_with_nonexistent_file_produces_error(
+    config_harness: Result<ConfigTestHarness>,
+) -> Result<()> {
+    let h = config_harness?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
 
@@ -144,85 +298,6 @@ fn config_flag_with_nonexistent_file_produces_error() -> Result<()> {
     ensure!(
         message.contains("missing.toml"),
         "error should mention the missing explicit config path, got {message}"
-    );
-    let _project_root = h.project.path();
-    Ok(())
-}
-
-#[rstest]
-fn netsuke_config_env_loads_specified_file() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
-    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-
-    let custom = h.write_config("env.toml", "theme = \"unicode\"\n")?;
-    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", custom.as_os_str());
-
-    let merged = parse_and_merge(&["netsuke"])?;
-    ensure!(
-        merged.theme == Some(ThemePreference::Unicode),
-        "NETSUKE_CONFIG should load the selected config file"
-    );
-    let _project_root = h.project.path();
-    Ok(())
-}
-
-#[rstest]
-fn netsuke_config_env_takes_precedence_over_legacy() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
-
-    let new_config = h.write_config("new.toml", "theme = \"unicode\"\n")?;
-    let legacy_config = h.write_config("legacy.toml", "theme = \"ascii\"\n")?;
-    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", new_config.as_os_str());
-    let _legacy_guard = EnvVarGuard::set("NETSUKE_CONFIG_PATH", legacy_config.as_os_str());
-
-    let merged = parse_and_merge(&["netsuke"])?;
-    ensure!(
-        merged.theme == Some(ThemePreference::Unicode),
-        "NETSUKE_CONFIG should win over NETSUKE_CONFIG_PATH"
-    );
-    let _project_root = h.project.path();
-    Ok(())
-}
-
-#[rstest]
-fn config_flag_takes_precedence_over_netsuke_config_env() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
-
-    let cli_config_path = h.write_config("cli.toml", "theme = \"unicode\"\n")?;
-    let cli_config_arg = cli_config_path.to_string_lossy().into_owned();
-    let env_config = h.write_config("env.toml", "theme = \"ascii\"\n")?;
-    let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", env_config.as_os_str());
-    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-
-    let merged = parse_and_merge(&["netsuke", "--config", &cli_config_arg])?;
-    ensure!(
-        merged.theme == Some(ThemePreference::Unicode),
-        "--config should win over NETSUKE_CONFIG"
-    );
-    let _project_root = h.project.path();
-    Ok(())
-}
-
-#[rstest]
-fn config_flag_values_still_overridden_by_env_and_cli_preferences() -> Result<()> {
-    let h = ConfigTestHarness::setup()?;
-    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-    let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", "unicode");
-
-    let custom_path = h.write_config("custom.toml", "theme = \"ascii\"\n")?;
-    let custom_arg = custom_path.to_string_lossy().into_owned();
-
-    let merged_with_cli_override =
-        parse_and_merge(&["netsuke", "--config", &custom_arg, "--theme", "ascii"])?;
-    ensure!(
-        merged_with_cli_override.theme == Some(ThemePreference::Ascii),
-        "CLI preference values should still override environment and selected config"
-    );
-
-    let merged_with_env_override = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
-    ensure!(
-        merged_with_env_override.theme == Some(ThemePreference::Unicode),
-        "environment preference values should still override the selected config"
     );
     let _project_root = h.project.path();
     Ok(())

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -60,6 +60,8 @@ fn sandbox_user_scope(home: &tempfile::TempDir) -> Result<(EnvVarGuard, EnvVarGu
 }
 
 struct ConfigTestHarness {
+    // Struct fields drop in declaration order; keep the lock last so process
+    // state is restored before another test can acquire `EnvLock`.
     _cwd_guard: CwdGuard,
     _user_scope: (EnvVarGuard, EnvVarGuard, EnvVarGuard),
     _home: tempfile::TempDir,

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -59,63 +59,82 @@ fn sandbox_user_scope(home: &tempfile::TempDir) -> Result<(EnvVarGuard, EnvVarGu
     ))
 }
 
+struct ConfigTestHarness {
+    _env_lock: EnvLock,
+    project: tempfile::TempDir,
+    _home: tempfile::TempDir,
+    _user_scope: (EnvVarGuard, EnvVarGuard, EnvVarGuard),
+    _cwd_guard: CwdGuard,
+}
+
+impl ConfigTestHarness {
+    fn setup() -> Result<Self> {
+        let env_lock = EnvLock::acquire();
+        let cwd_guard = CwdGuard::acquire()?;
+        let project = tempdir().context("create project directory")?;
+        let home = tempdir().context("create fake home directory")?;
+        let user_scope = sandbox_user_scope(&home)?;
+        std::env::set_current_dir(project.path()).context("change to project directory")?;
+        Ok(Self {
+            _env_lock: env_lock,
+            project,
+            _home: home,
+            _user_scope: user_scope,
+            _cwd_guard: cwd_guard,
+        })
+    }
+
+    fn write_config(&self, name: &str, content: &str) -> Result<std::path::PathBuf> {
+        let path = self.project.path().join(name);
+        fs::write(&path, content).with_context(|| format!("write config file {name}"))?;
+        std::env::set_current_dir(self.project.path()).context("change to project directory")?;
+        Ok(path)
+    }
+}
+
 #[rstest]
 fn config_flag_loads_specified_file() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::remove("NETSUKE_THEME");
 
-    let custom = project.path().join("custom.toml");
-    fs::write(&custom, "theme = \"unicode\"\n").context("write explicit config file")?;
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
+    let custom_path = h.write_config("custom.toml", "theme = \"unicode\"\n")?;
+    let custom_arg = custom_path.to_string_lossy().into_owned();
 
-    let merged = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    let merged = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
     ensure!(
         merged.theme == Some(ThemePreference::Unicode),
         "explicit --config file should be loaded"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn config_flag_skips_project_discovery() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
 
-    fs::write(project.path().join(".netsuke.toml"), "theme = \"ascii\"\n")
-        .context("write project config")?;
-    fs::write(project.path().join("custom.toml"), "theme = \"unicode\"\n")
-        .context("write custom config")?;
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
+    let _project_config = h.write_config(".netsuke.toml", "theme = \"ascii\"\n")?;
+    let custom_path = h.write_config("custom.toml", "theme = \"unicode\"\n")?;
+    let custom_arg = custom_path.to_string_lossy().into_owned();
 
-    let merged = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    let merged = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
     ensure!(
         merged.theme == Some(ThemePreference::Unicode),
         "explicit --config should bypass discovered project config"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn config_flag_with_nonexistent_file_produces_error() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
 
     let error = parse_and_merge(&["netsuke", "--config", "missing.toml"])
         .expect_err("missing explicit config file should fail");
@@ -124,104 +143,85 @@ fn config_flag_with_nonexistent_file_produces_error() -> Result<()> {
         message.contains("missing.toml"),
         "error should mention the missing explicit config path, got {message}"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn netsuke_config_env_loads_specified_file() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
 
-    let custom = project.path().join("env.toml");
-    fs::write(&custom, "theme = \"unicode\"\n").context("write NETSUKE_CONFIG file")?;
+    let custom = h.write_config("env.toml", "theme = \"unicode\"\n")?;
     let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", custom.as_os_str());
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
 
     let merged = parse_and_merge(&["netsuke"])?;
     ensure!(
         merged.theme == Some(ThemePreference::Unicode),
         "NETSUKE_CONFIG should load the selected config file"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn netsuke_config_env_takes_precedence_over_legacy() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
 
-    let new_config = project.path().join("new.toml");
-    let legacy_config = project.path().join("legacy.toml");
-    fs::write(&new_config, "theme = \"unicode\"\n").context("write NETSUKE_CONFIG file")?;
-    fs::write(&legacy_config, "theme = \"ascii\"\n").context("write legacy config file")?;
+    let new_config = h.write_config("new.toml", "theme = \"unicode\"\n")?;
+    let legacy_config = h.write_config("legacy.toml", "theme = \"ascii\"\n")?;
     let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", new_config.as_os_str());
     let _legacy_guard = EnvVarGuard::set("NETSUKE_CONFIG_PATH", legacy_config.as_os_str());
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
 
     let merged = parse_and_merge(&["netsuke"])?;
     ensure!(
         merged.theme == Some(ThemePreference::Unicode),
         "NETSUKE_CONFIG should win over NETSUKE_CONFIG_PATH"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn config_flag_takes_precedence_over_netsuke_config_env() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
 
-    let cli_config = project.path().join("cli.toml");
-    let env_config = project.path().join("env.toml");
-    fs::write(&cli_config, "theme = \"unicode\"\n").context("write CLI-selected config")?;
-    fs::write(&env_config, "theme = \"ascii\"\n").context("write env-selected config")?;
+    let cli_config_path = h.write_config("cli.toml", "theme = \"unicode\"\n")?;
+    let cli_config_arg = cli_config_path.to_string_lossy().into_owned();
+    let env_config = h.write_config("env.toml", "theme = \"ascii\"\n")?;
     let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG", env_config.as_os_str());
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
 
-    let merged = parse_and_merge(&["netsuke", "--config", "cli.toml"])?;
+    let merged = parse_and_merge(&["netsuke", "--config", &cli_config_arg])?;
     ensure!(
         merged.theme == Some(ThemePreference::Unicode),
         "--config should win over NETSUKE_CONFIG"
     );
+    let _project_root = h.project.path();
     Ok(())
 }
 
 #[rstest]
 fn config_flag_values_still_overridden_by_env_and_cli_preferences() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire()?;
-    let project = tempdir().context("create project directory")?;
-    let home = tempdir().context("create fake home directory")?;
-    let _user_scope = sandbox_user_scope(&home)?;
+    let h = ConfigTestHarness::setup()?;
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", "unicode");
 
-    let custom = project.path().join("custom.toml");
-    fs::write(&custom, "theme = \"ascii\"\n").context("write explicit config file")?;
-    std::env::set_current_dir(project.path()).context("change to project directory")?;
+    let custom_path = h.write_config("custom.toml", "theme = \"ascii\"\n")?;
+    let custom_arg = custom_path.to_string_lossy().into_owned();
 
     let merged_with_cli_override =
-        parse_and_merge(&["netsuke", "--config", "custom.toml", "--theme", "ascii"])?;
+        parse_and_merge(&["netsuke", "--config", &custom_arg, "--theme", "ascii"])?;
     ensure!(
         merged_with_cli_override.theme == Some(ThemePreference::Ascii),
         "CLI preference values should still override environment and selected config"
     );
 
-    let merged_with_env_override = parse_and_merge(&["netsuke", "--config", "custom.toml"])?;
+    let merged_with_env_override = parse_and_merge(&["netsuke", "--config", &custom_arg])?;
     ensure!(
         merged_with_env_override.theme == Some(ThemePreference::Unicode),
         "environment preference values should still override the selected config"
     );
+    let _project_root = h.project.path();
     Ok(())
 }

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -60,11 +60,11 @@ fn sandbox_user_scope(home: &tempfile::TempDir) -> Result<(EnvVarGuard, EnvVarGu
 }
 
 struct ConfigTestHarness {
-    _env_lock: EnvLock,
-    project: tempfile::TempDir,
-    _home: tempfile::TempDir,
-    _user_scope: (EnvVarGuard, EnvVarGuard, EnvVarGuard),
     _cwd_guard: CwdGuard,
+    _user_scope: (EnvVarGuard, EnvVarGuard, EnvVarGuard),
+    _home: tempfile::TempDir,
+    project: tempfile::TempDir,
+    _env_lock: EnvLock,
 }
 
 impl ConfigTestHarness {

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -289,6 +289,7 @@ fn config_flag_with_nonexistent_file_produces_error(
     config_harness: Result<ConfigTestHarness>,
 ) -> Result<()> {
     let h = config_harness?;
+    h.write_config(".netsuke.toml", "theme = \"unicode\"\n")?;
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
 

--- a/tests/cli_tests/config_selection.rs
+++ b/tests/cli_tests/config_selection.rs
@@ -1,8 +1,48 @@
-//! Integration tests for explicit configuration file selection.
+//! Integration tests for explicit configuration file selection and precedence.
 //!
-//! These tests cover the visible `--config` flag and `NETSUKE_CONFIG`
-//! environment variable, plus compatibility with the legacy
-//! `NETSUKE_CONFIG_PATH` override.
+//! # Scope
+//!
+//! These tests exercise the user-visible configuration-selection contract
+//! introduced in milestone 3.11.3:
+//!
+//! - `--config <PATH>` CLI flag (highest precedence)
+//! - `NETSUKE_CONFIG` environment variable
+//! - `NETSUKE_CONFIG_PATH` legacy alias (lowest explicit precedence)
+//! - Automatic project-scope discovery (when no explicit selector is active)
+//!
+//! # Relationship to other test modules
+//!
+//! - [`config_discovery`](super::config_discovery): covers automatic
+//!   multi-scope discovery and env-var overrides without an explicit
+//!   `--config` flag; the two modules are complementary.
+//! - [`merge`](super::merge): covers `OrthoConfig` layer-composition
+//!   semantics (defaults → file → env → CLI); the present module targets
+//!   the *selection* of which file enters that pipeline.
+//! - `tests/features/configuration_discovery.feature`: BDD scenarios that
+//!   duplicate the key precedence cases at the acceptance level.
+//!
+//! # Test infrastructure
+//!
+//! Every test receives a [`ConfigTestHarness`] via the `config_harness`
+//! rstest fixture.  The harness:
+//!
+//! 1. Acquires [`EnvLock`] (serialises all env-mutating tests process-wide).
+//! 2. Captures the process working directory via [`CwdGuard`].
+//! 3. Creates isolated `project` and `home` tempdirs.
+//! 4. Calls [`sandbox_user_scope`] to point `HOME`, `XDG_CONFIG_HOME`, and
+//!    `XDG_CONFIG_DIRS` at the fake home so `OrthoConfig` user-scope discovery
+//!    cannot read real host config files.
+//! 5. Changes the process CWD to the project tempdir.
+//!
+//! Fields drop in declaration order; `_cwd_guard` is declared first so the
+//! CWD is restored before `_env_lock` releases the mutex, preventing a race
+//! where another test calls `std::env::current_dir()` while the CWD still
+//! points at a deleted tempdir.
+//!
+//! [`parse_and_merge`] parses CLI arguments with a localiser and drives the
+//! full `merge_with_config` pipeline, returning the merged [`Cli`] struct.
+//! [`ConfigSelectionCase`] is a const-buildable descriptor used by the main
+//! parametric test [`config_selection_precedence_cases`].
 
 use anyhow::{Context, Result, ensure};
 use netsuke::cli_localization;

--- a/tests/cli_tests/helpers.rs
+++ b/tests/cli_tests/helpers.rs
@@ -15,6 +15,7 @@ pub(super) fn os_args(args: &[&str]) -> Vec<OsString> {
 /// Creates empty temporary directories for home and project, acquires
 /// `EnvLock`, and sets `HOME`, `XDG_CONFIG_HOME`, and `XDG_CONFIG_DIRS`
 /// to empty paths so host-level config files cannot leak into assertions.
+#[cfg(unix)]
 pub(super) struct UnixConfigTestEnv {
     _cwd_guard: super::merge::CwdGuard,
     pub(super) temp_home: tempfile::TempDir,

--- a/tests/cli_tests/helpers.rs
+++ b/tests/cli_tests/helpers.rs
@@ -16,10 +16,9 @@ pub(super) fn os_args(args: &[&str]) -> Vec<OsString> {
 /// `EnvLock`, and sets `HOME`, `XDG_CONFIG_HOME`, and `XDG_CONFIG_DIRS`
 /// to empty paths so host-level config files cannot leak into assertions.
 pub(super) struct UnixConfigTestEnv {
-    pub(super) _env_lock: test_support::env_lock::EnvLock,
+    _cwd_guard: super::merge::CwdGuard,
     pub(super) temp_home: tempfile::TempDir,
     pub(super) temp_project: tempfile::TempDir,
-    _cwd_guard: super::merge::CwdGuard,
     _xdg_home: tempfile::TempDir,
     _home_guard: test_support::EnvVarGuard,
     _xdg_home_guard: test_support::EnvVarGuard,
@@ -28,6 +27,7 @@ pub(super) struct UnixConfigTestEnv {
     _config_guard: test_support::EnvVarGuard,
     _diag_json_guard: test_support::EnvVarGuard,
     _output_format_guard: test_support::EnvVarGuard,
+    pub(super) _env_lock: test_support::env_lock::EnvLock,
 }
 
 #[cfg(unix)]
@@ -53,10 +53,9 @@ pub(super) fn unix_config_env() -> anyhow::Result<UnixConfigTestEnv> {
     let diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
     let output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
     Ok(UnixConfigTestEnv {
-        _env_lock: env_lock,
+        _cwd_guard: cwd_guard,
         temp_home,
         temp_project,
-        _cwd_guard: cwd_guard,
         _xdg_home: xdg_home,
         _home_guard: home_guard,
         _xdg_home_guard: xdg_home_guard,
@@ -65,5 +64,6 @@ pub(super) fn unix_config_env() -> anyhow::Result<UnixConfigTestEnv> {
         _config_guard: config_guard,
         _diag_json_guard: diag_json_guard,
         _output_format_guard: output_format_guard,
+        _env_lock: env_lock,
     })
 }

--- a/tests/cli_tests/helpers.rs
+++ b/tests/cli_tests/helpers.rs
@@ -5,3 +5,65 @@ use std::ffi::OsString;
 pub(super) fn os_args(args: &[&str]) -> Vec<OsString> {
     args.iter().map(|arg| OsString::from(*arg)).collect()
 }
+
+// ---------------------------------------------------------------------------
+// Unix config-environment fixture
+// ---------------------------------------------------------------------------
+
+/// Isolated test environment for Unix config-discovery tests.
+///
+/// Creates empty temporary directories for home and project, acquires
+/// `EnvLock`, and sets `HOME`, `XDG_CONFIG_HOME`, and `XDG_CONFIG_DIRS`
+/// to empty paths so host-level config files cannot leak into assertions.
+pub(super) struct UnixConfigTestEnv {
+    pub(super) _env_lock: test_support::env_lock::EnvLock,
+    pub(super) temp_home: tempfile::TempDir,
+    pub(super) temp_project: tempfile::TempDir,
+    _cwd_guard: super::merge::CwdGuard,
+    _xdg_home: tempfile::TempDir,
+    _home_guard: test_support::EnvVarGuard,
+    _xdg_home_guard: test_support::EnvVarGuard,
+    _xdg_dirs_guard: test_support::EnvVarGuard,
+    _config_path_guard: test_support::EnvVarGuard,
+    _config_guard: test_support::EnvVarGuard,
+    _diag_json_guard: test_support::EnvVarGuard,
+    _output_format_guard: test_support::EnvVarGuard,
+}
+
+#[cfg(unix)]
+#[rstest::fixture]
+pub(super) fn unix_config_env() -> anyhow::Result<UnixConfigTestEnv> {
+    use anyhow::Context;
+    use std::ffi::OsStr;
+    use tempfile::tempdir;
+    use test_support::EnvVarGuard;
+    use test_support::env_lock::EnvLock;
+
+    let env_lock = EnvLock::acquire();
+    let temp_home = tempdir().context("create temporary home directory")?;
+    let temp_project = tempdir().context("create temporary project directory")?;
+    let cwd_guard =
+        super::merge::CwdGuard::acquire().context("capture current working directory")?;
+    let xdg_home = tempdir().context("create temporary XDG config home")?;
+    let home_guard = EnvVarGuard::set("HOME", temp_home.path().as_os_str());
+    let xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg_home.path().as_os_str());
+    let xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
+    let config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    let config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
+    let output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
+    Ok(UnixConfigTestEnv {
+        _env_lock: env_lock,
+        temp_home,
+        temp_project,
+        _cwd_guard: cwd_guard,
+        _xdg_home: xdg_home,
+        _home_guard: home_guard,
+        _xdg_home_guard: xdg_home_guard,
+        _xdg_dirs_guard: xdg_dirs_guard,
+        _config_path_guard: config_path_guard,
+        _config_guard: config_guard,
+        _diag_json_guard: diag_json_guard,
+        _output_format_guard: output_format_guard,
+    })
+}

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -342,6 +342,7 @@ theme = "ascii
     let _xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", temp_xdg_home.path().as_os_str());
     let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
 
     std::env::set_current_dir(&temp_project).context("change to project directory")?;
 

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -251,6 +251,8 @@ default_targets = ["hello"]
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", OsStr::new("unicode"));
     let _colour_policy_guard = EnvVarGuard::set("NETSUKE_COLOUR_POLICY", OsStr::new("always"));
     let _scheme_guard = EnvVarGuard::remove("NETSUKE_FETCH_ALLOW_SCHEME");
+    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
+    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
 
     let localizer = Arc::from(cli_localization::build_localizer(None));
     let (cli, matches) = netsuke::cli::parse_with_localizer_from(["netsuke"], &localizer)
@@ -274,6 +276,8 @@ fn cli_merge_with_config_prefers_cli_theme_over_env_and_file() -> Result<()> {
 
     let _config_guard = EnvVarGuard::set("NETSUKE_CONFIG_PATH", config_path.as_os_str());
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", OsStr::new("unicode"));
+    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
+    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
 
     let localizer = Arc::from(cli_localization::build_localizer(None));
     let (cli, matches) =

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -343,6 +343,8 @@ theme = "ascii
     let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
     let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
+    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
 
     std::env::set_current_dir(&temp_project).context("change to project directory")?;
 
@@ -386,6 +388,8 @@ theme = "ascii
 
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
+    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
     std::env::set_current_dir(&temp_project).context("change to project directory")?;
 
     let config_arg = explicit_config.to_string_lossy().into_owned();

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -313,7 +313,7 @@ fn cli_merge_layers_prefers_cli_then_env_then_file_for_locale(
 #[rstest]
 fn resolve_merged_diag_json_handles_malformed_project_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_home = tempdir().context("create temporary home directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
 
@@ -356,5 +356,6 @@ theme = "ascii
         "should honour user config output_format=json despite malformed project config"
     );
 
+    drop(cwd_guard);
     Ok(())
 }

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -359,3 +359,55 @@ theme = "ascii
     drop(cwd_guard);
     Ok(())
 }
+
+#[rstest]
+fn resolve_merged_diag_json_does_not_discover_after_explicit_config_error() -> Result<()> {
+    let _env_lock = EnvLock::acquire();
+    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+    let temp_project = tempdir().context("create temporary project directory")?;
+
+    fs::write(
+        temp_project.path().join(".netsuke.toml"),
+        r#"
+output_format = "json"
+"#,
+    )
+    .context("write project .netsuke.toml")?;
+
+    let explicit_config = temp_project.path().join("broken.toml");
+    fs::write(
+        &explicit_config,
+        r#"
+theme = "ascii
+"#,
+    )
+    .context("write malformed explicit config")?;
+
+    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
+    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
+    std::env::set_current_dir(&temp_project).context("change to project directory")?;
+
+    let config_arg = explicit_config.to_string_lossy().into_owned();
+    let localizer = Arc::from(cli_localization::build_localizer(None));
+    let (cli, matches) =
+        netsuke::cli::parse_with_localizer_from(["netsuke", "--config", &config_arg], &localizer)
+            .context("parse CLI with malformed explicit config")?;
+
+    ensure!(
+        !netsuke::cli::resolve_merged_diag_json(&cli, &matches),
+        "malformed explicit config should not fall back to discovered project config"
+    );
+
+    let (cli_with_diag, matches_with_diag) = netsuke::cli::parse_with_localizer_from(
+        ["netsuke", "--config", &config_arg, "--diag-json"],
+        &localizer,
+    )
+    .context("parse CLI with explicit diagnostic JSON flag")?;
+    ensure!(
+        netsuke::cli::resolve_merged_diag_json(&cli_with_diag, &matches_with_diag),
+        "--diag-json should still force structured diagnostics"
+    );
+
+    drop(cwd_guard);
+    Ok(())
+}

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -3,6 +3,7 @@
 //! These tests validate `OrthoConfig` layer precedence (defaults, file, env,
 //! CLI) and list-value appending.
 
+#[cfg(unix)]
 use super::helpers::unix_config_env;
 use anyhow::{Context, Result, ensure};
 use netsuke::cli::Cli;

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -3,6 +3,7 @@
 //! These tests validate `OrthoConfig` layer precedence (defaults, file, env,
 //! CLI) and list-value appending.
 
+use super::helpers::unix_config_env;
 use anyhow::{Context, Result, ensure};
 use netsuke::cli::Cli;
 use netsuke::cli::config::{ColourPolicy, OutputFormat, SpinnerMode};
@@ -18,14 +19,12 @@ use std::sync::Arc;
 use tempfile::tempdir;
 use test_support::{EnvVarGuard, env_lock::EnvLock};
 
-/// RAII guard that restores the process working directory on drop.
-///
-/// Acquire this *after* `EnvLock` so the drop order (CWD restored first,
-/// lock released second) mirrors the acquire order.
-struct CwdGuard(std::path::PathBuf);
+/// RAII guard that restores the CWD on drop. Acquire after `EnvLock` so
+/// the CWD is restored before the lock releases.
+pub(super) struct CwdGuard(std::path::PathBuf);
 
 impl CwdGuard {
-    fn acquire() -> anyhow::Result<Self> {
+    pub(super) fn acquire() -> anyhow::Result<Self> {
         Ok(Self(
             std::env::current_dir().context("capture current working directory")?,
         ))
@@ -37,7 +36,6 @@ impl Drop for CwdGuard {
         drop(std::env::set_current_dir(&self.0));
     }
 }
-
 #[fixture]
 fn default_cli_json() -> Result<serde_json::Value> {
     Ok(sanitize_value(&Cli::default())?)
@@ -317,49 +315,28 @@ fn cli_merge_layers_prefers_cli_then_env_then_file_for_locale(
 
 #[cfg(unix)]
 #[rstest]
-fn resolve_merged_diag_json_handles_malformed_project_config() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let temp_home = tempdir().context("create temporary home directory")?;
-    let temp_project = tempdir().context("create temporary project directory")?;
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+fn resolve_merged_diag_json_handles_malformed_project_config(
+    unix_config_env: Result<super::helpers::UnixConfigTestEnv>,
+) -> Result<()> {
+    let env = unix_config_env?;
 
     // User config: valid, sets output_format=json
-    let user_config = temp_home.path().join(".netsuke.toml");
-    fs::write(
-        &user_config,
-        r#"
-output_format = "json"
-"#,
-    )
-    .context("write user .netsuke.toml")?;
+    let user_config = env.temp_home.path().join(".netsuke.toml");
+    fs::write(&user_config, "output_format = \"json\"\n").context("write user .netsuke.toml")?;
 
     // Project config: malformed (missing closing quote)
-    let project_config = temp_project.path().join(".netsuke.toml");
-    fs::write(
-        &project_config,
-        r#"
-theme = "ascii
-"#,
-    )
-    .context("write malformed project .netsuke.toml")?;
+    let project_config = env.temp_project.path().join(".netsuke.toml");
+    fs::write(&project_config, "theme = \"ascii\n")
+        .context("write malformed project .netsuke.toml")?;
 
-    let temp_xdg_home = tempdir().context("create temporary XDG config home")?;
-    let _home_guard = EnvVarGuard::set("HOME", temp_home.path().as_os_str());
-    let _xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", temp_xdg_home.path().as_os_str());
-    let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
-    let _config_path_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
-    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
-    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
-
-    std::env::set_current_dir(&temp_project).context("change to project directory")?;
+    std::env::set_current_dir(&env.temp_project).context("change to project directory")?;
 
     let localizer = Arc::from(cli_localization::build_localizer(None));
     let (cli, matches) = netsuke::cli::parse_with_localizer_from(["netsuke"], &localizer)
         .context("parse CLI for malformed project config test")?;
 
-    // resolve_merged_diag_json should not propagate the project config parse error,
-    // but should fall back to the valid user config setting (output_format=json)
+    // Malformed project config parse error should not propagate;
+    // resolve_merged_diag_json should fall back to the valid user config (output_format=json)
     ensure!(
         netsuke::cli::resolve_merged_diag_json(&cli, &matches),
         "should honour user config output_format=json despite malformed project config"
@@ -370,38 +347,21 @@ theme = "ascii
 
 #[cfg(unix)]
 #[rstest]
-fn resolve_merged_diag_json_does_not_discover_after_explicit_config_error() -> Result<()> {
-    let _env_lock = EnvLock::acquire();
-    let temp_home = tempdir().context("create temporary home directory")?;
-    let temp_project = tempdir().context("create temporary project directory")?;
-    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
+fn resolve_merged_diag_json_does_not_discover_after_explicit_config_error(
+    unix_config_env: Result<super::helpers::UnixConfigTestEnv>,
+) -> Result<()> {
+    let env = unix_config_env?;
 
     fs::write(
-        temp_project.path().join(".netsuke.toml"),
-        r#"
-output_format = "json"
-"#,
+        env.temp_project.path().join(".netsuke.toml"),
+        "output_format = \"json\"\n",
     )
     .context("write project .netsuke.toml")?;
 
-    let explicit_config = temp_project.path().join("broken.toml");
-    fs::write(
-        &explicit_config,
-        r#"
-theme = "ascii
-"#,
-    )
-    .context("write malformed explicit config")?;
+    let explicit_config = env.temp_project.path().join("broken.toml");
+    fs::write(&explicit_config, "theme = \"ascii\n").context("write malformed explicit config")?;
 
-    let temp_xdg_home = tempdir().context("create temporary XDG config home")?;
-    let _home_guard = EnvVarGuard::set("HOME", temp_home.path().as_os_str());
-    let _xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", temp_xdg_home.path().as_os_str());
-    let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
-    let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
-    let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
-    let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
-    let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
-    std::env::set_current_dir(&temp_project).context("change to project directory")?;
+    std::env::set_current_dir(&env.temp_project).context("change to project directory")?;
 
     let config_arg = explicit_config.to_string_lossy().into_owned();
     let localizer = Arc::from(cli_localization::build_localizer(None));

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -368,9 +368,11 @@ theme = "ascii
     Ok(())
 }
 
+#[cfg(unix)]
 #[rstest]
 fn resolve_merged_diag_json_does_not_discover_after_explicit_config_error() -> Result<()> {
     let _env_lock = EnvLock::acquire();
+    let temp_home = tempdir().context("create temporary home directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
     let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
 
@@ -391,6 +393,10 @@ theme = "ascii
     )
     .context("write malformed explicit config")?;
 
+    let temp_xdg_home = tempdir().context("create temporary XDG config home")?;
+    let _home_guard = EnvVarGuard::set("HOME", temp_home.path().as_os_str());
+    let _xdg_home_guard = EnvVarGuard::set("XDG_CONFIG_HOME", temp_xdg_home.path().as_os_str());
+    let _xdg_dirs_guard = EnvVarGuard::set("XDG_CONFIG_DIRS", OsStr::new(""));
     let _config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
     let _legacy_guard = EnvVarGuard::remove("NETSUKE_CONFIG_PATH");
     let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -319,9 +319,9 @@ fn cli_merge_layers_prefers_cli_then_env_then_file_for_locale(
 #[rstest]
 fn resolve_merged_diag_json_handles_malformed_project_config() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_home = tempdir().context("create temporary home directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
+    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
 
     // User config: valid, sets output_format=json
     let user_config = temp_home.path().join(".netsuke.toml");
@@ -365,15 +365,14 @@ theme = "ascii
         "should honour user config output_format=json despite malformed project config"
     );
 
-    drop(cwd_guard);
     Ok(())
 }
 
 #[rstest]
 fn resolve_merged_diag_json_does_not_discover_after_explicit_config_error() -> Result<()> {
     let _env_lock = EnvLock::acquire();
-    let cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
     let temp_project = tempdir().context("create temporary project directory")?;
+    let _cwd_guard = CwdGuard::acquire().context("capture current working directory")?;
 
     fs::write(
         temp_project.path().join(".netsuke.toml"),
@@ -419,6 +418,5 @@ theme = "ascii
         "--diag-json should still force structured diagnostics"
     );
 
-    drop(cwd_guard);
     Ok(())
 }

--- a/tests/cli_tests/merge.rs
+++ b/tests/cli_tests/merge.rs
@@ -253,6 +253,7 @@ default_targets = ["hello"]
     let _scheme_guard = EnvVarGuard::remove("NETSUKE_FETCH_ALLOW_SCHEME");
     let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
     let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
+    let _netsuke_config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
 
     let localizer = Arc::from(cli_localization::build_localizer(None));
     let (cli, matches) = netsuke::cli::parse_with_localizer_from(["netsuke"], &localizer)
@@ -278,6 +279,7 @@ fn cli_merge_with_config_prefers_cli_theme_over_env_and_file() -> Result<()> {
     let _theme_guard = EnvVarGuard::set("NETSUKE_THEME", OsStr::new("unicode"));
     let _diag_json_guard = EnvVarGuard::remove("NETSUKE_DIAG_JSON");
     let _output_format_guard = EnvVarGuard::remove("NETSUKE_OUTPUT_FORMAT");
+    let _netsuke_config_guard = EnvVarGuard::remove("NETSUKE_CONFIG");
 
     let localizer = Arc::from(cli_localization::build_localizer(None));
     let (cli, matches) =

--- a/tests/cli_tests/mod.rs
+++ b/tests/cli_tests/mod.rs
@@ -3,6 +3,7 @@
 //! This module exercises the command-line interface defined in `netsuke::cli`.
 
 mod config_discovery;
+mod config_selection;
 mod helpers;
 mod locale;
 mod merge;

--- a/tests/features/configuration_discovery.feature
+++ b/tests/features/configuration_discovery.feature
@@ -43,3 +43,41 @@ Feature: Configuration file discovery and precedence
     When the CLI is parsed with no additional arguments
     Then parsing succeeds
     And the theme preference is "unicode"
+
+  Scenario: Explicit config file overrides project discovery
+    Given a temporary workspace
+    And a project config file ".netsuke.toml" with theme "ascii"
+    And a custom config file "custom.toml" with theme "unicode"
+    When the CLI is parsed with "--config custom.toml"
+    Then parsing succeeds
+    And the theme preference is "unicode"
+
+  Scenario: NETSUKE_CONFIG environment variable selects config file
+    Given a temporary workspace
+    And a project config file ".netsuke.toml" with theme "ascii"
+    And a custom config file "override.toml" with theme "unicode"
+    And the environment variable "NETSUKE_CONFIG" points to "override.toml"
+    When the CLI is parsed with no additional arguments
+    Then parsing succeeds
+    And the theme preference is "unicode"
+
+  Scenario: NETSUKE_CONFIG takes precedence over NETSUKE_CONFIG_PATH
+    Given a temporary workspace
+    And a project config file ".netsuke.toml" with theme "ascii"
+    And a custom config file "new.toml" with theme "unicode"
+    And a custom config file "legacy.toml" with theme "ascii"
+    And the environment variable "NETSUKE_CONFIG" points to "new.toml"
+    And the environment variable "NETSUKE_CONFIG_PATH" points to "legacy.toml"
+    When the CLI is parsed with no additional arguments
+    Then parsing succeeds
+    And the theme preference is "unicode"
+
+  Scenario: CLI config flag takes precedence over NETSUKE_CONFIG
+    Given a temporary workspace
+    And a project config file ".netsuke.toml" with theme "ascii"
+    And a custom config file "cli.toml" with theme "unicode"
+    And a custom config file "env.toml" with theme "ascii"
+    And the environment variable "NETSUKE_CONFIG" points to "env.toml"
+    When the CLI is parsed with "--config cli.toml"
+    Then parsing succeeds
+    And the theme preference is "unicode"


### PR DESCRIPTION
## Summary
- Implement an explicit config-path surface via a CLI flag `--config <PATH>` and a user-facing environment variable `NETSUKE_CONFIG` to specify a config file directly, while keeping backwards-compatible `NETSUKE_CONFIG_PATH` as a silent alias.
- Integrate this into Netsuke's existing two-pass discovery with a clear precedence: `--config` > `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH` > discovery.
- Update documentation, localization keys, tests, and roadmap artifacts accordingly.

## Rationale
- Allow users to bypass automatic discovery and load a specific configuration file deterministically. Explicit precedence and clear messaging reduce ambiguity for users upgrading to the new surface.

## What changed
- CLI surface
  - Added `config: Option<PathBuf>` to `Cli` with `#[serde(skip)]` and localized help.
  - Introduced local resolution logic that prefers `--config`, then `NETSUKE_CONFIG`, then `NETSUKE_CONFIG_PATH`, else discovery.
  - Ensure the explicit path is respected by discovery/push logic when provided.
- Discovery & merge wiring
  - Centralized explicit config path resolution and wired it into the merge path, so an explicit path bypasses two-pass discovery and loads the file directly.
  - Updated the diag-JSON collection so early resolution also respects the explicit config path.
  - Adjusted merge entry points to pass the explicit config path through the pipeline.
- Environment variable precedence
  - Implemented precedence so `NETSUKE_CONFIG` overrides `NETSUKE_CONFIG_PATH` when both are set.
- Localization & build-time anchors
  - Added a new Fluent key for the `--config` flag help and English/Spanish messages.
  - Mapped the new key in `src/cli_l10n.rs`.
  - Added build-time symbol anchors where needed.
- Tests
  - Added integration tests for `--config` and `NETSUKE_CONFIG` interactions in `tests/cli_tests/config_selection.rs`.
  - Extended existing tests to cover explicit config behavior and precedence rules.
  - Expanded BDD coverage in `tests/features/configuration_discovery.feature` with scenarios for explicit config behavior.
- Documentation & sample configs
  - Added annotated `docs/sample-netsuke.toml` demonstrating all keys.
  - Updated user docs (`docs/users-guide.md`) to document `--config`, `NETSUKE_CONFIG`, and precedence.
  - Updated design docs (`docs/netsuke-design.md`) to reflect the new surface.
  - Updated roadmap (`docs/roadmap.md`) to mark 3.11.3 as done.
- Artifacts
  - New execplan document: 3-11-3-expose-config-path-and-netsuke-config.md under `docs/execplans`.
  - Updated various references to ensure documentation and localization stay in sync with the new behavior.

## Precedence and behavior
- Precedence ladder for selecting a config file:
  - 1) --config <PATH> (CLI flag, highest)
  - 2) NETSUKE_CONFIG (environment variable, new user-facing name)
  - 3) NETSUKE_CONFIG_PATH (environment variable, legacy alias)
  - 4) Automatic discovery (project/user scopes)
- Behavior details
  - The `--config` path is resolved against the process working directory and is a file selector (loads that file directly).
  - If the explicit path does not exist or cannot parse, an error is surfaced rather than silently falling back to discovery.
  - Relative paths passed to `--config` are resolved against the current working directory.
  - `NETSUKE_CONFIG_PATH` remains supported as a silent alias and is overridden by `NETSUKE_CONFIG` when both are set.
  - The existing two-pass discovery remains the default path when no explicit config is provided.

## Documentation & localization impact
- Localization keys
  - Added `CLI_FLAG_CONFIG_HELP` and wired it to map to the `--config` flag help.
  - English and Spanish Fluent messages added for the new flag.
- Documentation artifacts
  - `docs/sample-netsuke.toml` provides an annotated, parsable sample config.
  - `docs/users-guide.md` updated to describe `--config`, `NETSUKE_CONFIG`, and the precedence.
  - `docs/netsuke-design.md` updated to reflect the new override surface and precedence rules.
  - `docs/roadmap.md` updated to mark 3.11.3 as complete.

## Tests & validation
- Integration tests
  - New tests in `tests/cli_tests/config_selection.rs` validate:
    - `--config` loads the specified file and bypasses discovery
    - `NETSUKE_CONFIG` loads the specified file
    - precedence: `NETSUKE_CONFIG` > `NETSUKE_CONFIG_PATH`
    - `--config` takes precedence over `NETSUKE_CONFIG` when both are set
  - Extended or added tests cover missing files and error handling for explicit config loads.
- Behavior-driven tests
  - Extended `tests/features/configuration_discovery.feature` with explicit-config scenarios demonstrating the behavior to end users.
- Documentation checks
  - New sample config and documentation updated accordingly; localization checks aligned with new keys.

## Validation gates
- fmt, lint, tests pass in CI environment per the execplan.
- Help output for `netsuke --help` includes a localized `--config` flag description.
- All acceptance criteria from the plan are satisfied, including explicit config loading, environment override precedence, and silent alias support.

## Artifacts and notes
- Code changes across: `src/cli/mod.rs`, `src/cli/config_merge.rs`, `src/cli/config_merge_tests.rs`, `src/cli_l10n.rs`, `src/localization/keys.rs`.
- Localization files updated: `locales/en-US/messages.ftl`, `locales/es-ES/messages.ftl`.
- Tests updated/added: `tests/cli_tests/config_selection.rs`, `tests/features/configuration_discovery.feature`, `tests/bdd/steps/configuration_discovery.rs`.
- Documentation: `docs/sample-netsuke.toml`, `docs/users-guide.md`, `docs/netsuke-design.md`, `docs/roadmap.md`.
- ExecPlan added: `docs/execplans/3-11-3-expose-config-path-and-netsuke-config.md`.

If you have any questions or need adjustments to the wording of the new sections, I can tailor them to your preferred PR messaging style.

📎 **Task**: https://www.devboxer.com/task/05c12be9-87ad-42d7-8ba0-8e576601053d