### PR TITLE
Add safe PathGuard::set_path hiding unsafe set_var (#111)

### DIFF
--- a/test_support/src/path_guard.rs
+++ b/test_support/src/path_guard.rs
@@ -3,9 +3,10 @@
 //! Provides a guard that resets the environment variable on drop so tests do
 //! not pollute global state.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 
 use crate::env_guard::{EnvGuard, Environment, StdEnv};
+use crate::env_lock::EnvLock;
 
 /// Environment abstraction for setting variables.
 pub trait Env: Environment {}
@@ -64,5 +65,29 @@ impl<E: Env> PathGuard<E> {
     /// Access the underlying environment.
     pub fn env_mut(&mut self) -> &mut E {
         self.inner.env_mut()
+    }
+
+    /// Set `PATH` to `value` through the guard's environment.
+    ///
+    /// Safe wrapper around the `unsafe` [`Environment::set_var`] operation:
+    /// the global [`EnvLock`] serialises the mutation and the guard restores
+    /// the original value on drop, so the unsafety stays encapsulated here
+    /// rather than leaking `unsafe` blocks into consumer code.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use std::ffi::OsStr;
+    /// use test_support::PathGuard;
+    ///
+    /// let mut guard = PathGuard::capture();
+    /// guard.set_path(OsStr::new("/stub/bin"));
+    /// // The captured PATH is restored when `guard` drops.
+    /// ```
+    pub fn set_path(&mut self, value: &OsStr) {
+        let _lock = EnvLock::acquire();
+        // SAFETY: `EnvLock` serialises the mutation and the guard restores
+        // the captured value on drop.
+        unsafe { self.inner.env_mut().set_var("PATH", value) };
     }
 }

--- a/tests/path_guard_tests.rs
+++ b/tests/path_guard_tests.rs
@@ -34,9 +34,7 @@ fn restores_path_without_touching_real_env() {
         .return_const(());
     {
         let mut guard = PathGuard::with_env(Some("/orig".into()), env);
-        unsafe {
-            guard.env_mut().set_var("PATH", OsStr::new("/tmp"));
-        }
+        guard.set_path(OsStr::new("/tmp"));
     }
 }
 
@@ -45,8 +43,8 @@ fn restores_path_without_touching_real_env() {
 fn capture_snapshots_and_restores_real_path() -> Result<()> {
     let original = std::env::var_os("PATH");
     {
-        let _guard = PathGuard::capture();
-        test_support::env::set_var("PATH", OsStr::new("/netsuke-capture-test"));
+        let mut guard = PathGuard::capture();
+        guard.set_path(OsStr::new("/netsuke-capture-test"));
         let mutated = std::env::var_os("PATH").context("PATH should be set after mutation")?;
         ensure!(
             mutated == OsStr::new("/netsuke-capture-test"),


### PR DESCRIPTION
## Summary

Closes #111

`Environment::set_var` is `unsafe` under Rust 2024, forcing `unsafe` blocks into consumer code and tests that mutate `PATH` through a `PathGuard`. This adds a safe `set_path` method on `PathGuard` that acquires the global `EnvLock` (re-entrant per thread), performs the mutation, and leans on the guard's drop behaviour for restoration — encapsulating the unsafety inside the guard.

Stacked on #351 (`PathGuard::capture`), so this PR targets that branch; it retargets to `main` automatically once #351 merges.

## Changes

- `test_support/src/path_guard.rs`: add safe `set_path` with `EnvLock` serialisation and a SAFETY comment.
- `tests/path_guard_tests.rs`: both tests now use `set_path` instead of open-coded `unsafe` blocks.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make test` — pass (37 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a safe PathGuard::set_path helper that encapsulates unsafe PATH mutation behind an EnvLock-guarded API and update tests to use it.

New Features:
- Expose a safe PathGuard::set_path method to mutate PATH via the guard while restoring the original value on drop.

Enhancements:
- Serialize PATH environment mutations using EnvLock to keep unsafety internal to PathGuard and avoid leaking unsafe blocks into consumers.

Tests:
- Update PathGuard tests to use the new set_path API instead of calling unsafe Environment::set_var directly.