### PR TITLE
Add zero-argument PathGuard::capture constructor (#110)

### DIFF
--- a/test_support/src/path_guard.rs
+++ b/test_support/src/path_guard.rs
@@ -21,13 +21,35 @@ pub struct PathGuard<E: Env = StdEnv> {
 }
 
 impl PathGuard {
-    /// Create a guard capturing the current `PATH` using the real environment.
+    /// Create a guard that restores `PATH` to `original` when dropped.
     ///
-    /// Returns a guard that restores the variable when dropped.
+    /// Callers supply the value to reinstate; use [`PathGuard::capture`] to
+    /// snapshot the current `PATH` automatically.
     pub fn new(original: Option<OsString>) -> Self {
         Self {
             inner: EnvGuard::with_env_and_lock("PATH", original, StdEnv::default(), true),
         }
+    }
+
+    /// Capture the current `PATH` from the real environment.
+    ///
+    /// Zero-argument convenience for callers using the real environment: the
+    /// guard snapshots `PATH` at construction and restores that snapshot when
+    /// dropped, so tests need not fetch and pass the value manually.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use test_support::PathGuard;
+    ///
+    /// let guard = PathGuard::capture();
+    /// // Mutate PATH as the test requires; the original value is restored
+    /// // when `guard` drops.
+    /// drop(guard);
+    /// ```
+    #[must_use]
+    pub fn capture() -> Self {
+        Self::new(std::env::var_os("PATH"))
     }
 }
 

--- a/tests/path_guard_tests.rs
+++ b/tests/path_guard_tests.rs
@@ -1,9 +1,12 @@
-//! Tests for PATH restoration behaviour using mock environments.
+//! Tests for PATH restoration behaviour using mock and real environments.
 //!
 //! Verifies that `PathGuard` restores `PATH` without mutating the real
-//! process environment.
+//! process environment, and that `PathGuard::capture` snapshots and
+//! restores the real `PATH`.
 
+use anyhow::{Context, Result, ensure};
 use mockall::{Sequence, mock};
+use serial_test::serial;
 use std::ffi::OsStr;
 use test_support::{Environment, PathGuard};
 
@@ -35,4 +38,24 @@ fn restores_path_without_touching_real_env() {
             guard.env_mut().set_var("PATH", OsStr::new("/tmp"));
         }
     }
+}
+
+#[test]
+#[serial]
+fn capture_snapshots_and_restores_real_path() -> Result<()> {
+    let original = std::env::var_os("PATH");
+    {
+        let _guard = PathGuard::capture();
+        test_support::env::set_var("PATH", OsStr::new("/netsuke-capture-test"));
+        let mutated = std::env::var_os("PATH").context("PATH should be set after mutation")?;
+        ensure!(
+            mutated == OsStr::new("/netsuke-capture-test"),
+            "expected mutated PATH, got {mutated:?}"
+        );
+    }
+    ensure!(
+        std::env::var_os("PATH") == original,
+        "expected PATH to be restored to its captured value after guard drop"
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #110

Adds `PathGuard::capture()`, a zero-argument constructor that snapshots the current `PATH` from the real environment automatically, so callers no longer fetch and pass it manually.

## Changes

- `test_support/src/path_guard.rs`: add `capture()`; sharpen the `new` doc comment to distinguish the two constructors.
- `tests/path_guard_tests.rs`: add a `#[serial]` test verifying `capture` snapshots and restores the real `PATH` across a mutation.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make test` — pass (37 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a convenience constructor to PathGuard that automatically snapshots and restores the real PATH for tests.

New Features:
- Introduce PathGuard::capture(), a zero-argument constructor that captures the current PATH from the real environment and restores it on drop.

Tests:
- Add a serial test to verify that PathGuard::capture() snapshots the real PATH, allows mutation during the test, and restores the original value after drop.