### PR TITLE
Record design decision in docs Section 8.4 and update roadmap (3.13.2)

### DIFF
--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2109,6 +2109,12 @@ reporter output, timing summaries, and the semantic prefix surface are guarded
 by `insta` snapshots so spacing, prefix alignment, and wrapping regressions
 fail with reviewable diffs instead of drifting silently.
 
+The Advanced Usage chapter in `docs/users-guide.md` is validated by behavioural
+tests in `tests/features/advanced_usage.feature`. Netsuke treats those
+scenarios as executable documentation for the `clean`, `graph`, and `manifest`
+subcommands, configuration layering, and JSON diagnostics so the guide stays
+synchronized with runtime behaviour rather than drifting behind it.
+
 For screen readers: The following flowchart shows how the build script audits
 localization keys against English and Spanish Fluent bundles.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -318,8 +318,8 @@ library, and CLI ergonomics.
 - [x] 3.13.1. Add smoke tests for novice flows.
   - [x] Test first run success, missing manifest, and help output.
   - [x] Confirm UX matches documented journey.
-- [ ] 3.13.2. Extend user documentation with advanced usage chapter.
-  - [ ] Cover `clean`, `graph`, `manifest`, configuration layering, and JSON
+- [x] 3.13.2. Extend user documentation with advanced usage chapter.
+  - [x] Cover `clean`, `graph`, `manifest`, configuration layering, and JSON
     diagnostics.
 - [ ] 3.13.3. Provide CI-focused guidance.
   - [ ] Include examples of consuming JSON diagnostics.


### PR DESCRIPTION
## Summary
- Records design decision in docs Section 8.4
- Updates roadmap to reflect completion of 3.13.2 Advanced usage chapter
- Documents coverage includes: clean, graph, manifest, configuration layering, and JSON diagnostics

## Changes

### Documentation
- **Netsuke Design**: Updated docs/netsuke-design.md to record that the Advanced Usage chapter is validated by behavioural tests in `tests/features/advanced_usage.feature`. Netsuke treats those scenarios as executable documentation for the `clean`, `graph`, and `manifest` subcommands, configuration layering, and JSON diagnostics so the guide stays synchronized with runtime behaviour.
- **Roadmap**: Updated docs/roadmap.md to mark 3.13.2 as completed and to reflect that JSON diagnostics are included in the advanced usage chapter.

### Rationale
- Aligns docs with implemented content and tests

## Validation
- [x] Roadmap entry now shows 3.13.2 as completed
- [x] Netsuke design doc mentions the test-backed validation and coverage
- [x] Roadmap items listed in the roadmap match the implemented docs

## Notes
- No code changes; purely documentation alignment.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/f698cbb4-ff74-4b62-978c-3d2a95d2b8a7


📎 **Task**: https://www.devboxer.com/task/257645c0-463d-4cc8-b8b4-8d7b7da24c4d