### PR TITLE
Restore EnvLock synchronisation unit tests (#321)

### DIFF
--- a/tests/bdd/fixtures/mod.rs
+++ b/tests/bdd/fixtures/mod.rs
@@ -294,3 +294,77 @@ impl<T> RefCellOptionExt<T> for RefCell<Option<T>> {
         self.borrow_mut().take()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_env_lock_acquires_lock_on_first_call() {
+        let world = TestWorld::default();
+        assert!(
+            world.env_lock.borrow().is_none(),
+            "env_lock should be None before ensure_env_lock is called"
+        );
+        world.ensure_env_lock();
+        assert!(
+            world.env_lock.borrow().is_some(),
+            "env_lock should be Some after ensure_env_lock is called"
+        );
+    }
+
+    #[test]
+    fn ensure_env_lock_is_idempotent() {
+        let world = TestWorld::default();
+        world.ensure_env_lock();
+        world.ensure_env_lock();
+        assert!(
+            world.env_lock.borrow().is_some(),
+            "repeated ensure_env_lock calls should keep the lock held"
+        );
+    }
+
+    #[test]
+    fn ensure_env_lock_captures_cwd() {
+        // EnvLock is re-entrant per thread, so holding an outer lock keeps
+        // other tests from moving the CWD while this one asserts on it.
+        let _outer = EnvLock::acquire();
+        let world = TestWorld::default();
+        assert!(
+            world.original_cwd.borrow().is_none(),
+            "original_cwd should be None before ensure_env_lock is called"
+        );
+        world.ensure_env_lock();
+        let captured = world
+            .original_cwd
+            .borrow()
+            .clone()
+            .expect("original_cwd should be captured when the lock is first acquired");
+        let actual = std::env::current_dir().expect("current_dir");
+        assert_eq!(
+            captured, actual,
+            "captured CWD should match the actual CWD at lock acquisition time"
+        );
+    }
+
+    #[test]
+    fn drop_restores_cwd_after_ensure_env_lock() {
+        // Hold the (re-entrant) lock across the world's lifetime so the CWD
+        // cannot be moved by another test between drop and the assertion.
+        let _outer = EnvLock::acquire();
+        let original = std::env::current_dir().expect("current_dir");
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        {
+            let world = TestWorld::default();
+            world.ensure_env_lock();
+            std::env::set_current_dir(temp.path()).expect("chdir");
+        }
+
+        assert_eq!(
+            std::env::current_dir().expect("current_dir"),
+            original,
+            "Drop should restore the CWD captured at ensure_env_lock time"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #321

Restores the `#[cfg(test)] mod tests` block removed from `tests/bdd/fixtures/mod.rs` by PR #273, adapted to the current `ensure_env_lock` / `restore_environment_locked` semantics:

- `ensure_env_lock_acquires_lock_on_first_call`
- `ensure_env_lock_is_idempotent`
- `ensure_env_lock_captures_cwd`
- `drop_restores_cwd_after_ensure_env_lock`

The two CWD-asserting tests are hardened relative to the pre-#273 originals: they hold an outer `EnvLock` (re-entrant per thread) across the world's lifetime so a parallel test cannot move the process CWD between the world's drop and the assertion.

## Validation

- `cargo test --test bdd_tests fixtures::tests` — 4 passed
- `make check-fmt` / `make lint` / `make test` — pass (37 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore unit tests validating EnvLock environment synchronisation behavior in the BDD fixtures module.

Tests:
- Reintroduce tests ensuring EnvLock is acquired on first use and remains held across repeated ensure_env_lock calls.
- Add tests verifying ensure_env_lock captures the current working directory and that dropping the world restores the original CWD while guarding against parallel test interference.