### PR TITLE
Add snapshot tests for CircularDependency formatting (#332)

### DIFF
--- a/src/diagnostic_json_tests.rs
+++ b/src/diagnostic_json_tests.rs
@@ -152,3 +152,50 @@ fn render_manifest_parse_diagnostic_matches_snapshot() -> Result<()> {
     });
     Ok(())
 }
+
+/// Build a real `IrGenError::CircularDependency` through the IR pipeline.
+///
+/// Two targets that consume each other's outputs guarantee a cycle, and the
+/// detector's canonicalisation keeps the reported sequence deterministic.
+fn circular_dependency_error() -> Result<crate::ir::IrGenError> {
+    let manifest = manifest::from_str(concat!(
+        "netsuke_version: \"1.0.0\"\n",
+        "targets:\n",
+        "  - name: a\n",
+        "    sources: b\n",
+        "    command: echo a\n",
+        "  - name: b\n",
+        "    sources: a\n",
+        "    command: echo b\n",
+    ))?;
+    match crate::ir::BuildGraph::from_manifest(&manifest) {
+        Err(err) => Ok(err),
+        Ok(graph) => anyhow::bail!("expected circular dependency error, got graph {graph:?}"),
+    }
+}
+
+#[rstest]
+fn circular_dependency_display_matches_snapshot() -> Result<()> {
+    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
+    let _guard = set_en_localizer();
+    let err = circular_dependency_error()?;
+    snapshot_settings().bind(|| {
+        assert_snapshot!("circular_dependency_display", err.to_string());
+    });
+    Ok(())
+}
+
+#[rstest]
+fn circular_dependency_error_json_matches_snapshot() -> Result<()> {
+    let _lock = localizer_test_lock().expect("localizer test lock poisoned");
+    let _guard = set_en_localizer();
+    let err = circular_dependency_error()?;
+    let document = render_error_json(&err)?;
+    let value = parse_json_value(&document)?;
+    let rendered =
+        serde_json::to_string_pretty(&value).context("render circular dependency JSON")?;
+    snapshot_settings().bind(|| {
+        assert_snapshot!("circular_dependency_error_json", rendered);
+    });
+    Ok(())
+}

--- a/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap
+++ b/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_display.snap
@@ -1,0 +1,6 @@
+---
+source: src/diagnostic_json_tests.rs
+assertion_line: 183
+expression: err.to_string()
+---
+Circular dependency detected: ⁨["a", "b", "a"]⁩.

--- a/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_error_json.snap
+++ b/src/snapshots/diagnostic_json/netsuke__diagnostic_json__tests__circular_dependency_error_json.snap
@@ -1,0 +1,26 @@
+---
+source: src/diagnostic_json_tests.rs
+assertion_line: 198
+expression: rendered
+---
+{
+  "schema_version": 1,
+  "generator": {
+    "name": "netsuke",
+    "version": "0.1.0"
+  },
+  "diagnostics": [
+    {
+      "message": "Circular dependency detected: ⁨[\"a\", \"b\", \"a\"]⁩.",
+      "code": null,
+      "severity": "error",
+      "help": null,
+      "url": null,
+      "causes": [],
+      "source": null,
+      "primary_span": null,
+      "labels": [],
+      "related": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #332

Adds insta snapshot coverage for the user-facing `IrGenError::CircularDependency` message, following the established `diagnostic_json_tests` pattern (localiser lock + `set_en_localizer` + `assert_snapshot!`).

- `circular_dependency_display` — snapshots the `Display` rendering (`Circular dependency detected: ["a", "b", "a"].`).
- `circular_dependency_error_json` — snapshots the JSON diagnostic document via `render_error_json` (the plain-error path; `IrGenError` does not implement `miette::Diagnostic`, so `render_diagnostic_json` does not apply).

The error is produced through the real pipeline (`manifest::from_str` → `BuildGraph::from_manifest`) with a two-target cycle; the detector's canonical rotation keeps the snapshot deterministic.

## Validation

- `make check-fmt` / `make lint` / `make test` — pass (37 suites; both snapshots committed and green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add snapshot-based regression tests for the CircularDependency IR generation error formatting.

Tests:
- Add snapshot test for the Display output of IrGenError::CircularDependency built via the real IR pipeline.
- Add snapshot test for the JSON error document produced for IrGenError::CircularDependency using render_error_json().