### PR TITLE
Snapshot circular dependency diagnostics (#332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "mockable",
  "netsuke",
  "ninja_env",
+ "rstest",
  "sha2",
  "tempfile",
  "thiserror 1.0.69",

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -375,9 +375,9 @@ Environment variable mutations and working-directory changes are process-global
 side effects that can cause data races when tests run in parallel. The
 `test_support` crate and test fixtures provide resource acquisition is
 initialization (RAII)-based utilities to serialize and safely restore these
-mutations.
-For locale-sensitive snapshot tests, use the `EnLocalizer` RAII pattern
-documented in the [snapshot testing guide](snapshot-testing-in-netsuke-using-insta.md#locale-pinned-snapshot-tests).
+mutations. For locale-sensitive snapshot tests, use the `EnLocalizer` RAII
+pattern documented in the
+[snapshot testing guide](snapshot-testing-in-netsuke-using-insta.md#locale-pinned-snapshot-tests).
 
 ### `EnvLock`
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -376,6 +376,8 @@ side effects that can cause data races when tests run in parallel. The
 `test_support` crate and test fixtures provide resource acquisition is
 initialization (RAII)-based utilities to serialize and safely restore these
 mutations.
+For locale-sensitive snapshot tests, use the `EnLocalizer` RAII pattern
+documented in the [snapshot testing guide](snapshot-testing-in-netsuke-using-insta.md#locale-pinned-snapshot-tests).
 
 ### `EnvLock`
 

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -224,8 +224,8 @@ Ninja file text respectively.
 
 ## Locale-pinned snapshot tests
 
-Some `Display` implementations in Netsuke call `localization::message(...)`,
-so their output varies with the active locale.  A snapshot test that exercises
+Some `Display` implementations in Netsuke call `localization::message(...)`, so
+their output varies with the active locale.  A snapshot test that exercises
 such output must hold both the global localizer serialisation mutex and a
 `LocalizerGuard` for the entire duration of the assertion; otherwise concurrent
 tests may install a different locale and produce non-deterministic output.
@@ -274,8 +274,8 @@ fn my_locale_sensitive_snapshot(en_localizer: EnLocalizer) {
 }
 ```
 
-Both guards are released when `_en_localizer` is dropped at the end of the
-test function, serialising locale state across the test suite.
+Both guards are released when `_en_localizer` is dropped at the end of the test
+function, serialising locale state across the test suite.
 
 ### Relevant utilities
 

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -230,39 +230,25 @@ such output must hold both the global localizer serialisation mutex and a
 `LocalizerGuard` for the entire duration of the assertion; otherwise concurrent
 tests may install a different locale and produce non-deterministic output.
 
-### The `EnLocalizer` pattern
+### The shared `EnLocalizer` fixture
 
-Wrap both guards in a struct with underscore-prefixed fields so the Rust
-compiler keeps them alive until the struct is dropped:
+`test_support` provides a single canonical fixture for this. Do **not** define
+a local `EnLocalizer`/`EnUsLocalizerFixture` in each test module; import the
+shared one so locale pinning stays consistent and free of duplication.
 
-```rust
-use std::sync::MutexGuard;
-use test_support::{LocalizerGuard, localizer_test_lock, set_en_localizer};
-
-/// RAII bundle that holds the global localizer test lock and the English
-/// locale guard for the duration of a test.
-struct EnLocalizer {
-    _lock: MutexGuard<'static, ()>,
-    _guard: LocalizerGuard,
-}
-```
+`test_support::EnLocalizer` is an RAII bundle that holds both the global
+localizer test lock and the English `LocalizerGuard` in underscore-prefixed
+fields, so the compiler keeps them alive until the bundle is dropped.
+`test_support::en_localizer` is the matching `#[fixture]` constructor.
 
 ### Wiring with rstest
 
-Annotate a constructor function with `#[fixture]` and accept it as a parameter
-in `#[rstest]` tests, binding it immediately so the compiler recognises the
-RAII intent:
+Import the shared type and fixture, accept it as a parameter in `#[rstest]`
+tests, and bind it immediately so the compiler recognises the RAII intent:
 
 ```rust
-use rstest::{fixture, rstest};
-
-#[fixture]
-fn en_localizer() -> EnLocalizer {
-    EnLocalizer {
-        _lock: localizer_test_lock().expect("localizer test lock poisoned"),
-        _guard: set_en_localizer(),
-    }
-}
+use rstest::rstest;
+use test_support::{EnLocalizer, en_localizer};
 
 #[rstest]
 fn my_locale_sensitive_snapshot(en_localizer: EnLocalizer) {
@@ -279,6 +265,10 @@ function, serialising locale state across the test suite.
 
 ### Relevant utilities
 
+- `test_support::EnLocalizer` — RAII bundle holding the global localizer test
+  lock and the English `LocalizerGuard`; both are released on drop.
+- `test_support::en_localizer` — `#[fixture]` constructor that builds an
+  `EnLocalizer`; prefer this over a per-module fixture.
 - `test_support::LocalizerGuard` — opaque guard returned by
   `set_en_localizer()`; dropping it uninstalls the locale.
 - `test_support::localizer_test_lock()` — acquires the global mutex that

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -222,6 +222,70 @@ include `tests/snapshots/ir/simple_manifest_ir.snap` and
 per test module). These snapshot files contain the expected IR debug output and
 Ninja file text respectively.
 
+## Locale-pinned snapshot tests
+
+Some `Display` implementations in Netsuke call `localization::message(...)`,
+so their output varies with the active locale.  A snapshot test that exercises
+such output must hold both the global localizer serialisation mutex and a
+`LocalizerGuard` for the entire duration of the assertion; otherwise concurrent
+tests may install a different locale and produce non-deterministic output.
+
+### The `EnLocalizer` pattern
+
+Wrap both guards in a struct with underscore-prefixed fields so the Rust
+compiler keeps them alive until the struct is dropped:
+
+```rust
+use std::sync::MutexGuard;
+use test_support::{LocalizerGuard, localizer_test_lock, set_en_localizer};
+
+/// RAII bundle that holds the global localizer test lock and the English
+/// locale guard for the duration of a test.
+struct EnLocalizer {
+    _lock: MutexGuard<'static, ()>,
+    _guard: LocalizerGuard,
+}
+```
+
+### Wiring with rstest
+
+Annotate a constructor function with `#[fixture]` and accept it as a parameter
+in `#[rstest]` tests, binding it immediately so the compiler recognises the
+RAII intent:
+
+```rust
+use rstest::{fixture, rstest};
+
+#[fixture]
+fn en_localizer() -> EnLocalizer {
+    EnLocalizer {
+        _lock: localizer_test_lock().expect("localizer test lock poisoned"),
+        _guard: set_en_localizer(),
+    }
+}
+
+#[rstest]
+fn my_locale_sensitive_snapshot(en_localizer: EnLocalizer) {
+    let _en_localizer = en_localizer;   // keep guards alive
+    let rendered = my_error().to_string();
+    snapshot_settings().bind(|| {
+        assert_snapshot!("my_error_display", rendered);
+    });
+}
+```
+
+Both guards are released when `_en_localizer` is dropped at the end of the
+test function, serialising locale state across the test suite.
+
+### Relevant utilities
+
+- `test_support::LocalizerGuard` — opaque guard returned by
+  `set_en_localizer()`; dropping it uninstalls the locale.
+- `test_support::localizer_test_lock()` — acquires the global mutex that
+  serialises all locale mutations across concurrent test threads.
+- `test_support::set_en_localizer()` — installs `en-US` as the active locale
+  and returns a `LocalizerGuard`.
+
 ## Running and Updating Snapshot Tests
 
 To execute the snapshot tests, run `cargo test`. All tests (including our new

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -8,6 +8,7 @@ use crate::runner::RunnerError;
 use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
+use proptest::prelude::*;
 use rstest::rstest;
 use serde_json::{Map, Value};
 use std::path::PathBuf;
@@ -245,4 +246,99 @@ fn render_manifest_parse_diagnostic_matches_snapshot(en_localizer: EnLocalizer) 
         assert_snapshot!("manifest_parse_error", rendered);
     });
     Ok(())
+}
+
+/// Generates between `min` and `max` distinct single-character node names as
+/// [`Utf8PathBuf`] values, suitable for constructing arbitrary cycle fixtures.
+fn arb_unique_nodes(min: usize, max: usize) -> impl Strategy<Value = Vec<camino::Utf8PathBuf>> {
+    proptest::collection::vec("[a-z]", min..=max)
+        .prop_filter("nodes must be unique", |v| {
+            let set: std::collections::HashSet<_> = v.iter().collect();
+            set.len() == v.len()
+        })
+        .prop_map(|v| v.into_iter().map(camino::Utf8PathBuf::from).collect())
+}
+
+/// Appends the first node to `nodes` to close the cycle, returning the cycle
+/// path as borrowed string slices.
+///
+/// `arb_unique_nodes` always yields at least two nodes, so the first element is
+/// guaranteed to exist; the `expect` documents that invariant.
+fn closed_cycle_slices(nodes: &[camino::Utf8PathBuf]) -> Vec<&str> {
+    let mut cycle_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
+    let first = *cycle_nodes
+        .first()
+        .expect("arb_unique_nodes yields at least two nodes");
+    cycle_nodes.push(first);
+    cycle_nodes
+}
+
+proptest! {
+    /// The `Display` output of `IrGenError::CircularDependency` is non-empty
+    /// and contains every node name for arbitrary unique cycles of 2–8 nodes.
+    ///
+    /// This tests the rendering layer, not the fixture constructor: the
+    /// assertion is on the *output* of `to_string()`, which calls into the
+    /// localisation and formatting pipeline.  Locale pinning is unnecessary
+    /// because the cycle nodes are interpolated verbatim into the message
+    /// regardless of the active locale.
+    #[test]
+    fn prop_circular_dependency_display_is_nonempty_and_contains_nodes(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let cycle_nodes = closed_cycle_slices(&nodes);
+        let error = circular_dependency_error_for(cycle_nodes);
+        let rendered = error.to_string();
+        prop_assert!(
+            !rendered.is_empty(),
+            "Display output must not be empty for a {}-node cycle",
+            nodes.len(),
+        );
+        for node in &nodes {
+            prop_assert!(
+                rendered.contains(node.as_str()),
+                "Display output must contain node {node:?} for a {}-node cycle; got: {rendered:?}",
+                nodes.len(),
+            );
+        }
+    }
+
+    /// `render_error_json` produces valid JSON for `CircularDependency` errors
+    /// of arbitrary cycle sizes (2–8 nodes).
+    ///
+    /// Validates the rendering pipeline — not the fixture construction — by
+    /// checking that the result parses as JSON, contains a non-empty
+    /// `diagnostics` array, and provides a non-empty `message` field.  The
+    /// structural assertions do not depend on the active locale.
+    #[test]
+    fn prop_render_circular_dependency_json_is_valid_for_arbitrary_cycles(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let cycle_nodes = closed_cycle_slices(&nodes);
+        let error = anyhow::Error::new(circular_dependency_error_for(cycle_nodes))
+            .context(localization::message(keys::RUNNER_CONTEXT_BUILD_GRAPH));
+        let document = render_error_json(error.as_ref())
+            .expect("render_error_json must not fail for a well-formed CircularDependency");
+        let value: serde_json::Value = serde_json::from_str(&document)
+            .expect("render_error_json must produce valid JSON");
+        let diagnostics = value
+            .get("diagnostics")
+            .and_then(serde_json::Value::as_array)
+            .expect("JSON must contain a diagnostics array");
+        prop_assert!(
+            !diagnostics.is_empty(),
+            "diagnostics array must not be empty for a {}-node cycle",
+            nodes.len(),
+        );
+        let message = diagnostics
+            .first()
+            .and_then(|diagnostic| diagnostic.get("message"))
+            .and_then(serde_json::Value::as_str)
+            .expect("first diagnostic must contain a message string");
+        prop_assert!(
+            !message.is_empty(),
+            "diagnostic message must not be empty for a {}-node cycle",
+            nodes.len(),
+        );
+    }
 }

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -88,6 +88,8 @@ fn circular_dependency_error() -> IrGenError {
     circular_dependency_error_for(vec!["a", "b", "a"])
 }
 
+/// Verifies that `render_error_json` records a plain error's full cause chain
+/// in the `causes` field and emits the expected schema version and generator name.
 #[rstest]
 fn render_plain_error_json_records_cause_chain() -> Result<()> {
     let error = anyhow::anyhow!("top level failure").context("outer context");
@@ -135,6 +137,8 @@ fn render_plain_error_json_records_cause_chain() -> Result<()> {
     Ok(())
 }
 
+/// Verifies that `render_diagnostic_json` for a `RunnerError` includes the
+/// diagnostic code and help text without fabricating source-file spans or labels.
 #[rstest]
 fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
     let _lock = localizer_test_lock().expect("localizer test lock poisoned");
@@ -223,6 +227,8 @@ fn circular_dependency_structural_invariants(
     }
 }
 
+/// Asserts that the `Display` output of `IrGenError::CircularDependency`
+/// matches the stored insta snapshot, preserving the user-facing format.
 #[rstest]
 fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer) {
     let _en_localizer = en_localizer;
@@ -233,6 +239,8 @@ fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer
     });
 }
 
+/// Asserts that the JSON diagnostic output for `IrGenError::CircularDependency`
+/// wrapped in a build-graph context matches the stored insta snapshot.
 #[rstest]
 fn render_circular_dependency_json_matches_snapshot(en_localizer: EnLocalizer) -> Result<()> {
     let _en_localizer = en_localizer;
@@ -280,6 +288,8 @@ fn render_circular_dependency_json_has_expected_shape(en_localizer: EnLocalizer)
     Ok(())
 }
 
+/// Asserts that the JSON diagnostic output for a YAML parse error in the
+/// manifest matches the stored insta snapshot.
 #[rstest]
 fn render_manifest_parse_diagnostic_matches_snapshot() -> Result<()> {
     let _lock = localizer_test_lock().expect("localizer test lock poisoned");

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -61,12 +61,12 @@ fn manifest_not_found_error() -> RunnerError {
     }
 }
 
-fn circular_dependency_error() -> IrGenError {
-    let cycle = vec![
-        Utf8PathBuf::from("a"),
-        Utf8PathBuf::from("b"),
-        Utf8PathBuf::from("a"),
-    ];
+/// Constructs an [`IrGenError::CircularDependency`] for the given cycle path.
+///
+/// `cycle_nodes` must contain at least two elements, and the first and last
+/// elements must be identical (i.e. it must form a valid closed cycle).
+fn circular_dependency_error_for(cycle_nodes: Vec<&str>) -> IrGenError {
+    let cycle: Vec<Utf8PathBuf> = cycle_nodes.into_iter().map(Utf8PathBuf::from).collect();
     let message =
         localization::message(keys::IR_CIRCULAR_DEPENDENCY).with_arg("cycle", format!("{cycle:?}"));
     IrGenError::CircularDependency {
@@ -74,6 +74,12 @@ fn circular_dependency_error() -> IrGenError {
         missing_dependencies: Vec::new(),
         message,
     }
+}
+
+/// Constructs the canonical three-node circular-dependency fixture used by
+/// snapshot tests.
+fn circular_dependency_error() -> IrGenError {
+    circular_dependency_error_for(vec!["a", "b", "a"])
 }
 
 #[rstest]
@@ -164,6 +170,53 @@ fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
     Ok(())
 }
 
+/// Verifies structural invariants of `IrGenError::CircularDependency` across
+/// cycle lengths without relying on snapshot output.
+#[rstest]
+#[case(vec!["x", "x"], "minimal two-node cycle")]
+#[case(vec!["a", "b", "a"], "three-node cycle")]
+#[case(vec!["a", "b", "c", "a"], "four-node cycle")]
+#[case(vec!["p", "q", "r", "s", "p"], "five-node cycle")]
+fn circular_dependency_structural_invariants(
+    en_localizer: EnLocalizer,
+    #[case] cycle_nodes: Vec<&str>,
+    #[case] description: &str,
+) {
+    let _en_localizer = en_localizer;
+    let error = circular_dependency_error_for(cycle_nodes.clone());
+
+    if let IrGenError::CircularDependency {
+        cycle,
+        missing_dependencies,
+        ..
+    } = &error
+    {
+        assert_eq!(
+            cycle.len(),
+            cycle_nodes.len(),
+            "{description}: cycle length must match the input"
+        );
+        assert_eq!(
+            cycle.first(),
+            cycle.last(),
+            "{description}: cycle must be closed: first and last nodes must be equal"
+        );
+        assert!(
+            missing_dependencies.is_empty(),
+            "{description}: fixture must not report missing dependencies"
+        );
+        let rendered = error.to_string();
+        for node in &cycle_nodes {
+            assert!(
+                rendered.contains(node),
+                "{description}: Display output must contain node {node:?}: got {rendered:?}"
+            );
+        }
+    } else {
+        panic!("expected CircularDependency variant");
+    }
+}
+
 #[rstest]
 fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer) {
     let _en_localizer = en_localizer;
@@ -187,6 +240,37 @@ fn render_circular_dependency_json_matches_snapshot(en_localizer: EnLocalizer) -
     snapshot_settings().bind(|| {
         assert_snapshot!("circular_dependency_json", rendered);
     });
+    Ok(())
+}
+
+/// Verifies that `render_error_json` for a `CircularDependency` error produces
+/// a well-formed diagnostics document with a non-empty cause chain.
+#[rstest]
+fn render_circular_dependency_json_has_expected_shape(en_localizer: EnLocalizer) -> Result<()> {
+    let _en_localizer = en_localizer;
+    let error = anyhow::Error::new(circular_dependency_error())
+        .context(localization::message(keys::RUNNER_CONTEXT_BUILD_GRAPH));
+    let document = render_error_json(error.as_ref())?;
+    let value = parse_json_value(&document)?;
+    let diagnostic = first_diagnostic(&value)?;
+
+    let causes = diagnostic
+        .get("causes")
+        .and_then(Value::as_array)
+        .context("circular dependency JSON must include a causes array")?;
+    let message = diagnostic
+        .get("message")
+        .and_then(Value::as_str)
+        .context("circular dependency JSON must include a message string")?;
+
+    ensure!(
+        !causes.is_empty(),
+        "circular dependency must have at least one cause"
+    );
+    ensure!(
+        !message.is_empty(),
+        "circular dependency message must not be empty"
+    );
     Ok(())
 }
 

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -166,7 +166,7 @@ fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
 
 #[rstest]
 fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer) {
-    let _ = &en_localizer;
+    let _en_localizer = en_localizer;
     let rendered = circular_dependency_error().to_string();
 
     snapshot_settings().bind(|| {
@@ -176,7 +176,7 @@ fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer
 
 #[rstest]
 fn render_circular_dependency_json_matches_snapshot(en_localizer: EnLocalizer) -> Result<()> {
-    let _ = &en_localizer;
+    let _en_localizer = en_localizer;
     let error = anyhow::Error::new(circular_dependency_error())
         .context(localization::message(keys::RUNNER_CONTEXT_BUILD_GRAPH));
     let document = render_error_json(error.as_ref())?;

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -14,11 +14,13 @@ use std::path::PathBuf;
 use std::sync::MutexGuard;
 use test_support::{LocalizerGuard, localizer_test_lock, set_en_localizer};
 
+/// RAII bundle holding both the global localizer test lock and the locale guard for a test.
 struct EnLocalizer {
     _lock: MutexGuard<'static, ()>,
     _guard: LocalizerGuard,
 }
 
+/// Rstest fixture that acquires the localizer test lock and installs the English localiser.
 #[fixture]
 fn en_localizer() -> EnLocalizer {
     EnLocalizer {
@@ -27,10 +29,12 @@ fn en_localizer() -> EnLocalizer {
     }
 }
 
+/// Parses a JSON string into a [`serde_json::Value`].
 fn parse_json_value(document: &str) -> Result<Value> {
     serde_json::from_str(document).context("parse diagnostics JSON")
 }
 
+/// Builds insta [`Settings`] pointing at the `src/snapshots/diagnostic_json` directory.
 fn snapshot_settings() -> Settings {
     let mut settings = Settings::new();
     settings.set_snapshot_path(concat!(
@@ -40,6 +44,7 @@ fn snapshot_settings() -> Settings {
     settings
 }
 
+/// Extracts the first diagnostic object from the top-level `diagnostics` array.
 fn first_diagnostic(value: &Value) -> Result<&Map<String, Value>> {
     value
         .get("diagnostics")
@@ -49,6 +54,7 @@ fn first_diagnostic(value: &Value) -> Result<&Map<String, Value>> {
         .context("diagnostic entry should be an object")
 }
 
+/// Constructs a deterministic [`RunnerError::ManifestNotFound`] fixture.
 fn manifest_not_found_error() -> RunnerError {
     RunnerError::ManifestNotFound {
         manifest_name: String::from("Netsukefile"),

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -9,26 +9,10 @@ use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
 use proptest::prelude::*;
-use rstest::{fixture, rstest};
+use rstest::rstest;
 use serde_json::{Map, Value};
 use std::path::PathBuf;
-use std::sync::MutexGuard;
-use test_support::{LocalizerGuard, localizer_test_lock, set_en_localizer};
-
-/// RAII bundle holding both the global localizer test lock and the locale guard for a test.
-struct EnLocalizer {
-    _lock: MutexGuard<'static, ()>,
-    _guard: LocalizerGuard,
-}
-
-/// Rstest fixture that acquires the localizer test lock and installs the English localiser.
-#[fixture]
-fn en_localizer() -> EnLocalizer {
-    EnLocalizer {
-        _lock: localizer_test_lock().expect("localizer test lock poisoned"),
-        _guard: set_en_localizer(),
-    }
-}
+use test_support::{EnLocalizer, en_localizer};
 
 /// Parses a JSON string into a [`serde_json::Value`].
 fn parse_json_value(document: &str) -> Result<Value> {
@@ -152,9 +136,8 @@ fn render_plain_error_json_records_cause_chain() -> Result<()> {
 /// Verifies that `render_diagnostic_json` for a `RunnerError` includes the
 /// diagnostic code and help text without fabricating source-file spans or labels.
 #[rstest]
-fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
-    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
-    let _guard = set_en_localizer();
+fn render_runner_diagnostic_json_records_help_without_spans(en_localizer: EnLocalizer) -> Result<()> {
+    let _en_localizer = en_localizer;
     let document = render_diagnostic_json(&manifest_not_found_error())?;
     let value = parse_json_value(&document)?;
     let diagnostic = first_diagnostic(&value)?;
@@ -303,9 +286,8 @@ fn render_circular_dependency_json_has_expected_shape(en_localizer: EnLocalizer)
 /// Asserts that the JSON diagnostic output for a YAML parse error in the
 /// manifest matches the stored insta snapshot.
 #[rstest]
-fn render_manifest_parse_diagnostic_matches_snapshot() -> Result<()> {
-    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
-    let _guard = set_en_localizer();
+fn render_manifest_parse_diagnostic_matches_snapshot(en_localizer: EnLocalizer) -> Result<()> {
+    let _en_localizer = en_localizer;
     let err = manifest::from_str("targets:\n\t- name: test\n")
         .expect_err("invalid YAML should fail to parse");
     let manifest_err = err

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -1,10 +1,12 @@
 //! Tests for Netsuke's JSON diagnostics schema.
 
 use super::{render_diagnostic_json, render_error_json};
+use crate::ir::IrGenError;
 use crate::localization::{self, keys};
 use crate::manifest;
 use crate::runner::RunnerError;
 use anyhow::{Context, Result, ensure};
+use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
 use rstest::rstest;
 use serde_json::{Map, Value};
@@ -42,6 +44,21 @@ fn manifest_not_found_error() -> RunnerError {
             .with_arg("manifest_name", "Netsukefile")
             .with_arg("directory", "the current directory"),
         help: localization::message(keys::RUNNER_MANIFEST_NOT_FOUND_HELP),
+    }
+}
+
+fn circular_dependency_error() -> IrGenError {
+    let cycle = vec![
+        Utf8PathBuf::from("a"),
+        Utf8PathBuf::from("b"),
+        Utf8PathBuf::from("a"),
+    ];
+    let message =
+        localization::message(keys::IR_CIRCULAR_DEPENDENCY).with_arg("cycle", format!("{cycle:?}"));
+    IrGenError::CircularDependency {
+        cycle,
+        missing_dependencies: Vec::new(),
+        message,
     }
 }
 
@@ -130,6 +147,33 @@ fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
         labels == &Value::Array(Vec::new()),
         "manifest-not-found should not include labels",
     );
+    Ok(())
+}
+
+#[rstest]
+fn render_circular_dependency_display_matches_snapshot() {
+    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
+    let _guard = set_en_localizer();
+    let rendered = circular_dependency_error().to_string();
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!("circular_dependency_display", rendered);
+    });
+}
+
+#[rstest]
+fn render_circular_dependency_json_matches_snapshot() -> Result<()> {
+    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
+    let _guard = set_en_localizer();
+    let error = circular_dependency_error();
+    let document = render_error_json(&error)?;
+    let value = parse_json_value(&document)?;
+    let rendered =
+        serde_json::to_string_pretty(&value).context("render diagnostic JSON snapshot value")?;
+
+    snapshot_settings().bind(|| {
+        assert_snapshot!("circular_dependency_json", rendered);
+    });
     Ok(())
 }
 

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -136,7 +136,9 @@ fn render_plain_error_json_records_cause_chain() -> Result<()> {
 /// Verifies that `render_diagnostic_json` for a `RunnerError` includes the
 /// diagnostic code and help text without fabricating source-file spans or labels.
 #[rstest]
-fn render_runner_diagnostic_json_records_help_without_spans(en_localizer: EnLocalizer) -> Result<()> {
+fn render_runner_diagnostic_json_records_help_without_spans(
+    en_localizer: EnLocalizer,
+) -> Result<()> {
     let _en_localizer = en_localizer;
     let document = render_diagnostic_json(&manifest_not_found_error())?;
     let value = parse_json_value(&document)?;

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -165,8 +165,9 @@ fn render_circular_dependency_display_matches_snapshot() {
 fn render_circular_dependency_json_matches_snapshot() -> Result<()> {
     let _lock = localizer_test_lock().expect("localizer test lock poisoned");
     let _guard = set_en_localizer();
-    let error = circular_dependency_error();
-    let document = render_error_json(&error)?;
+    let error = anyhow::Error::new(circular_dependency_error())
+        .context(localization::message(keys::RUNNER_CONTEXT_BUILD_GRAPH));
+    let document = render_error_json(error.as_ref())?;
     let value = parse_json_value(&document)?;
     let rendered =
         serde_json::to_string_pretty(&value).context("render diagnostic JSON snapshot value")?;

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -8,7 +8,6 @@ use crate::runner::RunnerError;
 use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
-use proptest::prelude::*;
 use rstest::rstest;
 use serde_json::{Map, Value};
 use std::path::PathBuf;
@@ -71,17 +70,6 @@ fn circular_dependency_error_for(cycle_nodes: Vec<&str>) -> IrGenError {
 /// snapshot tests.
 fn circular_dependency_error() -> IrGenError {
     circular_dependency_error_for(vec!["a", "b", "a"])
-}
-
-/// Generates between `min` and `max` distinct single-character node names as
-/// [`Utf8PathBuf`] values.
-fn arb_unique_nodes(min: usize, max: usize) -> impl Strategy<Value = Vec<camino::Utf8PathBuf>> {
-    proptest::collection::vec("[a-z]", min..=max)
-        .prop_filter("nodes must be unique", |v| {
-            let set: std::collections::HashSet<_> = v.iter().collect();
-            set.len() == v.len()
-        })
-        .prop_map(|v| v.into_iter().map(camino::Utf8PathBuf::from).collect())
 }
 
 /// Verifies that `render_error_json` records a plain error's full cause chain
@@ -177,53 +165,6 @@ fn render_runner_diagnostic_json_records_help_without_spans(
     Ok(())
 }
 
-/// Verifies structural invariants of `IrGenError::CircularDependency` across
-/// cycle lengths without relying on snapshot output.
-#[rstest]
-#[case(vec!["x", "x"], "minimal two-node cycle")]
-#[case(vec!["a", "b", "a"], "three-node cycle")]
-#[case(vec!["a", "b", "c", "a"], "four-node cycle")]
-#[case(vec!["p", "q", "r", "s", "p"], "five-node cycle")]
-fn circular_dependency_structural_invariants(
-    en_localizer: EnLocalizer,
-    #[case] cycle_nodes: Vec<&str>,
-    #[case] description: &str,
-) {
-    let _en_localizer = en_localizer;
-    let error = circular_dependency_error_for(cycle_nodes.clone());
-
-    if let IrGenError::CircularDependency {
-        cycle,
-        missing_dependencies,
-        ..
-    } = &error
-    {
-        assert_eq!(
-            cycle.len(),
-            cycle_nodes.len(),
-            "{description}: cycle length must match the input"
-        );
-        assert_eq!(
-            cycle.first(),
-            cycle.last(),
-            "{description}: cycle must be closed: first and last nodes must be equal"
-        );
-        assert!(
-            missing_dependencies.is_empty(),
-            "{description}: fixture must not report missing dependencies"
-        );
-        let rendered = error.to_string();
-        for node in &cycle_nodes {
-            assert!(
-                rendered.contains(node),
-                "{description}: Display output must contain node {node:?}: got {rendered:?}"
-            );
-        }
-    } else {
-        panic!("expected CircularDependency variant");
-    }
-}
-
 /// Asserts that the `Display` output of `IrGenError::CircularDependency`
 /// matches the stored insta snapshot, preserving the user-facing format.
 #[rstest]
@@ -304,73 +245,4 @@ fn render_manifest_parse_diagnostic_matches_snapshot(en_localizer: EnLocalizer) 
         assert_snapshot!("manifest_parse_error", rendered);
     });
     Ok(())
-}
-
-proptest! {
-    /// Cycle closure holds for arbitrary unique node sequences of length 2–8:
-    /// the first and last elements of the constructed cycle are always equal.
-    #[test]
-    fn prop_circular_dependency_cycle_is_closed(
-        nodes in arb_unique_nodes(2, 8),
-    ) {
-        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
-        let mut cycle_nodes = base_nodes;
-        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
-        let error = circular_dependency_error_for(cycle_nodes);
-        if let IrGenError::CircularDependency { cycle, .. } = &error {
-            prop_assert_eq!(cycle.first(), cycle.last());
-        }
-    }
-
-    /// Cycle length equals the number of input nodes plus one (the closure
-    /// node), for arbitrary unique node sequences of length 2–8.
-    #[test]
-    fn prop_circular_dependency_cycle_length_matches_input(
-        nodes in arb_unique_nodes(2, 8),
-    ) {
-        let input_len = nodes.len();
-        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
-        let mut cycle_nodes = base_nodes;
-        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
-        let error = circular_dependency_error_for(cycle_nodes);
-        if let IrGenError::CircularDependency { cycle, .. } = &error {
-            prop_assert_eq!(cycle.len(), input_len + 1);
-        }
-    }
-
-    /// The fixture never populates `missing_dependencies`, regardless of cycle
-    /// size.
-    #[test]
-    fn prop_circular_dependency_missing_deps_is_empty(
-        nodes in arb_unique_nodes(2, 8),
-    ) {
-        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
-        let mut cycle_nodes = base_nodes;
-        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
-        let error = circular_dependency_error_for(cycle_nodes);
-        if let IrGenError::CircularDependency { missing_dependencies, .. } = &error {
-            prop_assert!(missing_dependencies.is_empty());
-        }
-    }
-
-    /// The `Display` output contains every node in the cycle, for arbitrary
-    /// unique node sequences of length 2–8.
-    #[test]
-    fn prop_circular_dependency_display_contains_all_nodes(
-        nodes in arb_unique_nodes(2, 8),
-    ) {
-        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
-        let mut cycle_nodes = base_nodes;
-        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
-        // Display does not require locale pinning: it need not produce
-        // localised output for the structural node-presence assertion.
-        let error = circular_dependency_error_for(cycle_nodes);
-        let rendered = error.to_string();
-        for node in &nodes {
-            prop_assert!(
-                rendered.contains(node.as_str()),
-                "Display output must contain {node:?}; got {rendered:?}",
-            );
-        }
-    }
 }

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -8,6 +8,7 @@ use crate::runner::RunnerError;
 use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
+use proptest::prelude::*;
 use rstest::{fixture, rstest};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
@@ -86,6 +87,17 @@ fn circular_dependency_error_for(cycle_nodes: Vec<&str>) -> IrGenError {
 /// snapshot tests.
 fn circular_dependency_error() -> IrGenError {
     circular_dependency_error_for(vec!["a", "b", "a"])
+}
+
+/// Generates between `min` and `max` distinct single-character node names as
+/// [`Utf8PathBuf`] values.
+fn arb_unique_nodes(min: usize, max: usize) -> impl Strategy<Value = Vec<camino::Utf8PathBuf>> {
+    proptest::collection::vec("[a-z]", min..=max)
+        .prop_filter("nodes must be unique", |v| {
+            let set: std::collections::HashSet<_> = v.iter().collect();
+            set.len() == v.len()
+        })
+        .prop_map(|v| v.into_iter().map(camino::Utf8PathBuf::from).collect())
 }
 
 /// Verifies that `render_error_json` records a plain error's full cause chain
@@ -308,4 +320,73 @@ fn render_manifest_parse_diagnostic_matches_snapshot() -> Result<()> {
         assert_snapshot!("manifest_parse_error", rendered);
     });
     Ok(())
+}
+
+proptest! {
+    /// Cycle closure holds for arbitrary unique node sequences of length 2–8:
+    /// the first and last elements of the constructed cycle are always equal.
+    #[test]
+    fn prop_circular_dependency_cycle_is_closed(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
+        let mut cycle_nodes = base_nodes;
+        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
+        let error = circular_dependency_error_for(cycle_nodes);
+        if let IrGenError::CircularDependency { cycle, .. } = &error {
+            prop_assert_eq!(cycle.first(), cycle.last());
+        }
+    }
+
+    /// Cycle length equals the number of input nodes plus one (the closure
+    /// node), for arbitrary unique node sequences of length 2–8.
+    #[test]
+    fn prop_circular_dependency_cycle_length_matches_input(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let input_len = nodes.len();
+        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
+        let mut cycle_nodes = base_nodes;
+        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
+        let error = circular_dependency_error_for(cycle_nodes);
+        if let IrGenError::CircularDependency { cycle, .. } = &error {
+            prop_assert_eq!(cycle.len(), input_len + 1);
+        }
+    }
+
+    /// The fixture never populates `missing_dependencies`, regardless of cycle
+    /// size.
+    #[test]
+    fn prop_circular_dependency_missing_deps_is_empty(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
+        let mut cycle_nodes = base_nodes;
+        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
+        let error = circular_dependency_error_for(cycle_nodes);
+        if let IrGenError::CircularDependency { missing_dependencies, .. } = &error {
+            prop_assert!(missing_dependencies.is_empty());
+        }
+    }
+
+    /// The `Display` output contains every node in the cycle, for arbitrary
+    /// unique node sequences of length 2–8.
+    #[test]
+    fn prop_circular_dependency_display_contains_all_nodes(
+        nodes in arb_unique_nodes(2, 8),
+    ) {
+        let base_nodes: Vec<&str> = nodes.iter().map(|node| node.as_str()).collect();
+        let mut cycle_nodes = base_nodes;
+        cycle_nodes.push(cycle_nodes.first().copied().expect("nodes must be non-empty"));
+        // Display does not require locale pinning: it need not produce
+        // localised output for the structural node-presence assertion.
+        let error = circular_dependency_error_for(cycle_nodes);
+        let rendered = error.to_string();
+        for node in &nodes {
+            prop_assert!(
+                rendered.contains(node.as_str()),
+                "Display output must contain {node:?}; got {rendered:?}",
+            );
+        }
+    }
 }

--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -8,10 +8,24 @@ use crate::runner::RunnerError;
 use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
 use insta::{Settings, assert_snapshot};
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
-use test_support::{localizer_test_lock, set_en_localizer};
+use std::sync::MutexGuard;
+use test_support::{LocalizerGuard, localizer_test_lock, set_en_localizer};
+
+struct EnLocalizer {
+    _lock: MutexGuard<'static, ()>,
+    _guard: LocalizerGuard,
+}
+
+#[fixture]
+fn en_localizer() -> EnLocalizer {
+    EnLocalizer {
+        _lock: localizer_test_lock().expect("localizer test lock poisoned"),
+        _guard: set_en_localizer(),
+    }
+}
 
 fn parse_json_value(document: &str) -> Result<Value> {
     serde_json::from_str(document).context("parse diagnostics JSON")
@@ -151,9 +165,8 @@ fn render_runner_diagnostic_json_records_help_without_spans() -> Result<()> {
 }
 
 #[rstest]
-fn render_circular_dependency_display_matches_snapshot() {
-    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
-    let _guard = set_en_localizer();
+fn render_circular_dependency_display_matches_snapshot(en_localizer: EnLocalizer) {
+    let _ = &en_localizer;
     let rendered = circular_dependency_error().to_string();
 
     snapshot_settings().bind(|| {
@@ -162,9 +175,8 @@ fn render_circular_dependency_display_matches_snapshot() {
 }
 
 #[rstest]
-fn render_circular_dependency_json_matches_snapshot() -> Result<()> {
-    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
-    let _guard = set_en_localizer();
+fn render_circular_dependency_json_matches_snapshot(en_localizer: EnLocalizer) -> Result<()> {
+    let _ = &en_localizer;
     let error = anyhow::Error::new(circular_dependency_error())
         .context(localization::message(keys::RUNNER_CONTEXT_BUILD_GRAPH));
     let document = render_error_json(error.as_ref())?;

--- a/src/manifest/tests/macros.rs
+++ b/src/manifest/tests/macros.rs
@@ -9,8 +9,7 @@ use anyhow::{Context, Result as AnyResult, anyhow, ensure};
 use minijinja::value::{Kwargs, Value};
 use minijinja::{Environment, UndefinedBehavior};
 use rstest::{fixture, rstest};
-use std::sync::Arc;
-use test_support::localizer_test_lock;
+use test_support::{EnLocalizer, en_localizer};
 
 struct MacroRenderCase<'a> {
     signature: &'a str,
@@ -28,21 +27,6 @@ fn strict_env() -> Environment<'static> {
     let mut env = Environment::new();
     env.set_undefined_behavior(UndefinedBehavior::Strict);
     env
-}
-
-type EnLocalizerFixture = (
-    std::sync::MutexGuard<'static, ()>,
-    crate::localization::LocalizerGuard,
-);
-
-#[fixture]
-fn en_localizer() -> AnyResult<EnLocalizerFixture> {
-    let lock = localizer_test_lock()
-        .map_err(|e| anyhow::Error::msg(e.to_string()))
-        .context("localizer test lock poisoned")?;
-    let localizer = crate::cli_localization::build_localizer(Some("en-US"));
-    let guard = localization::set_localizer_for_tests(Arc::from(localizer));
-    Ok((lock, guard))
 }
 
 #[rstest]
@@ -65,11 +49,11 @@ fn parse_macro_name_extracts_identifier(
 #[case("(name)", keys::MANIFEST_MACRO_SIGNATURE_MISSING_IDENTIFIER)]
 #[case("   ", keys::MANIFEST_MACRO_SIGNATURE_MISSING_IDENTIFIER)]
 fn parse_macro_name_errors(
-    en_localizer: AnyResult<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] signature: &str,
     #[case] key: &'static str,
 ) -> AnyResult<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     let expected = localization::message(key).to_string();
     match parse_macro_name(signature) {
         Ok(name) => Err(anyhow!(
@@ -184,12 +168,12 @@ fn register_macro_is_reusable(mut strict_env: Environment<'static>) -> AnyResult
 
 /// Helper to verify macro registration fails with expected error.
 fn assert_macro_registration_fails(
-    en_localizer: AnyResult<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     doc: &ManifestValue,
     env: &mut Environment<'static>,
     fail_message: &str,
 ) -> AnyResult<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     match register_manifest_macros(doc, env) {
         Ok(()) => Err(anyhow!("{fail_message}")),
         Err(err) => {
@@ -206,7 +190,7 @@ fn assert_macro_registration_fails(
 #[rstest]
 fn register_manifest_macros_validates_shape(
     mut strict_env: Environment<'static>,
-    en_localizer: AnyResult<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
 ) -> AnyResult<()> {
     let mut mapping = ManifestMap::new();
     mapping.insert(
@@ -250,7 +234,7 @@ fn build_macro_doc(macro_mapping: ManifestMap) -> ManifestValue {
 )]
 fn register_manifest_macros_invalid_macro_entry(
     mut strict_env: Environment<'static>,
-    en_localizer: AnyResult<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] macro_mapping: ManifestMap,
     #[case] fail_message: &str,
 ) -> AnyResult<()> {

--- a/src/output_prefs_tests.rs
+++ b/src/output_prefs_tests.rs
@@ -1,17 +1,12 @@
 //! Tests for output preference resolution and token-backed prefix rendering.
 
 use super::*;
-use crate::cli_localization;
-use crate::localization::{self, LocalizerGuard};
 use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
 use anyhow::{Result, ensure};
 use insta::assert_snapshot;
-use rstest::{fixture, rstest};
-use std::error::Error;
-use std::fmt;
-use std::sync::{Arc, MutexGuard};
+use rstest::rstest;
 use test_support::fluent::normalize_fluent_isolates;
-use test_support::localizer::localizer_test_lock;
+use test_support::{EnLocalizer, en_localizer};
 
 #[derive(Debug)]
 struct ThemeResolutionCase<'a> {
@@ -59,17 +54,6 @@ fn resolve_output_prefs(
 ) {
     let env = fake_env(no_color, no_emoji_env);
     assert_eq!(resolve_with(no_emoji, env).emoji_allowed(), expected_emoji);
-}
-
-#[fixture]
-fn en_us_localizer() -> Result<EnUsLocalizerFixture, EnUsLocalizerFixtureError> {
-    let lock = localizer_test_lock()?;
-    let localizer = Arc::from(cli_localization::build_localizer(Some("en-US")));
-    let guard = localization::set_localizer_for_tests(localizer);
-    Ok(EnUsLocalizerFixture {
-        _lock: lock,
-        _guard: guard,
-    })
 }
 
 #[rstest]
@@ -155,12 +139,12 @@ fn resolve_from_theme_with_uses_theme_resolution(#[case] case: ThemeResolutionCa
 )]
 #[case::ascii_timing(Some(ThemePreference::Ascii), OutputPrefs::timing_prefix, "T Timing:")]
 fn prefix_rendering_uses_theme_symbols(
-    en_us_localizer: Result<EnUsLocalizerFixture, EnUsLocalizerFixtureError>,
+    en_localizer: EnLocalizer,
     #[case] theme: Option<ThemePreference>,
     #[case] prefix_fn: fn(OutputPrefs) -> String,
     #[case] expected: &str,
 ) -> Result<()> {
-    let _localizer = en_us_localizer?;
+    let _localizer = en_localizer;
     let prefs = resolve_from_theme_with(
         theme,
         ThemeContext::new(None, None, OutputMode::Standard),
@@ -185,36 +169,16 @@ fn spacing_accessors_follow_resolved_theme(#[case] mode: OutputMode) {
     assert_eq!(prefs.task_indent(), "  ");
     assert_eq!(prefs.timing_indent(), "  ");
 }
-struct EnUsLocalizerFixture {
-    _lock: MutexGuard<'static, ()>,
-    _guard: LocalizerGuard,
-}
-#[derive(Debug)]
-struct EnUsLocalizerFixtureError(String);
-
-impl fmt::Display for EnUsLocalizerFixtureError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl Error for EnUsLocalizerFixtureError {}
-
-impl From<std::sync::PoisonError<MutexGuard<'static, ()>>> for EnUsLocalizerFixtureError {
-    fn from(err: std::sync::PoisonError<MutexGuard<'static, ()>>) -> Self {
-        Self(err.to_string())
-    }
-}
 
 #[rstest]
 #[case::unicode(crate::theme::ThemePreference::Unicode, "all_prefixes_unicode")]
 #[case::ascii(crate::theme::ThemePreference::Ascii, "all_prefixes_ascii")]
 fn prefix_and_spacing_snapshot(
-    en_us_localizer: Result<EnUsLocalizerFixture, EnUsLocalizerFixtureError>,
+    en_localizer: EnLocalizer,
     #[case] theme: crate::theme::ThemePreference,
     #[case] snapshot_name: &str,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+) {
+    let _localizer = en_localizer;
     let prefs = theme_prefs(theme);
     let rendered = normalize_fluent_isolates(&format!(
         concat!(
@@ -238,5 +202,4 @@ fn prefix_and_spacing_snapshot(
     snapshot_settings("output_prefs").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
-    Ok(())
 }

--- a/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap
+++ b/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap
@@ -1,0 +1,5 @@
+---
+source: src/diagnostic_json_tests.rs
+expression: rendered
+---
+Circular dependency detected: ⁨["a", "b", "a"]⁩.

--- a/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap
+++ b/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap
@@ -10,12 +10,14 @@ expression: rendered
   },
   "diagnostics": [
     {
-      "message": "Circular dependency detected: ⁨[\"a\", \"b\", \"a\"]⁩.",
+      "message": "Failed to build graph from the manifest.",
       "code": null,
       "severity": "error",
       "help": null,
       "url": null,
-      "causes": [],
+      "causes": [
+        "Circular dependency detected: ⁨[\"a\", \"b\", \"a\"]⁩."
+      ],
       "source": null,
       "primary_span": null,
       "labels": [],

--- a/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap
+++ b/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap
@@ -1,0 +1,25 @@
+---
+source: src/diagnostic_json_tests.rs
+expression: rendered
+---
+{
+  "schema_version": 1,
+  "generator": {
+    "name": "netsuke",
+    "version": "0.1.0"
+  },
+  "diagnostics": [
+    {
+      "message": "Circular dependency detected: ⁨[\"a\", \"b\", \"a\"]⁩.",
+      "code": null,
+      "severity": "error",
+      "help": null,
+      "url": null,
+      "causes": [],
+      "source": null,
+      "primary_span": null,
+      "labels": [],
+      "related": []
+    }
+  ]
+}

--- a/src/status_tests.rs
+++ b/src/status_tests.rs
@@ -14,16 +14,14 @@
 )]
 
 use super::*;
-use crate::cli_localization;
-use crate::localization::{self, LocalizerGuard};
+use crate::localization;
 use crate::output_prefs;
 use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
 use anyhow::{Result, ensure};
 use insta::assert_snapshot;
 use rstest::{fixture, rstest};
-use std::sync::{Arc, MutexGuard};
 use test_support::fluent::normalize_fluent_isolates;
-use test_support::localizer::localizer_test_lock;
+use test_support::{EnLocalizer, en_localizer};
 
 fn test_prefs() -> crate::output_prefs::OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
@@ -39,23 +37,6 @@ fn stage6_message(reporter: &IndicatifReporter) -> String {
         .get(STAGE6_INDEX)
         .expect("stage 6 progress bar should exist")
         .message()
-}
-
-struct EnUsLocalizerFixture {
-    _lock: MutexGuard<'static, ()>,
-    _guard: LocalizerGuard,
-}
-
-#[fixture]
-fn en_us_localizer() -> Result<EnUsLocalizerFixture> {
-    let lock = localizer_test_lock()
-        .map_err(|err| anyhow::anyhow!("failed to acquire localizer test lock: {err}"))?;
-    let localizer = Arc::from(cli_localization::build_localizer(Some("en-US")));
-    let guard = localization::set_localizer_for_tests(localizer);
-    Ok(EnUsLocalizerFixture {
-        _lock: lock,
-        _guard: guard,
-    })
 }
 
 #[fixture]
@@ -115,13 +96,13 @@ fn localization_key_from_static_str() {
 #[case(1, 2, "cc -c src/main.c", "Task 1/2: cc -c src/main.c")]
 #[case(2, 2, "", "Task 2/2")]
 fn task_progress_update_formats_expected_text(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] current: u32,
     #[case] total: u32,
     #[case] description: &str,
     #[case] expected: &str,
 ) -> Result<()> {
-    let _localizer = en_us_localizer?;
+    let _localizer = en_localizer;
     let rendered = task_progress_update(current, total, description);
     ensure!(
         normalize_fluent_isolates(&rendered) == expected,
@@ -132,10 +113,10 @@ fn task_progress_update_formats_expected_text(
 
 #[rstest]
 fn indicatif_reporter_ignores_task_updates_when_stage6_is_not_running(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     force_text_reporter: IndicatifReporter,
 ) -> Result<()> {
-    let _localizer = en_us_localizer?;
+    let _localizer = en_localizer;
     force_text_reporter.report_task_progress(1, 2, "cc -c src/a.c");
     let stage6_message = stage6_message(&force_text_reporter);
     ensure!(
@@ -147,10 +128,10 @@ fn indicatif_reporter_ignores_task_updates_when_stage6_is_not_running(
 
 #[rstest]
 fn indicatif_reporter_sets_stage6_bar_message_for_non_text_updates(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     running_stage6_reporter: IndicatifReporter,
 ) -> Result<()> {
-    let _localizer = en_us_localizer?;
+    let _localizer = en_localizer;
     running_stage6_reporter.report_task_progress(1, 2, "cc -c src/a.c");
     let stage6_message = stage6_message(&running_stage6_reporter);
     let task = task_progress_update(1, 2, "cc -c src/a.c");
@@ -173,10 +154,8 @@ fn indicatif_reporter_sets_stage6_bar_message_for_non_text_updates(
 }
 
 #[rstest]
-fn accessible_reporter_formats_stage_with_info_prefix(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+fn accessible_reporter_formats_stage_with_info_prefix(en_localizer: EnLocalizer) -> Result<()> {
+    let _localizer = en_localizer;
     let prefs = test_prefs();
     let reporter = AccessibleReporter::with_writer(prefs, Vec::new());
     reporter.report_stage(
@@ -203,10 +182,8 @@ fn accessible_reporter_formats_stage_with_info_prefix(
 }
 
 #[rstest]
-fn accessible_reporter_indents_task_progress(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+fn accessible_reporter_indents_task_progress(en_localizer: EnLocalizer) -> Result<()> {
+    let _localizer = en_localizer;
     let prefs = test_prefs();
     let reporter = AccessibleReporter::with_writer(prefs, Vec::new());
     reporter.report_task_progress(1, 2, "cc -c src/main.c");
@@ -229,10 +206,8 @@ fn accessible_reporter_indents_task_progress(
 }
 
 #[rstest]
-fn completion_line_includes_success_prefix(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+fn completion_line_includes_success_prefix(en_localizer: EnLocalizer) -> Result<()> {
+    let _localizer = en_localizer;
     let prefs = test_prefs();
     let line = normalize_fluent_isolates(&format_completion_line(
         prefs,
@@ -256,11 +231,11 @@ fn completion_line_includes_success_prefix(
     "accessible_ascii_stage_and_completion"
 )]
 fn accessible_reporter_stage_and_completion_snapshot(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] theme: crate::theme::ThemePreference,
     #[case] snapshot_name: &str,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+) {
+    let _localizer = en_localizer;
     let prefs = theme_prefs(theme);
     let reporter = AccessibleReporter::with_writer(prefs, Vec::new());
 
@@ -282,7 +257,6 @@ fn accessible_reporter_stage_and_completion_snapshot(
     snapshot_settings("status").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
-    Ok(())
 }
 
 #[rstest]
@@ -292,11 +266,11 @@ fn accessible_reporter_stage_and_completion_snapshot(
 )]
 #[case::ascii(crate::theme::ThemePreference::Ascii, "accessible_ascii_task_progress")]
 fn accessible_reporter_task_progress_snapshot(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] theme: crate::theme::ThemePreference,
     #[case] snapshot_name: &str,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+) {
+    let _localizer = en_localizer;
     let reporter = AccessibleReporter::with_writer(theme_prefs(theme), Vec::new());
     reporter.report_task_progress(1, 2, "cc -c src/a.c");
     reporter.report_task_progress(2, 2, "cc -c src/b.c");
@@ -310,5 +284,4 @@ fn accessible_reporter_task_progress_snapshot(
     snapshot_settings("status").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
-    Ok(())
 }

--- a/src/status_timing_tests.rs
+++ b/src/status_timing_tests.rs
@@ -1,39 +1,19 @@
 //! Tests for verbose timing summary support.
 
 use super::*;
-use crate::cli_localization;
-use crate::localization::{self, LocalizerGuard};
 use crate::output_prefs;
 use crate::snapshot_test_support::{snapshot_settings, theme_prefs};
-use anyhow::Result;
 use insta::assert_snapshot;
 use rstest::{fixture, rstest};
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, MutexGuard};
 use test_support::fluent::normalize_fluent_isolates;
-use test_support::localizer::localizer_test_lock;
+use test_support::{EnLocalizer, en_localizer};
 
 #[fixture]
 fn test_prefs() -> OutputPrefs {
     output_prefs::resolve_with(None, |_| None)
-}
-
-struct EnUsLocalizerFixture {
-    _lock: MutexGuard<'static, ()>,
-    _guard: LocalizerGuard,
-}
-
-#[fixture]
-fn en_us_localizer() -> Result<EnUsLocalizerFixture> {
-    let lock = localizer_test_lock()
-        .map_err(|err| anyhow::anyhow!("failed to acquire localizer test lock: {err}"))?;
-    let localizer = Arc::from(cli_localization::build_localizer(Some("en-US")));
-    let guard = localization::set_localizer_for_tests(localizer);
-    Ok(EnUsLocalizerFixture {
-        _lock: lock,
-        _guard: guard,
-    })
 }
 
 #[derive(Debug)]
@@ -293,11 +273,11 @@ fn verbose_timing_reporter_suppresses_progress_updates_after_complete(test_prefs
 #[case::unicode(crate::theme::ThemePreference::Unicode, "timing_summary_unicode")]
 #[case::ascii(crate::theme::ThemePreference::Ascii, "timing_summary_ascii")]
 fn timing_summary_snapshot(
-    en_us_localizer: Result<EnUsLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] theme: crate::theme::ThemePreference,
     #[case] snapshot_name: &str,
-) -> Result<()> {
-    let _localizer = en_us_localizer?;
+) {
+    let _localizer = en_localizer;
     let total = StageNumber::new_unchecked(6);
     let mut state = TimingState::default();
     state.start_stage(
@@ -333,6 +313,4 @@ fn timing_summary_snapshot(
     snapshot_settings("status_timing").bind(|| {
         assert_snapshot!(snapshot_name, rendered);
     });
-
-    Ok(())
 }

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -16,6 +16,6 @@ anyhow = "1"
 thiserror = "1"
 assert_cmd = "2.0.0"
 netsuke = { path = ".." }
+rstest = "0.18.0"
 
 [dev-dependencies]
-rstest = "0.18.0"

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -46,7 +46,7 @@ pub use cwd_guard::CwdGuard;
 pub use env_guard::{EnvGuard, Environment, StdEnv};
 
 /// Re-export localizer helpers for integration tests.
-pub use localizer::{localizer_test_lock, set_en_localizer};
+pub use localizer::{LocalizerGuard, localizer_test_lock, set_en_localizer};
 
 /// Re-export manifest helpers for integration tests.
 pub use manifest::ensure_manifest_exists;

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -4,6 +4,8 @@
 //! - creating fake executables for process-related tests
 //! - manipulating PATH safely (PathGuard)
 //! - serializing environment mutation across tests (EnvLock)
+//! - pinning the active locale for snapshot tests (LocalizerGuard,
+//!   localizer_test_lock, set_en_localizer)
 //! - computing SHA-256 hashes for cache keys (hash module)
 //! - spawning lightweight HTTP servers for network tests (http module)
 //!

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -48,7 +48,9 @@ pub use cwd_guard::CwdGuard;
 pub use env_guard::{EnvGuard, Environment, StdEnv};
 
 /// Re-export localizer helpers for integration tests.
-pub use localizer::{LocalizerGuard, localizer_test_lock, set_en_localizer};
+pub use localizer::{
+    EnLocalizer, LocalizerGuard, en_localizer, localizer_test_lock, set_en_localizer,
+};
 
 /// Re-export manifest helpers for integration tests.
 pub use manifest::ensure_manifest_exists;

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -4,8 +4,9 @@
 //! - creating fake executables for process-related tests
 //! - manipulating PATH safely (PathGuard)
 //! - serializing environment mutation across tests (EnvLock)
-//! - pinning the active locale for snapshot tests (LocalizerGuard,
-//!   localizer_test_lock, set_en_localizer)
+//! - pinning the active locale for snapshot tests (the EnLocalizer RAII bundle
+//!   and its en_localizer fixture, plus LocalizerGuard, localizer_test_lock,
+//!   and set_en_localizer)
 //! - computing SHA-256 hashes for cache keys (hash module)
 //! - spawning lightweight HTTP servers for network tests (http module)
 //!

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -4,9 +4,8 @@
 //! - creating fake executables for process-related tests
 //! - manipulating PATH safely (PathGuard)
 //! - serializing environment mutation across tests (EnvLock)
-//! - pinning the active locale for snapshot tests (the EnLocalizer RAII bundle
-//!   and its en_localizer fixture, plus LocalizerGuard, localizer_test_lock,
-//!   and set_en_localizer)
+//! - pinning the active locale for snapshot tests (EnLocalizer, en_localizer,
+//!   LocalizerGuard, localizer_test_lock, set_en_localizer)
 //! - computing SHA-256 hashes for cache keys (hash module)
 //! - spawning lightweight HTTP servers for network tests (http module)
 //!

--- a/test_support/src/localizer.rs
+++ b/test_support/src/localizer.rs
@@ -3,6 +3,7 @@
 use netsuke::cli_localization;
 use netsuke::localization;
 pub use netsuke::localization::LocalizerGuard;
+use rstest::fixture;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
 /// Mutex used to serialize process-wide localizer mutations in tests.
@@ -18,4 +19,34 @@ pub fn localizer_test_lock() -> Result<MutexGuard<'static, ()>, PoisonError<Mute
 pub fn set_en_localizer() -> LocalizerGuard {
     let localizer = cli_localization::build_localizer(Some("en-US"));
     localization::set_localizer_for_tests(Arc::from(localizer))
+}
+
+/// RAII bundle holding both the global localiser test lock and the English
+/// locale guard for the lifetime of a test.
+///
+/// Construct via the [`en_localizer`] rstest fixture.  Both guards are
+/// released when this value is dropped.
+pub struct EnLocalizer {
+    _lock: MutexGuard<'static, ()>,
+    _guard: LocalizerGuard,
+}
+
+/// Rstest fixture that acquires the global localiser test lock and installs
+/// the English localiser, returning an [`EnLocalizer`] RAII bundle.
+///
+/// Bind the returned value immediately in each test body:
+///
+/// ```rust,ignore
+/// #[rstest]
+/// fn my_test(en_localizer: EnLocalizer) {
+///     let _en_localizer = en_localizer;
+///     // … assertions …
+/// }
+/// ```
+#[fixture]
+pub fn en_localizer() -> EnLocalizer {
+    EnLocalizer {
+        _lock: localizer_test_lock().expect("localizer test lock poisoned"),
+        _guard: set_en_localizer(),
+    }
 }

--- a/test_support/src/localizer.rs
+++ b/test_support/src/localizer.rs
@@ -1,7 +1,8 @@
 //! Test helpers for localizer configuration.
 
 use netsuke::cli_localization;
-use netsuke::localization::{self, LocalizerGuard};
+use netsuke::localization;
+pub use netsuke::localization::LocalizerGuard;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
 /// Mutex used to serialize process-wide localizer mutations in tests.

--- a/tests/manifest_glob_tests.rs
+++ b/tests/manifest_glob_tests.rs
@@ -3,11 +3,11 @@
 use anyhow::{Context, Result, anyhow, ensure};
 use netsuke::{
     ast::{NetsukeManifest, StringOrList},
-    cli_localization, localization, manifest,
+    manifest,
 };
 use rstest::{fixture, rstest};
-use std::{fs, path::Path, sync::Arc};
-use test_support::{display_error_chain, localizer_test_lock, manifest::manifest_yaml};
+use std::{fs, path::Path};
+use test_support::{EnLocalizer, display_error_chain, en_localizer, manifest::manifest_yaml};
 
 #[derive(Debug)]
 struct TestFiles<'a> {
@@ -28,21 +28,6 @@ struct GlobTestCase<'a> {
 struct BraceErrorTestCase<'a> {
     pub pattern: &'a str,
     pub expected: &'a str,
-}
-
-type EnLocalizerFixture = (
-    std::sync::MutexGuard<'static, ()>,
-    localization::LocalizerGuard,
-);
-
-#[fixture]
-fn en_localizer() -> Result<EnLocalizerFixture> {
-    let lock = localizer_test_lock()
-        .map_err(|e| anyhow::Error::msg(e.to_string()))
-        .context("localizer test lock poisoned")?;
-    let localizer = cli_localization::build_localizer(Some("en-US"));
-    let guard = localization::set_localizer_for_tests(Arc::from(localizer));
-    Ok((lock, guard))
 }
 
 fn target_names(manifest: &NetsukeManifest) -> Result<Vec<String>> {
@@ -88,11 +73,11 @@ fn parse_error_msg(yaml: &str) -> Result<String> {
 
 /// Helper to assert that a glob pattern produces an error message containing expected substrings.
 fn assert_glob_error_contains(
-    en_localizer: Result<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     pattern: &str,
     expected_substrings: &[&str],
 ) -> Result<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     let yaml = manifest_yaml(&format!(
         "targets:\n  - foreach: glob('{pattern}')\n    name: bad\n    command: echo hi\n"
     ));
@@ -209,7 +194,7 @@ fn test_glob_behavior(temp_dir: tempfile::TempDir, #[case] case: GlobTestCase) -
 }
 
 #[rstest]
-fn glob_unmatched_bracket_errors(en_localizer: Result<EnLocalizerFixture>) -> Result<()> {
+fn glob_unmatched_bracket_errors(en_localizer: EnLocalizer) -> Result<()> {
     assert_glob_error_contains(
         en_localizer,
         "[",
@@ -223,10 +208,10 @@ fn glob_unmatched_bracket_errors(en_localizer: Result<EnLocalizerFixture>) -> Re
 #[case(BraceErrorTestCase { pattern: "foo{bar{baz.txt", expected: "unmatched" })]
 #[case(BraceErrorTestCase { pattern: "{a,b{c,d}", expected: "unmatched" })]
 fn glob_unmatched_brace_errors(
-    en_localizer: Result<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] case: BraceErrorTestCase,
 ) -> Result<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     let yaml = manifest_yaml(&format!(
         "targets:\n  - foreach: glob('{pattern}')\n    name: bad\n    command: echo hi\n",
         pattern = case.pattern,
@@ -243,10 +228,10 @@ fn glob_unmatched_brace_errors(
 #[case(BraceErrorTestCase { pattern: "foo\\\\{bar}", expected: "unmatched" })]
 #[case(BraceErrorTestCase { pattern: "{foo\\\\}", expected: "unmatched" })]
 fn glob_unmatched_brace_errors_with_escapes(
-    en_localizer: Result<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] case: BraceErrorTestCase,
 ) -> Result<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     let yaml = manifest_yaml(&format!(
         "targets:\n  - foreach: glob('{pattern}')\n    name: bad\n    command: echo hi\n",
         pattern = case.pattern,
@@ -258,16 +243,12 @@ fn glob_unmatched_brace_errors_with_escapes(
 }
 
 #[rstest]
-fn glob_unmatched_opening_brace_reports_position(
-    en_localizer: Result<EnLocalizerFixture>,
-) -> Result<()> {
+fn glob_unmatched_opening_brace_reports_position(en_localizer: EnLocalizer) -> Result<()> {
     assert_glob_error_contains(en_localizer, "{", &["unmatched", "position"])
 }
 
 #[rstest]
-fn glob_unmatched_closing_brace_reports_position(
-    en_localizer: Result<EnLocalizerFixture>,
-) -> Result<()> {
+fn glob_unmatched_closing_brace_reports_position(en_localizer: EnLocalizer) -> Result<()> {
     assert_glob_error_contains(en_localizer, "foo}", &["unmatched", "position"])
 }
 
@@ -293,10 +274,10 @@ fn glob_escaped_braces_are_literals(#[case] case: BraceErrorTestCase) -> Result<
 #[case(BraceErrorTestCase { pattern: "\\{foo", expected: "unmatched" })]
 #[case(BraceErrorTestCase { pattern: "foo\\}", expected: "unmatched" })]
 fn glob_windows_backslash_does_not_escape_braces(
-    en_localizer: Result<EnLocalizerFixture>,
+    en_localizer: EnLocalizer,
     #[case] case: BraceErrorTestCase,
 ) -> Result<()> {
-    let (_lock, _guard) = en_localizer?;
+    let _en = en_localizer;
     let yaml = manifest_yaml(&format!(
         "targets:\n  - foreach: glob('{pattern}')\n    name: bad\n    command: echo hi\n",
         pattern = case.pattern,


### PR DESCRIPTION
## Summary

This branch adds `insta` snapshot coverage for Issue #332 so the user-facing `IrGenError::CircularDependency` message remains stable after the cycle-detection traversal refactor.

Closes #332.

## Review walkthrough

- Start with [src/diagnostic_json_tests.rs](https://github.com/leynos/netsuke/blob/issue-332-snapshot-tests-for-circulardependency-error-message-formatting/src/diagnostic_json_tests.rs) to see the representative circular dependency fixture and the two snapshot assertions.
- Then review [src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap](https://github.com/leynos/netsuke/blob/issue-332-snapshot-tests-for-circulardependency-error-message-formatting/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap) for the direct `Display` output.
- Finish with [src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap](https://github.com/leynos/netsuke/blob/issue-332-snapshot-tests-for-circulardependency-error-message-formatting/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_json.snap) for the generic diagnostic JSON rendering.

## Validation

- `INSTA_UPDATE=always cargo test render_circular_dependency --workspace`: passed.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed.
- `coderabbit review --agent`: passed with `findings: 0`.

## Summary by Sourcery

Tests:
- Add insta snapshot tests for circular dependency display formatting and diagnostic JSON output.