### PR TITLE
Dedup fake executable creation in test support (#63)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -474,6 +474,22 @@ packaged crate builds successfully for release. It then uses
 build-script sources, including `build_l10n_audit.rs`, and rejects stale
 `ninja_env/` paths.
 
+
+### Temporary executable test helpers
+
+The low-level executable-stub primitive is owned by
+[`test_support::exec`](../test_support/src/exec.rs). Use
+`write_exec_with_content` only from test-support or test code that needs a
+temporary executable with controlled script content; production code must not
+call it. Prefer higher-level domain helpers, such as the fake-Ninja factories,
+when they fit. The caller composes the primitive with a temporary directory and
+retains that directory for as long as the executable is needed.
+
+Callers supply a platform-appropriate filename and script body. The helper
+writes that content and applies executable permissions only on Unix.
+`write_exec` is the minimal-script convenience wrapper;
+`write_exec_with_content` is the shared primitive for custom behaviour.
+
 ### User-facing documentation examples
 
 Every fenced example in `README.md`, `docs/users-guide.md`, and

--- a/src/stdlib/which/cache.rs
+++ b/src/stdlib/which/cache.rs
@@ -272,7 +272,7 @@ mod tests {
 
         let target = cwd.join("target");
         test_support::fs::create_dir_all(target.as_std_path())?;
-        test_support::write_exec(target.as_path(), "tool")?;
+        test_support::write_exec(target.as_std_path(), "tool")?;
 
         let capacity = NonZeroUsize::new(64).expect("non-zero cache capacity");
         // Use path_override to set empty PATH instead of mutating global env

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -39,7 +39,7 @@ fn search_workspace_returns_executable_and_skips_non_exec(
     #[from(workspace)] workspace_res: Result<TempWorkspace>,
 ) -> Result<()> {
     let workspace = workspace_res?;
-    let exec = write_exec(workspace.root(), "tool")?;
+    let exec = write_exec(workspace.root().as_std_path(), "tool")?;
     let non_exec = workspace.root().join("tool2");
     test_fs::write(non_exec.as_std_path(), b"not exec").context("write non exec")?;
 
@@ -59,10 +59,10 @@ fn search_workspace_collects_all_matches(
     #[from(workspace)] workspace_res: Result<TempWorkspace>,
 ) -> Result<()> {
     let workspace = workspace_res?;
-    let first = write_exec(workspace.root(), "tool")?;
+    let first = write_exec(workspace.root().as_std_path(), "tool")?;
     let subdir = workspace.root().join("bin");
     test_fs::create_dir_all(subdir.as_std_path()).context("mkdir bin")?;
-    let second = write_exec(subdir.as_path(), "tool")?;
+    let second = write_exec(subdir.as_std_path(), "tool")?;
 
     let path_value = std::ffi::OsString::from(workspace.root().as_str());
     let snapshot = EnvSnapshot::capture(Some(workspace.root()), Some(path_value.as_os_str()))
@@ -85,7 +85,7 @@ fn search_workspace_skips_heavy_directories(
     let workspace = workspace_res?;
     let heavy = workspace.root().join("target");
     test_fs::create_dir_all(heavy.as_std_path()).context("mkdir target")?;
-    write_exec(heavy.as_path(), "tool")?;
+    write_exec(heavy.as_std_path(), "tool")?;
 
     let path_value = std::ffi::OsString::from(workspace.root().as_str());
     let snapshot = EnvSnapshot::capture(Some(workspace.root()), Some(path_value.as_os_str()))

--- a/test_support/src/check_ninja.rs
+++ b/test_support/src/check_ninja.rs
@@ -64,11 +64,9 @@ impl ShellFlag {
 /// both so callers keep the directory alive for the script's lifetime.
 fn write_fake_ninja_script(script: &str, context: &str) -> Result<(TempDir, PathBuf)> {
     let dir = TempDir::new().with_context(|| format!("{context}: create temp dir"))?;
-    let root = camino::Utf8Path::from_path(dir.path())
-        .with_context(|| format!("{context}: temp dir path is not valid UTF-8"))?;
-    let path = write_exec_with_content(root, "ninja", script)
+    let path = write_exec_with_content(dir.path(), "ninja", script)
         .with_context(|| format!("{context}: write script"))?;
-    Ok((dir, path.into_std_path_buf()))
+    Ok((dir, path))
 }
 
 /// Create a fake Ninja that validates the build file path provided via `-f`.

--- a/test_support/src/check_ninja.rs
+++ b/test_support/src/check_ninja.rs
@@ -1,10 +1,10 @@
 //! Helpers for validating build file paths and tool invocations via fake Ninja binaries.
 
 use anyhow::{Context, Result};
-use std::fs::{self, File};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+use crate::exec::write_exec_with_content;
 
 /// Represents a Ninja tool name (e.g., "clean", "compdb").
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,22 +57,18 @@ impl ShellFlag {
     }
 }
 
-/// Make a script file executable on Unix platforms.
-#[cfg(unix)]
-fn make_script_executable(path: &Path, context: &str) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = fs::metadata(path)
-        .with_context(|| format!("{context}: read metadata {}", path.display()))?
-        .permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms)
-        .with_context(|| format!("{context}: set permissions {}", path.display()))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn make_script_executable(_path: &Path, _context: &str) -> Result<()> {
-    Ok(())
+/// Write a fake `ninja` script into a fresh temporary directory.
+///
+/// Shared plumbing for the fake-Ninja factories below: creates the temp
+/// directory, writes `script` via [`write_exec_with_content`], and returns
+/// both so callers keep the directory alive for the script's lifetime.
+fn write_fake_ninja_script(script: &str, context: &str) -> Result<(TempDir, PathBuf)> {
+    let dir = TempDir::new().with_context(|| format!("{context}: create temp dir"))?;
+    let root = camino::Utf8Path::from_path(dir.path())
+        .with_context(|| format!("{context}: temp dir path is not valid UTF-8"))?;
+    let path = write_exec_with_content(root, "ninja", script)
+        .with_context(|| format!("{context}: write script"))?;
+    Ok((dir, path.into_std_path_buf()))
 }
 
 /// Create a fake Ninja that validates the build file path provided via `-f`.
@@ -80,33 +76,17 @@ fn make_script_executable(_path: &Path, _context: &str) -> Result<()> {
 /// The script exits with status `1` if the file is missing or not a regular
 /// file, otherwise `0`.
 pub fn fake_ninja_check_build_file() -> Result<(TempDir, PathBuf)> {
-    let dir = TempDir::new().context("fake_ninja_check_build_file: create temp dir")?;
-    let path = dir.path().join("ninja");
-    let mut file = File::create(&path).with_context(|| {
-        format!(
-            "fake_ninja_check_build_file: create script {}",
-            path.display()
-        )
-    })?;
-    writeln!(
-        file,
+    write_fake_ninja_script(
         concat!(
             "#!/bin/sh\n",
             "if [ \"$1\" = \"-f\" ] && [ ! -f \"$2\" ]; then\n",
             "  echo \"missing build file: $2\" >&2\n",
             "  exit 1\n",
             "fi\n",
-            "exit 0"
+            "exit 0\n"
         ),
+        "fake_ninja_check_build_file",
     )
-    .with_context(|| {
-        format!(
-            "fake_ninja_check_build_file: write script {}",
-            path.display()
-        )
-    })?;
-    make_script_executable(&path, "fake_ninja_check_build_file")?;
-    Ok((dir, path))
 }
 
 /// Create a fake Ninja that validates `-t <tool>` was invoked with the expected tool name.
@@ -267,24 +247,9 @@ pub fn fake_ninja_expect_tool_with_jobs(
     expected_jobs: Option<u32>,
     expected_directory: Option<&Path>,
 ) -> Result<(TempDir, PathBuf)> {
-    let dir = TempDir::new().context("fake_ninja_expect_tool_with_jobs: create temp dir")?;
-    let path = dir.path().join("ninja");
-    let mut file = File::create(&path).with_context(|| {
-        format!(
-            "fake_ninja_expect_tool_with_jobs: create script {}",
-            path.display()
-        )
-    })?;
     let script_content =
         build_tool_validation_script(expected_tool, expected_jobs, expected_directory)?;
-    write!(file, "{}", script_content).with_context(|| {
-        format!(
-            "fake_ninja_expect_tool_with_jobs: write script {}",
-            path.display()
-        )
-    })?;
-    make_script_executable(&path, "fake_ninja_expect_tool_with_jobs")?;
-    Ok((dir, path))
+    write_fake_ninja_script(&script_content, "fake_ninja_expect_tool_with_jobs")
 }
 
 /// Stub for non-Unix platforms that returns an error.

--- a/test_support/src/check_ninja.rs
+++ b/test_support/src/check_ninja.rs
@@ -268,6 +268,9 @@ pub fn fake_ninja_expect_tool_with_jobs(
 
 #[cfg(test)]
 mod tests {
+    //! Unit coverage for the fake-Ninja factories in this module: verifies the
+    //! generated shell scripts validate `-t`, `-f`, `-j`, and `-C` invocations
+    //! as expected by [`super::fake_ninja_expect_tool_with_jobs`].
     use super::*;
 
     /// Verify that the fake ninja script validates `-C <directory>` correctly.

--- a/test_support/src/exec.rs
+++ b/test_support/src/exec.rs
@@ -7,25 +7,25 @@
 //! # Examples
 //!
 //! ```rust
-//! use camino::Utf8Path;
 //! use tempfile::TempDir;
 //! use test_support::write_exec;
 //!
 //! let temp = TempDir::new().expect("tempdir");
-//! let root = Utf8Path::from_path(temp.path()).expect("utf8 path");
-//! let path = write_exec(root, "tool").expect("stub executable");
+//! let path = write_exec(temp.path(), "tool").expect("stub executable");
 //! assert!(path.exists());
 //! ```
 
 use anyhow::{Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
-use std::fs;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 /// Write a minimal executable file named `name` inside `root`.
-pub fn write_exec(root: &Utf8Path, name: &str) -> Result<Utf8PathBuf> {
+pub fn write_exec(root: &Path, name: &str) -> Result<PathBuf> {
     write_exec_with_content(root, name, "#!/bin/sh\n")
 }
 
@@ -39,32 +39,28 @@ pub fn write_exec(root: &Utf8Path, name: &str) -> Result<Utf8PathBuf> {
 /// # Examples
 ///
 /// ```rust
-/// use camino::Utf8Path;
 /// use tempfile::TempDir;
 /// use test_support::exec::write_exec_with_content;
 ///
 /// let temp = TempDir::new().expect("tempdir");
-/// let root = Utf8Path::from_path(temp.path()).expect("utf8 path");
-/// let path = write_exec_with_content(root, "tool", "#!/bin/sh\nexit 3\n")
+/// let path = write_exec_with_content(temp.path(), "tool", "#!/bin/sh\nexit 3\n")
 ///     .expect("stub executable");
 /// assert!(path.exists());
 /// ```
-pub fn write_exec_with_content(root: &Utf8Path, name: &str, content: &str) -> Result<Utf8PathBuf> {
+pub fn write_exec_with_content(root: &Path, name: &str, content: &str) -> Result<PathBuf> {
     let path = root.join(name);
-    fs::write(path.as_std_path(), content).with_context(|| format!("write exec stub {name}"))?;
+    fs::write(&path, content).with_context(|| format!("write exec stub {name}"))?;
     make_executable(&path)?;
     Ok(path)
 }
 
 /// Mark an existing file as executable on Unix; no-op elsewhere.
-pub fn make_executable(path: &Utf8Path) -> Result<()> {
+pub fn make_executable(path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(path.as_std_path())
-            .context("stat exec stub")?
-            .permissions();
+        let mut perms = fs::metadata(path).context("stat exec stub")?.permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(path.as_std_path(), perms).context("chmod exec stub")?;
+        fs::set_permissions(path, perms).context("chmod exec stub")?;
     }
 
     #[cfg(not(unix))]

--- a/test_support/src/exec.rs
+++ b/test_support/src/exec.rs
@@ -26,9 +26,32 @@ use std::os::unix::fs::PermissionsExt;
 
 /// Write a minimal executable file named `name` inside `root`.
 pub fn write_exec(root: &Utf8Path, name: &str) -> Result<Utf8PathBuf> {
+    write_exec_with_content(root, name, "#!/bin/sh\n")
+}
+
+/// Write an executable script named `name` inside `root` with `content`.
+///
+/// This is the shared primitive behind the fake-executable helpers: it
+/// creates the file, writes the script body verbatim, and marks the result
+/// executable on Unix. Callers provide platform-appropriate content (for
+/// example a POSIX shell script on Unix or a batch file on Windows).
+///
+/// # Examples
+///
+/// ```rust
+/// use camino::Utf8Path;
+/// use tempfile::TempDir;
+/// use test_support::exec::write_exec_with_content;
+///
+/// let temp = TempDir::new().expect("tempdir");
+/// let root = Utf8Path::from_path(temp.path()).expect("utf8 path");
+/// let path = write_exec_with_content(root, "tool", "#!/bin/sh\nexit 3\n")
+///     .expect("stub executable");
+/// assert!(path.exists());
+/// ```
+pub fn write_exec_with_content(root: &Utf8Path, name: &str, content: &str) -> Result<Utf8PathBuf> {
     let path = root.join(name);
-    fs::write(path.as_std_path(), b"#!/bin/sh\n")
-        .with_context(|| format!("write exec stub {name}"))?;
+    fs::write(path.as_std_path(), content).with_context(|| format!("write exec stub {name}"))?;
     make_executable(&path)?;
     Ok(path)
 }

--- a/test_support/src/exec.rs
+++ b/test_support/src/exec.rs
@@ -54,17 +54,17 @@ pub fn write_exec_with_content(root: &Path, name: &str, content: &str) -> Result
     Ok(path)
 }
 
-/// Mark an existing file as executable on Unix; no-op elsewhere.
+/// Mark an existing file as executable by setting its Unix permission bits.
+#[cfg(unix)]
 pub fn make_executable(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        let mut perms = fs::metadata(path).context("stat exec stub")?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(path, perms).context("chmod exec stub")?;
-    }
+    let mut perms = fs::metadata(path).context("stat exec stub")?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).context("chmod exec stub")?;
+    Ok(())
+}
 
-    #[cfg(not(unix))]
-    let _ = path;
-
+/// No-op on non-Unix platforms, where executability is not a permission bit.
+#[cfg(not(unix))]
+pub fn make_executable(_path: &Path) -> Result<()> {
     Ok(())
 }

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -109,24 +109,56 @@ impl std::error::Error for ProbesError {}
 /// ```
 pub fn fake_ninja(exit_code: u8) -> Result<(TempDir, PathBuf)> {
     let dir = TempDir::new().context("fake_ninja: create temporary directory")?;
-    let root = camino::Utf8Path::from_path(dir.path())
-        .context("fake_ninja: temporary directory path is not valid UTF-8")?;
 
     #[cfg(unix)]
-    let path =
-        exec::write_exec_with_content(root, "ninja", &format!("#!/bin/sh\nexit {exit_code}\n"))
-            .context("fake_ninja: write script")?;
+    let path = exec::write_exec_with_content(
+        dir.path(),
+        "ninja",
+        &format!("#!/bin/sh\nexit {exit_code}\n"),
+    )
+    .context("fake_ninja: write script")?;
     #[cfg(windows)]
     let path = exec::write_exec_with_content(
-        root,
+        dir.path(),
         "ninja.cmd",
         &format!("@echo off\r\nexit /B {exit_code}\r\n"),
     )
     .context("fake_ninja: write batch file")?;
 
-    Ok((dir, path.into_std_path_buf()))
+    Ok((dir, path))
 }
 
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{
+        EnvVarGuard, TempDir, check_ninja::fake_ninja_check_build_file, env_lock::EnvLock,
+        fake_ninja,
+    };
+    use anyhow::{Context, Result};
+    use std::{ffi::OsString, fs, os::unix::ffi::OsStringExt};
+
+    #[test]
+    fn fake_ninja_helpers_support_non_utf8_temp_directories() -> Result<()> {
+        let parent = TempDir::new().context("create parent temporary directory")?;
+        let non_utf8_root = parent.path().join(OsString::from_vec(b"tmp-\xff".to_vec()));
+        fs::create_dir(&non_utf8_root).context("create non-UTF-8 temporary directory")?;
+
+        let _env_lock = EnvLock::acquire();
+        let _tmpdir = EnvVarGuard::set("TMPDIR", non_utf8_root.as_os_str());
+
+        let (_exit_dir, exit_script) = fake_ninja(0)?;
+        let (_check_dir, check_script) = fake_ninja_check_build_file()?;
+
+        assert!(exit_script.starts_with(&non_utf8_root));
+        assert!(check_script.starts_with(&non_utf8_root));
+        assert!(exit_script.exists(), "fake_ninja should create its script");
+        assert!(
+            check_script.exists(),
+            "fake_ninja_check_build_file should create its script"
+        );
+        Ok(())
+    }
+}
 /// Probe that required binaries are available in `PATH`.
 ///
 /// Each entry provides the programme name and the arguments used to probe it,

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -57,16 +57,13 @@ pub use localizer::{
 pub use manifest::ensure_manifest_exists;
 
 /// Helpers for writing executable stubs and setting executable bits in tests.
-pub use exec::{make_executable, write_exec};
+pub use exec::{make_executable, write_exec, write_exec_with_content};
 
 mod error;
 /// Format an error and its sources (outermost → root) using `Display`, joined
 /// with ": ", to produce deterministic text for test assertions.
 pub use error::display_error_chain;
-
 use anyhow::{Context, Result};
-use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
@@ -112,31 +109,22 @@ impl std::error::Error for ProbesError {}
 /// ```
 pub fn fake_ninja(exit_code: u8) -> Result<(TempDir, PathBuf)> {
     let dir = TempDir::new().context("fake_ninja: create temporary directory")?;
+    let root = camino::Utf8Path::from_path(dir.path())
+        .context("fake_ninja: temporary directory path is not valid UTF-8")?;
 
     #[cfg(unix)]
-    let path = dir.path().join("ninja");
+    let path =
+        exec::write_exec_with_content(root, "ninja", &format!("#!/bin/sh\nexit {exit_code}\n"))
+            .context("fake_ninja: write script")?;
     #[cfg(windows)]
-    let path = dir.path().join("ninja.cmd");
+    let path = exec::write_exec_with_content(
+        root,
+        "ninja.cmd",
+        &format!("@echo off\r\nexit /B {exit_code}\r\n"),
+    )
+    .context("fake_ninja: write batch file")?;
 
-    #[cfg(unix)]
-    {
-        let mut file = File::create(&path)
-            .with_context(|| format!("fake_ninja: create script {}", path.display()))?;
-        writeln!(file, "#!/bin/sh\nexit {}", exit_code)
-            .with_context(|| format!("fake_ninja: write script {}", path.display()))?;
-        crate::fs::set_mode(&path, 0o755)
-            .with_context(|| format!("fake_ninja: set permissions {}", path.display()))?;
-    }
-
-    #[cfg(windows)]
-    {
-        let mut file = File::create(&path)
-            .with_context(|| format!("fake_ninja: create batch file {}", path.display()))?;
-        writeln!(file, "@echo off\r\nexit /B {}", exit_code)
-            .with_context(|| format!("fake_ninja: write batch file {}", path.display()))?;
-    }
-
-    Ok((dir, path))
+    Ok((dir, path.into_std_path_buf()))
 }
 
 /// Probe that required binaries are available in `PATH`.

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -60,10 +60,10 @@ pub use manifest::ensure_manifest_exists;
 pub use exec::{make_executable, write_exec, write_exec_with_content};
 
 mod error;
+use anyhow::{Context, Result};
 /// Format an error and its sources (outermost → root) using `Display`, joined
 /// with ": ", to produce deterministic text for test assertions.
 pub use error::display_error_chain;
-use anyhow::{Context, Result};
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
@@ -159,6 +159,7 @@ mod tests {
         Ok(())
     }
 }
+
 /// Probe that required binaries are available in `PATH`.
 ///
 /// Each entry provides the programme name and the arguments used to probe it,

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -130,6 +130,11 @@ pub fn fake_ninja(exit_code: u8) -> Result<(TempDir, PathBuf)> {
 
 #[cfg(all(test, unix))]
 mod tests {
+    //! Regression coverage for the fake-executable helpers on non-UTF-8
+    //! temporary directories: exercises [`super::fake_ninja`] and
+    //! [`super::check_ninja::fake_ninja_check_build_file`] with a temp
+    //! directory rooted under a path containing invalid UTF-8 bytes,
+    //! confirming both stubs are created on OS-native paths.
     use super::{
         EnvVarGuard, TempDir, check_ninja::fake_ninja_check_build_file, env_lock::EnvLock,
         fake_ninja,

--- a/tests/documentation_examples_e2e_tests.rs
+++ b/tests/documentation_examples_e2e_tests.rs
@@ -22,8 +22,8 @@ fn executable_path(stub_directory: &Utf8Path) -> Result<String> {
 }
 
 fn write_stub(directory: &Utf8Path, name: &str, script: &str) -> Result<()> {
-    let path = write_exec(directory, name)?;
-    test_fs::write(path.as_std_path(), script).with_context(|| format!("write {name} stub"))?;
+    let path = write_exec(directory.as_std_path(), name)?;
+    test_fs::write(&path, script).with_context(|| format!("write {name} stub"))?;
     Ok(())
 }
 

--- a/tests/documentation_examples_e2e_tests.rs
+++ b/tests/documentation_examples_e2e_tests.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::process::Command;
 use test_support::fs as test_fs;
 use test_support::netsuke::{NetsukeRun, run_netsuke_in_with_env};
-use test_support::{ninja::ninja_integration_workspace, write_exec};
+use test_support::{ninja::ninja_integration_workspace, write_exec, write_exec_with_content};
 
 fn executable_path(stub_directory: &Utf8Path) -> Result<String> {
     let host_path = std::env::var("PATH").context("read host PATH")?;
@@ -22,8 +22,8 @@ fn executable_path(stub_directory: &Utf8Path) -> Result<String> {
 }
 
 fn write_stub(directory: &Utf8Path, name: &str, script: &str) -> Result<()> {
-    let path = write_exec(directory.as_std_path(), name)?;
-    test_fs::write(&path, script).with_context(|| format!("write {name} stub"))?;
+    write_exec_with_content(directory.as_std_path(), name, script)
+        .with_context(|| format!("write {name} stub"))?;
     Ok(())
 }
 
@@ -358,7 +358,7 @@ fn stdlib_host_context_example_uses_controlled_process_state() -> Result<()> {
             "done\n"
         ),
     )?;
-    write_exec(&stub_directory, "guide-tool")?;
+    write_exec(stub_directory.as_std_path(), "guide-tool")?;
     let path = executable_path(&stub_directory)?;
     let run = run_netsuke_in_with_env(
         workspace.path(),


### PR DESCRIPTION
## Summary

Closes #63

The duplication originally flagged (`fake_ninja` vs `fake_ninja_pwd` in `tests/support/mod.rs`) was removed by earlier refactors, but the same create-file/write-script/chmod pattern had reappeared in three places across the `test_support` crate: `fake_ninja` in `lib.rs`, and `fake_ninja_check_build_file` plus `fake_ninja_expect_tool_with_jobs` in `check_ninja.rs` (which carried its own private `make_script_executable` copy).

## Changes

- `test_support/src/exec.rs`: add `write_exec_with_content`, the shared primitive that writes a script body and marks it executable; `write_exec` now delegates to it. The API accepts OS-native `&std::path::Path` and returns `std::path::PathBuf`, so temporary paths are never round-tripped through `camino::Utf8Path`.
- `test_support/src/lib.rs`: `fake_ninja` uses the shared primitive; drop now-unused `fs`/`File`/`Write` imports; re-export the new helper. Add a Unix-only regression test covering non-UTF-8 temporary directories, plus module-level Rustdoc on the test module.
- `test_support/src/check_ninja.rs`: add a `write_fake_ninja_script` wrapper owning the temp-dir plumbing; both fake-Ninja factories route through it; delete the duplicate `make_script_executable`; add module-level Rustdoc on the test module.
- `docs/developers-guide.md`: document ownership, permitted call sites, composition, platform contract, and the `write_exec`/`write_exec_with_content` relationship for the shared executable-stub primitive.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make typecheck` — pass
- `make test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deduplicate fake Ninja executable creation in test helpers by introducing a shared script-writing utility and routing existing fake-ninja factories through it.

Enhancements:
- Introduce a reusable helper for writing executable scripts with arbitrary content and make existing helpers delegate to it.
- Refactor fake Ninja test helpers to share common temp-directory and script-writing logic and remove duplicated permission-setting code.
- Re-export the new executable helper from the test support crate for reuse by other tests.

## References

- Lody session: https://lody.ai/leynos/sessions/5888df58-0de0-40fb-976e-a463cfa03242
