### PR TITLE
Document CommandArg and remove unused BuildTargets::is_empty (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
   of truth for the compiler contract
   ([#465](https://github.com/leynos/netsuke/issues/465))
 
+### Removed
+
+- Remove `runner::BuildTargets::is_empty`, which had no callers anywhere in
+  the workspace. Library consumers who need the same answer can call
+  `BuildTargets::as_slice().is_empty()`
+  ([#75](https://github.com/leynos/netsuke/issues/75))
+
 ## [0.1.0] - 2026-07-28
 
 _Initial release._

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2691,6 +2691,43 @@ paths:
 4. Let `run_command_and_stream_with_context` handle span creation, execution
    logging, failure logging, and exit-status enforcement via context helpers.
 
+### Module: `runner::process::redaction`
+
+`src/runner/process/redaction.rs` owns the argument-redaction boundary that
+`command_logging` consumes. `CommandArg` is a newtype over a single
+command-line argument string; it gives the redaction helpers a dedicated type
+to operate on instead of passing bare `String` values around.
+
+`CommandArg` carries no redaction guarantee of its own. The same type holds
+both the raw arguments read from `Command::get_args` and the values returned
+by the redaction helpers, and `as_str` is available on either. The invariant
+is therefore a discipline on the call site, not a property of the type:
+logging paths must render only what `redact_argument` or
+`redact_sensitive_args` returned. `CommandLogContext::from_command` is the
+one place that observes this, redacting the collected arguments before it
+builds `redacted_command`.
+
+An argument is treated as sensitive when it is a `key=value` pair whose
+trimmed key case-insensitively matches `password`, `token`, `secret`,
+`api_key`, `apikey`, `auth`, or `authorization`. Matching arguments keep the
+key and replace the value with `***REDACTED***`; positional arguments with no
+`=` are passed through unchanged, so a path such as `secrets.yml` is not
+mangled. Widen the keyword list rather than adding a second redaction path if
+new sensitive arguments appear.
+
+The module's doc examples are marked `ignore`. `CommandArg` and the helpers
+are crate-private, and the `cfg(doctest)` re-export in `runner::process::doc`
+is compiled out of the library that doctests link against, so no doctest can
+import them. Behaviour is covered by the unit tests in the module instead.
+
+### Module: `runner` target selection
+
+`BuildTargets<'a>` is a borrowing newtype over the requested target list,
+constructed by `BuildTargets::new` and read through `as_slice`. It exposes no
+`is_empty`: the accessor existed but had no callers anywhere in the
+workspace, so it was removed; call `as_slice().is_empty()` where that
+question needs asking.
+
 ## IR cycle detection
 
 ### Module: `ir::cycle`

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -94,11 +94,6 @@ impl<'a> BuildTargets<'a> {
     pub const fn as_slice(&self) -> &'a [String] {
         self.0
     }
-    /// Indicate whether no explicit targets were provided.
-    #[must_use]
-    pub const fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
 }
 
 #[expect(

--- a/src/runner/process/redaction.rs
+++ b/src/runner/process/redaction.rs
@@ -1,13 +1,27 @@
 //! Argument redaction helpers for the Ninja runner.
 //! Provides the `CommandArg` wrapper used by doctests and logging.
 
+/// A single command-line argument passed to a spawned process.
+///
+/// Wrapping the raw `String` gives the redaction helpers a dedicated type to
+/// operate on, so call sites cannot accidentally log an unredacted argument
+/// where a redacted one is expected.
+///
+/// # Examples
+/// ```ignore
+/// use netsuke::runner::process::redaction::CommandArg;
+/// let arg = CommandArg::new("token=abc".into());
+/// assert_eq!(arg.as_str(), "token=abc");
+/// ```
 #[derive(Debug, Clone)]
 pub struct CommandArg(String);
 impl CommandArg {
+    /// Wrap a raw argument string.
     #[must_use]
     pub const fn new(arg: String) -> Self {
         Self(arg)
     }
+    /// Borrow the underlying argument text.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0

--- a/src/runner/process/redaction.rs
+++ b/src/runner/process/redaction.rs
@@ -4,8 +4,14 @@
 /// A single command-line argument passed to a spawned process.
 ///
 /// Wrapping the raw `String` gives the redaction helpers a dedicated type to
-/// operate on, so call sites cannot accidentally log an unredacted argument
-/// where a redacted one is expected.
+/// operate on. The type does not record whether the text is raw or redacted,
+/// so it offers no guarantee on its own: logging call sites must consume only
+/// the values returned by [`redact_argument`] or [`redact_sensitive_args`].
+///
+/// The example is `ignore`d because `CommandArg` is crate-private; the
+/// `cfg(doctest)` re-export in `runner::process::doc` is compiled out of the
+/// library that doctests link against, so no doctest can import it. Behaviour
+/// is covered by the unit tests in this module instead.
 ///
 /// # Examples
 /// ```ignore
@@ -107,6 +113,16 @@ mod tests {
     //! Unit tests for sensitive environment variable redaction.
 
     use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("token=abc")]
+    #[case("")]
+    #[case("  spaced  ")]
+    fn command_arg_borrows_the_wrapped_text(#[case] raw: &str) {
+        let arg = CommandArg::new(String::from(raw));
+        assert_eq!(arg.as_str(), raw);
+    }
 
     #[test]
     fn is_sensitive_arg_only_flags_known_keys() {


### PR DESCRIPTION
## Summary

Closes #75

Of the three types named in the issue, `NinjaContent` and `BuildTargets` were already documented by earlier refactors. The remaining gaps were `CommandArg` (no type or method docs) and `BuildTargets::is_empty` (defined but never called anywhere in the workspace).

## Changes

- `src/runner/process/redaction.rs`: document the `CommandArg` newtype (including its purpose: separating redacted from unredacted arguments at logging call sites) and its `new`/`as_str` methods.
- `src/runner/mod.rs`: remove the unused `BuildTargets::is_empty`.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make test` — pass (37 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the CommandArg wrapper type and remove an unused BuildTargets helper.

Enhancements:
- Clarify the intent and usage of CommandArg to prevent accidental logging of unredacted arguments.

Documentation:
- Add API-level documentation and usage example for the CommandArg argument wrapper type.

Chores:
- Remove the unused BuildTargets::is_empty helper method from the runner module.