### PR TITLE
Extract shared raw CLI hint scanner (#342)

### DIFF
--- a/src/cli_l10n.rs
+++ b/src/cli_l10n.rs
@@ -220,35 +220,124 @@ const fn subcommand_long_about_key(subcommand: Subcommand) -> &'static str {
     }
 }
 
-/// Inspect raw arguments and extract the `--locale` value when present.
+/// Raw argument hints collected before clap parsing runs.
 ///
-/// When multiple `--locale` flags are provided, the last one is used.
-#[must_use]
-pub fn locale_hint_from_args(args: &[OsString]) -> Option<String> {
-    let mut hint = None;
+/// `values` holds the last value seen for each requested value-taking flag
+/// (from either `--flag value` or `--flag=value`); `flags` records which
+/// requested bare flags appeared. Scanning stops at a `--` terminator.
+#[derive(Debug, Default)]
+struct RawArgHints {
+    values: std::collections::HashMap<&'static str, String>,
+    flags: std::collections::HashSet<&'static str>,
+}
+
+impl RawArgHints {
+    fn value(&self, flag: &str) -> Option<&str> {
+        self.values.get(flag).map(String::as_str)
+    }
+
+    fn has_flag(&self, flag: &str) -> bool {
+        self.flags.contains(flag)
+    }
+}
+
+/// Scan raw arguments for startup hints shared by locale and diagnostic-mode
+/// detection.
+///
+/// The scanner implements the option grammar both hint paths must agree on:
+///
+/// - scanning stops at a bare `--` terminator;
+/// - a flag in `value_flags` consumes the next argument as its value unless
+///   that argument is `--` or absent, in which case scanning stops;
+/// - `--flag=value` records the value inline;
+/// - the last occurrence of a value flag wins;
+/// - a flag in `bare_flags` is recorded by presence alone.
+///
+/// Value interpretation stays with the callers, keeping this scanner purely
+/// lexical.
+fn scan_raw_hints(
+    args: &[OsString],
+    value_flags: &[&'static str],
+    bare_flags: &[&'static str],
+) -> RawArgHints {
+    let mut hints = RawArgHints::default();
     let mut iter = args.iter().peekable();
     while let Some(arg) = iter.next() {
         let text = arg.to_string_lossy();
         if text == "--" {
             break;
         }
-        if text == "--locale" {
-            let Some(next) = iter.peek() else {
-                break;
-            };
-            let next_text = next.to_string_lossy();
-            if next_text == "--" {
-                break;
-            }
-            hint = Some(next_text.into_owned());
-            iter.next();
+        if let Some(flag) = bare_flags.iter().find(|flag| text == **flag) {
+            hints.flags.insert(flag);
             continue;
         }
-        if let Some(value) = text.strip_prefix("--locale=") {
-            hint = Some(value.to_owned());
+        if scan_value_flags(&text, &mut iter, value_flags, &mut hints) == ScanStep::Stop {
+            break;
         }
     }
-    hint
+    hints
+}
+
+/// Outcome of scanning one argument: keep going or stop at a terminator.
+#[derive(Debug, PartialEq, Eq)]
+enum ScanStep {
+    Continue,
+    Stop,
+}
+
+type RawArgIter<'a> = std::iter::Peekable<std::slice::Iter<'a, OsString>>;
+
+/// Match `text` against the value-taking flags, recording any value found.
+fn scan_value_flags(
+    text: &str,
+    iter: &mut RawArgIter<'_>,
+    value_flags: &[&'static str],
+    hints: &mut RawArgHints,
+) -> ScanStep {
+    for flag in value_flags {
+        if text == *flag {
+            return consume_flag_value(flag, iter, hints);
+        }
+        if let Some(value) = text
+            .strip_prefix(flag)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
+            hints.values.insert(flag, value.to_owned());
+            return ScanStep::Continue;
+        }
+    }
+    ScanStep::Continue
+}
+
+/// Consume the argument following `flag` as its value.
+///
+/// A missing value or a `--` terminator stops the scan, mirroring the
+/// behaviour of the original per-flag scanners.
+fn consume_flag_value(
+    flag: &'static str,
+    iter: &mut RawArgIter<'_>,
+    hints: &mut RawArgHints,
+) -> ScanStep {
+    let Some(next) = iter.peek() else {
+        return ScanStep::Stop;
+    };
+    let next_text = next.to_string_lossy();
+    if next_text == "--" {
+        return ScanStep::Stop;
+    }
+    hints.values.insert(flag, next_text.into_owned());
+    iter.next();
+    ScanStep::Continue
+}
+
+/// Inspect raw arguments and extract the `--locale` value when present.
+///
+/// When multiple `--locale` flags are provided, the last one is used.
+#[must_use]
+pub fn locale_hint_from_args(args: &[OsString]) -> Option<String> {
+    scan_raw_hints(args, &["--locale"], &[])
+        .value("--locale")
+        .map(str::to_owned)
 }
 
 pub(crate) fn parse_bool_hint(value: &str) -> Option<bool> {
@@ -268,34 +357,11 @@ pub(crate) fn parse_bool_hint(value: &str) -> Option<bool> {
 /// assignment.
 #[must_use]
 pub fn diag_json_hint_from_args(args: &[OsString]) -> Option<bool> {
-    let mut diag_json_hint = None;
-    let mut output_format_hint = None;
-    let mut iter = args.iter().peekable();
-    while let Some(arg) = iter.next() {
-        let text = arg.to_string_lossy();
-        if text == "--" {
-            break;
-        }
-        if text == "--diag-json" {
-            diag_json_hint = Some(true);
-            continue;
-        }
-        if text == "--output-format" {
-            let Some(next) = iter.peek() else {
-                break;
-            };
-            let next_text = next.to_string_lossy();
-            if next_text == "--" {
-                break;
-            }
-            output_format_hint = diag_json_hint_from_output_format(&next_text);
-            iter.next();
-            continue;
-        }
-        if let Some(value) = text.strip_prefix("--output-format=") {
-            output_format_hint = diag_json_hint_from_output_format(value);
-        }
-    }
+    let hints = scan_raw_hints(args, &["--output-format"], &["--diag-json"]);
+    let output_format_hint = hints
+        .value("--output-format")
+        .and_then(diag_json_hint_from_output_format);
+    let diag_json_hint = hints.has_flag("--diag-json").then_some(true);
     output_format_hint.or(diag_json_hint)
 }
 

--- a/tests/cli_tests/locale.rs
+++ b/tests/cli_tests/locale.rs
@@ -115,6 +115,63 @@ fn diag_json_hint_from_args_honours_output_format(
 }
 
 #[rstest]
+fn locale_hint_from_args_keeps_earlier_value_when_last_flag_lacks_value() -> Result<()> {
+    let args = os_args(&["netsuke", "--locale=fr-FR", "--locale"]);
+    let hint = locale_hint_from_args(&args);
+    ensure!(
+        hint.as_deref() == Some("fr-FR"),
+        "a trailing valueless --locale should not discard the earlier value, got: {hint:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn locale_hint_from_args_keeps_earlier_value_when_terminator_follows_flag() -> Result<()> {
+    let args = os_args(&["netsuke", "--locale", "es-ES", "--locale", "--"]);
+    let hint = locale_hint_from_args(&args);
+    ensure!(
+        hint.as_deref() == Some("es-ES"),
+        "--locale followed by \"--\" should stop scanning and keep the earlier value, got: {hint:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn diag_json_hint_value_flag_consumes_following_flag_like_token() -> Result<()> {
+    // `--output-format` greedily consumes the next token as its value, so the
+    // `--diag-json` here is a (bogus) format value, not a bare flag.
+    let args = os_args(&["netsuke", "--output-format", "--diag-json"]);
+    let hint = diag_json_hint_from_args(&args);
+    ensure!(
+        hint.is_none(),
+        "--diag-json consumed as an --output-format value must not count as a flag, got: {hint:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn diag_json_hint_later_invalid_output_format_resets_earlier_valid_one() -> Result<()> {
+    let args = os_args(&["netsuke", "--output-format=json", "--output-format=tap"]);
+    let hint = diag_json_hint_from_args(&args);
+    ensure!(
+        hint.is_none(),
+        "the last --output-format wins even when its value is unrecognised, got: {hint:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn diag_json_hint_bare_flag_survives_invalid_output_format() -> Result<()> {
+    let args = os_args(&["netsuke", "--diag-json", "--output-format=tap"]);
+    let hint = diag_json_hint_from_args(&args);
+    ensure!(
+        hint == Some(true),
+        "an unrecognised --output-format should fall back to the bare flag, got: {hint:?}"
+    );
+    Ok(())
+}
+
+#[rstest]
 fn cli_localises_invalid_subcommand_in_spanish() -> Result<()> {
     let localizer = Arc::from(cli_localization::build_localizer(Some("es-ES")));
     let err = netsuke::cli::parse_with_localizer_from(


### PR DESCRIPTION
## Summary

Closes #342

`locale_hint_from_args` and `diag_json_hint_from_args` in `src/cli_l10n.rs` duplicated the raw argument grammar (`--` terminator, `--flag value`, `--flag=value`, last-wins). This extracts a single lexical scanner so the locale and diagnostic-mode startup paths cannot diverge.

## Changes

- `src/cli_l10n.rs`: add `scan_raw_hints(args, value_flags, bare_flags) -> RawArgHints` plus small `scan_value_flags`/`consume_flag_value` helpers (flattened to satisfy the nesting threshold). Both public hint functions now delegate to it; value interpretation stays at the call sites as the issue suggests.
- `tests/cli_tests/locale.rs`: five new edge-case tests — trailing valueless flag keeps the earlier value, `--` after a value flag stops scanning without discarding state, a value flag greedily consumes a flag-like token (`--output-format --diag-json` → `None`), the last `--output-format` wins even when unrecognised, and a bare `--diag-json` survives an unrecognised format value.

All existing locale/diag-json hint tests pass unchanged, pinning behavioural equivalence.

## Validation

- `make check-fmt` / `make lint` / `make test` — pass (37 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract a shared raw CLI argument scanner used by locale and diagnostic JSON hint detection to keep their startup parsing behavior consistent.

Enhancements:
- Introduce a reusable lexical scanner for raw CLI hints that supports value flags, bare flags, and terminator handling, and use it in both locale and diagnostic-mode hint extraction.

Tests:
- Add edge-case tests for locale and diagnostic JSON hint parsing to pin behavior around missing values, `--` terminators, value precedence, and interaction between output format and diag-json flags.