### PR TITLE
Reduce GlobEntryResult alias to module visibility (#174)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1545,10 +1545,11 @@ it names a `glob` crate type that callers should never have to depend on.
 
 Two compile-time guards hold that boundary:
 
-- `#[deny(unreachable_pub)]` on the `mod glob;` declaration. Because the module
-  is private, widening any item inside it to `pub` makes that item unreachable
-  from the crate root and fails the build. This is what catches an accidental
-  `pub type GlobEntryResult`.
+- `#[deny(unreachable_pub)]` on the `mod glob;` declaration. The lint rejects
+  `pub` items that are still unreachable from the crate root, which is what
+  catches an accidental `pub type GlobEntryResult`. `glob_paths` is exempt only
+  because `src/manifest/mod.rs` deliberately re-exports it, making it genuinely
+  reachable; every item here that is not re-exported stays guarded.
 - A `compile_fail,E0603` doctest on `GlobEntryResult`, paired with a passing
   doctest that imports `netsuke::manifest::glob_paths`. Together these pin the
   downstream view: the alias has no public path, while the entry point does.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1533,6 +1533,33 @@ targets:
     command: "cargo clippy --manifest-path {{ item }}/Cargo.toml"
 ```
 
+## Manifest glob module boundary
+
+Glob expansion lives in `src/manifest/glob/`, and `glob_paths` is its only
+boundary. `src/manifest/mod.rs` declares `mod glob;` privately and re-exports
+just that function, so nothing else in the module — `GlobPattern`, the error
+helpers in `glob/errors.rs`, the `walk` submodule, or the `GlobEntryResult`
+alias — is reachable from the crate root. `GlobEntryResult` in particular
+stays private to `manifest::glob`: only `glob_paths` and `walk` consume it, and
+it names a `glob` crate type that callers should never have to depend on.
+
+Two compile-time guards hold that boundary:
+
+- `#[deny(unreachable_pub)]` on the `mod glob;` declaration. Because the module
+  is private, widening any item inside it to `pub` makes that item unreachable
+  from the crate root and fails the build. This is what catches an accidental
+  `pub type GlobEntryResult`.
+- A `compile_fail,E0603` doctest on `GlobEntryResult`, paired with a passing
+  doctest that imports `netsuke::manifest::glob_paths`. Together these pin the
+  downstream view: the alias has no public path, while the entry point does.
+  The passing doctest is the control — if the harness wiring breaks, it fails
+  rather than letting the rejection pass vacuously.
+
+When adding to this module, keep new items private, or `pub(super)` when a
+sibling submodule needs them; widen the boundary only by adding a deliberate
+re-export in `src/manifest/mod.rs`. The comments in the source are supporting
+detail for these rules, not a substitute for them.
+
 ## Test isolation utilities
 
 Environment variable mutations and working-directory changes are process-global

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1550,11 +1550,15 @@ Two compile-time guards hold that boundary:
   catches an accidental `pub type GlobEntryResult`. `glob_paths` is exempt only
   because `src/manifest/mod.rs` deliberately re-exports it, making it genuinely
   reachable; every item here that is not re-exported stays guarded.
-- A `compile_fail,E0603` doctest on `GlobEntryResult`, paired with a passing
-  doctest that imports `netsuke::manifest::glob_paths`. Together these pin the
-  downstream view: the alias has no public path, while the entry point does.
-  The passing doctest is the control — if the harness wiring breaks, it fails
-  rather than letting the rejection pass vacuously.
+- A pair of doctests attached to the public `glob_paths` documentation: a
+  `compile_fail,E0603` block importing `netsuke::manifest::glob::GlobEntryResult`
+  and a passing block importing `netsuke::manifest::glob_paths`. Together they
+  validate the downstream view — the alias has no public path, while the entry
+  point does. The passing block is the control: if the rustdoc harness wiring
+  breaks, it fails rather than letting the rejection pass vacuously. Both are
+  attached to `glob_paths` rather than to the private items they describe
+  because rustdoc renders and runs the examples of public items, which also
+  makes the boundary discoverable from the published API documentation.
 
 When adding to this module, keep new items private, or `pub(super)` when a
 sibling submodule needs them; widen the boundary only by adding a deliberate

--- a/src/manifest/glob/errors.rs
+++ b/src/manifest/glob/errors.rs
@@ -5,10 +5,10 @@ use crate::localization::{self, keys};
 
 #[derive(Debug)]
 pub(super) struct GlobErrorContext {
-    pub pattern: String,
-    pub error_char: char,
-    pub position: usize,
-    pub error_type: GlobErrorType,
+    pub(super) pattern: String,
+    pub(super) error_char: char,
+    pub(super) position: usize,
+    pub(super) error_type: GlobErrorType,
 }
 
 #[derive(Debug)]

--- a/src/manifest/glob/mod.rs
+++ b/src/manifest/glob/mod.rs
@@ -65,7 +65,11 @@ impl GlobPattern {
     }
 }
 
-pub type GlobEntryResult = std::result::Result<std::path::PathBuf, glob::GlobError>;
+/// Result of iterating a single entry produced by the `glob` crate walker.
+///
+/// Internal to the glob module: only [`glob_paths`] and the `walk` submodule
+/// consume it, so it is deliberately not part of the public API surface.
+type GlobEntryResult = std::result::Result<std::path::PathBuf, glob::GlobError>;
 
 /// Expand a glob pattern and collect the matching UTF-8 file paths.
 ///

--- a/src/manifest/glob/mod.rs
+++ b/src/manifest/glob/mod.rs
@@ -16,7 +16,7 @@ use normalize::force_literal_escapes;
 
 #[derive(Debug, Clone)]
 /// A glob pattern and its normalised representation.
-pub struct GlobPattern {
+struct GlobPattern {
     raw: String,
     normalized: String,
 }
@@ -28,7 +28,7 @@ impl GlobPattern {
         clippy::missing_const_for_fn,
         reason = "const String::as_str() not available on all MSRV targets"
     )]
-    pub fn raw(&self) -> &str {
+    fn raw(&self) -> &str {
         self.raw.as_str()
     }
 
@@ -38,7 +38,7 @@ impl GlobPattern {
         clippy::missing_const_for_fn,
         reason = "const String::as_str() not available on all MSRV targets"
     )]
-    pub fn normalized(&self) -> &str {
+    fn normalized(&self) -> &str {
         self.normalized.as_str()
     }
 
@@ -47,7 +47,7 @@ impl GlobPattern {
     /// # Errors
     ///
     /// Returns an error when brace validation fails.
-    pub fn new(raw: &str) -> std::result::Result<Self, Error> {
+    fn new(raw: &str) -> std::result::Result<Self, Error> {
         validate_brace_matching(raw)?;
 
         #[cfg(unix)]
@@ -69,15 +69,20 @@ impl GlobPattern {
 ///
 /// Internal to the glob module: only [`glob_paths`] and the `walk` submodule
 /// consume it, so it is deliberately not part of the public API surface.
-/// The alias has no public path — this rejection is enforced at compile
-/// time:
+///
+/// Two compile-time guards keep it that way. `#[deny(unreachable_pub)]` on the
+/// `mod glob;` declaration in [`crate::manifest`] rejects any attempt to widen
+/// this alias — or any other item here — to `pub`, because nothing inside the
+/// private module is reachable from the crate root. The doctest below then
+/// pins the outcome from a downstream crate's point of view: no path through
+/// [`crate::manifest`] names the alias.
 ///
 /// ```compile_fail,E0603
 /// use netsuke::manifest::glob::GlobEntryResult;
 /// ```
 ///
-/// while the re-exported entry point remains reachable (the control for the
-/// rejection above — it fails instead if the harness wiring breaks):
+/// The re-exported entry point remains reachable — the control for the
+/// rejection above, which fails instead if the doctest harness wiring breaks:
 ///
 /// ```
 /// use netsuke::manifest::glob_paths;

--- a/src/manifest/glob/mod.rs
+++ b/src/manifest/glob/mod.rs
@@ -70,35 +70,46 @@ impl GlobPattern {
 /// Internal to the glob module: only [`glob_paths`] and the `walk` submodule
 /// consume it, so it is deliberately not part of the public API surface.
 ///
-/// Two compile-time guards keep it that way. `#[deny(unreachable_pub)]` on the
-/// `mod glob;` declaration in [`crate::manifest`] rejects `pub` items that are
-/// still unreachable from the crate root, so widening this alias to `pub`
-/// fails the build. [`glob_paths`] is exempt only because it is deliberately
-/// re-exported by [`crate::manifest`], which makes it genuinely reachable;
-/// every item here that is not re-exported stays guarded. The doctest below
-/// then pins the outcome from a downstream crate's point of view: no path
-/// through [`crate::manifest`] names the alias.
-///
-/// ```compile_fail,E0603
-/// use netsuke::manifest::glob::GlobEntryResult;
-/// ```
-///
-/// The re-exported entry point remains reachable — the control for the
-/// rejection above, which fails instead if the doctest harness wiring breaks:
-///
-/// ```
-/// use netsuke::manifest::glob_paths;
-/// let _: fn(&str) -> _ = glob_paths;
-/// ```
+/// `#[deny(unreachable_pub)]` on the `mod glob;` declaration in
+/// [`crate::manifest`] rejects `pub` items that are still unreachable from the
+/// crate root, so widening this alias to `pub` fails the build. The doctests on
+/// [`glob_paths`] pin the same boundary from a downstream crate's point of
+/// view; they live there because that is where rustdoc will run them.
 type GlobEntryResult = std::result::Result<std::path::PathBuf, glob::GlobError>;
 
 /// Expand a glob pattern and collect the matching UTF-8 file paths.
+///
+/// This is the only public item in the glob module: `netsuke::manifest`
+/// re-exports it and nothing else. The examples below hold that boundary from
+/// a downstream crate's point of view, and are attached here rather than to the
+/// private items they describe because rustdoc renders and runs the examples of
+/// public items.
 ///
 /// # Errors
 ///
 /// Returns an error when the pattern is syntactically invalid, when
 /// capability-restricted filesystem access fails, or when a match contains
 /// non-UTF-8 data.
+///
+/// # Examples
+///
+/// The entry point is reachable through the re-export:
+///
+/// ```
+/// use netsuke::manifest::glob_paths;
+/// let _: fn(&str) -> _ = glob_paths;
+/// ```
+///
+/// The module's internals are not. `GlobEntryResult` is a private alias inside
+/// the private `manifest::glob` module, so no downstream path names it:
+///
+/// ```compile_fail,E0603
+/// use netsuke::manifest::glob::GlobEntryResult;
+/// ```
+///
+/// The passing example above is the control for this rejection: it fails
+/// instead if the rustdoc harness wiring breaks, so the `compile_fail` block
+/// cannot pass vacuously.
 pub fn glob_paths(pattern: &str) -> std::result::Result<Vec<String>, Error> {
     use glob::{MatchOptions, glob_with};
 

--- a/src/manifest/glob/mod.rs
+++ b/src/manifest/glob/mod.rs
@@ -71,11 +71,13 @@ impl GlobPattern {
 /// consume it, so it is deliberately not part of the public API surface.
 ///
 /// Two compile-time guards keep it that way. `#[deny(unreachable_pub)]` on the
-/// `mod glob;` declaration in [`crate::manifest`] rejects any attempt to widen
-/// this alias — or any other item here — to `pub`, because nothing inside the
-/// private module is reachable from the crate root. The doctest below then
-/// pins the outcome from a downstream crate's point of view: no path through
-/// [`crate::manifest`] names the alias.
+/// `mod glob;` declaration in [`crate::manifest`] rejects `pub` items that are
+/// still unreachable from the crate root, so widening this alias to `pub`
+/// fails the build. [`glob_paths`] is exempt only because it is deliberately
+/// re-exported by [`crate::manifest`], which makes it genuinely reachable;
+/// every item here that is not re-exported stays guarded. The doctest below
+/// then pins the outcome from a downstream crate's point of view: no path
+/// through [`crate::manifest`] names the alias.
 ///
 /// ```compile_fail,E0603
 /// use netsuke::manifest::glob::GlobEntryResult;

--- a/src/manifest/glob/mod.rs
+++ b/src/manifest/glob/mod.rs
@@ -69,6 +69,20 @@ impl GlobPattern {
 ///
 /// Internal to the glob module: only [`glob_paths`] and the `walk` submodule
 /// consume it, so it is deliberately not part of the public API surface.
+/// The alias has no public path — this rejection is enforced at compile
+/// time:
+///
+/// ```compile_fail,E0603
+/// use netsuke::manifest::glob::GlobEntryResult;
+/// ```
+///
+/// while the re-exported entry point remains reachable (the control for the
+/// rejection above — it fails instead if the harness wiring breaks):
+///
+/// ```
+/// use netsuke::manifest::glob_paths;
+/// let _: fn(&str) -> _ = glob_paths;
+/// ```
 type GlobEntryResult = std::result::Result<std::path::PathBuf, glob::GlobError>;
 
 /// Expand a glob pattern and collect the matching UTF-8 file paths.

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -30,6 +30,11 @@ use std::{path::Path, sync::Arc};
 
 mod diagnostics;
 mod expand;
+// `glob_paths` is the module's only boundary: every other item, including the
+// `GlobEntryResult` alias, stays module-private. Denying `unreachable_pub`
+// here turns a widened `pub` inside the private module into a build failure,
+// so the boundary cannot regress silently.
+#[deny(unreachable_pub)]
 mod glob;
 mod hints;
 mod jinja_macros;

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -32,8 +32,10 @@ mod diagnostics;
 mod expand;
 // `glob_paths` is the module's only boundary: every other item, including the
 // `GlobEntryResult` alias, stays module-private. Denying `unreachable_pub`
-// here turns a widened `pub` inside the private module into a build failure,
-// so the boundary cannot regress silently.
+// here rejects `pub` items that are still unreachable from the crate root, so
+// the boundary cannot regress silently. The `glob_paths` re-export below makes
+// that one item genuinely reachable and therefore exempt; anything else
+// widened to `pub` fails the build.
 #[deny(unreachable_pub)]
 mod glob;
 mod hints;


### PR DESCRIPTION
## Summary

Closes #174

`GlobEntryResult` in `src/manifest/glob/mod.rs` was declared `pub` but is only consumed within the glob module (by `glob_paths` and the `walk` submodule). It is now a private alias, reducing the public API surface as requested.

The boundary is held by two compile-time guards:

- `#[deny(unreachable_pub)]` on the `mod glob;` declaration in `src/manifest/mod.rs`. Because the module is private, widening any item inside it to `pub` makes that item unreachable from the crate root and fails the build. This was verified by temporarily restoring `pub type GlobEntryResult`, which produced `error: unreachable pub item`.
- A `compile_fail,E0603` doctest on the public `glob_paths` documentation, paired with a passing doctest importing `netsuke::manifest::glob_paths` as the control. This pins the downstream view rather than the alias's own visibility.

`GlobPattern`, its accessors, and the `GlobErrorContext` fields are narrowed to match — they are consumed only within the glob subtree.

## Review feedback addressed

- **Testing (Overall)** — the doctest alone could not distinguish a public alias from a private `glob` module, since both yield E0603. The `unreachable_pub` deny supplies the missing discrimination, and it is a build failure rather than a test-only signal.
- **Developer documentation** — added a "Manifest glob module boundary" section to `docs/developers-guide.md` recording that `glob_paths` is the boundary, that `GlobEntryResult` stays private to `manifest::glob`, and how both guards work.
- **`unreachable_pub` wording** — the description overreached by saying nothing inside the private module is reachable from the crate root. `glob_paths` is re-exported and so is genuinely reachable and exempt. Reworded in the alias docs, the guard comment, and the developers' guide to state the rule as the lint applies it, naming the re-export as the sole exemption.
- **Doctests relocated to the public entry point** — both blocks now hang off the `glob_paths` documentation rather than the private `GlobEntryResult` alias. rustdoc renders and runs the examples of public items, so the compile-fail check is discoverable from the published API docs as well as executed. Confirmed running as `manifest::glob::glob_paths (line 98)` and `(line 106) - compile fail`; replacing the compile-fail body with compiling code makes it FAIL, so it is not vacuous.

## Validation

- `make check-fmt` — pass
- `make lint` — pass
- `make typecheck` — pass
- `make test` — pass (1688 passed, 1 skipped; doctests included)
- `make markdownlint` — pass
- `make nixie` — pass

## References

- Issue [#174](https://github.com/leynos/netsuke/issues/174)
- [Lody session](https://lody.ai/leynos/sessions/938c3aa0-36bd-406a-955c-e32c3193ed82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
