### PR TITLE
Add structured debug logging to config merge pipeline (#318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,8 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/cli/discovery.rs
+++ b/src/cli/discovery.rs
@@ -22,17 +22,37 @@ pub(crate) fn push_file_layers(
     composer: &mut MergeComposer,
     errors: &mut Vec<Arc<ortho_config::OrthoError>>,
 ) {
-    let layers_result = explicit_config_path(cli).map_or_else(
+    let explicit_path = explicit_config_path(cli);
+    if let Some(path) = &explicit_path {
+        tracing::debug!(layer = "file", path = %path.display(), "loading explicit configuration file");
+    } else {
+        tracing::debug!(layer = "file", "discovering configuration files");
+    }
+    let layers_result = explicit_path.map_or_else(
         || collect_file_layers(cli.directory.as_deref()),
         |path| load_layers_from_path(&path),
     );
     match layers_result {
-        Ok(layers) => {
-            for layer in layers {
-                composer.push_layer(layer);
-            }
+        Ok(layers) => push_discovered_layers(composer, layers),
+        Err(err) => {
+            tracing::debug!(layer = "file", error = %err, "configuration file discovery failed");
+            errors.push(err);
         }
-        Err(err) => errors.push(err),
+    }
+}
+
+/// Push discovered file layers onto the composer, logging each path.
+fn push_discovered_layers(composer: &mut MergeComposer, layers: Vec<MergeLayer<'static>>) {
+    if layers.is_empty() {
+        tracing::debug!(layer = "file", "no configuration file layers found");
+    }
+    for layer in layers {
+        tracing::debug!(
+            layer = "file",
+            path = ?layer.path(),
+            "discovered configuration file layer"
+        );
+        composer.push_layer(layer);
     }
 }
 

--- a/src/cli/merge.rs
+++ b/src/cli/merge.rs
@@ -38,6 +38,9 @@ use crate::theme::ThemePreference;
 
 const ENV_PREFIX: &str = "NETSUKE_";
 
+/// Error type accumulated while composing configuration layers.
+type MergeError = std::sync::Arc<ortho_config::OrthoError>;
+
 /// Merge discovered configuration layers over parsed CLI input.
 ///
 /// # Errors
@@ -48,34 +51,85 @@ pub fn merge_with_config(cli: &Cli, matches: &ArgMatches) -> OrthoResult<Cli> {
     let mut errors = Vec::new();
     let mut composer = MergeComposer::with_capacity(4);
 
-    match sanitize_value(&CliConfig::default()) {
-        Ok(value) => composer.push_defaults(value),
-        Err(err) => errors.push(err),
-    }
-
+    push_defaults_layer(&mut composer, &mut errors);
     push_file_layers(cli, &mut composer, &mut errors);
-
-    let env_provider = env_provider()
-        .map(|key| Uncased::new(key.as_str().to_ascii_uppercase()))
-        .split("__");
-    match Figment::from(env_provider)
-        .extract::<Value>()
-        .into_ortho_merge()
-    {
-        Ok(value) => composer.push_environment(value),
-        Err(err) => errors.push(err),
-    }
-
-    match cli_overrides_from_matches(cli, matches) {
-        Ok(value) if !is_empty_value(&value) => composer.push_cli(value),
-        Ok(_) => {}
-        Err(err) => errors.push(err),
-    }
+    push_environment_layer(&mut composer, &mut errors);
+    push_cli_layer(cli, matches, &mut composer, &mut errors);
 
     let composition = LayerComposition::new(composer.layers(), errors);
     let merged = composition.into_merge_result(CliConfig::merge_from_layers)?;
     validate_output_format_source(&merged, matches)?;
     Ok(apply_config(cli, merged))
+}
+
+/// Push the serialised `CliConfig::default()` layer, logging the outcome.
+fn push_defaults_layer(composer: &mut MergeComposer, errors: &mut Vec<MergeError>) {
+    match sanitize_value(&CliConfig::default()) {
+        Ok(value) => {
+            tracing::debug!(layer = "defaults", "applied default configuration layer");
+            composer.push_defaults(value);
+        }
+        Err(err) => {
+            tracing::debug!(layer = "defaults", error = %err, "default configuration layer failed");
+            errors.push(err);
+        }
+    }
+}
+
+/// Push the `NETSUKE_`-prefixed environment layer, logging the outcome.
+fn push_environment_layer(composer: &mut MergeComposer, errors: &mut Vec<MergeError>) {
+    let provider = env_provider()
+        .map(|key| Uncased::new(key.as_str().to_ascii_uppercase()))
+        .split("__");
+    match Figment::from(provider)
+        .extract::<Value>()
+        .into_ortho_merge()
+    {
+        Ok(value) => {
+            tracing::debug!(
+                layer = "environment",
+                is_empty = is_empty_value(&value),
+                "merged environment configuration layer"
+            );
+            composer.push_environment(value);
+        }
+        Err(err) => {
+            tracing::debug!(layer = "environment", error = %err, "environment configuration layer failed");
+            errors.push(err);
+        }
+    }
+}
+
+/// Push explicitly supplied CLI overrides, logging which keys were set.
+fn push_cli_layer(
+    cli: &Cli,
+    matches: &ArgMatches,
+    composer: &mut MergeComposer,
+    errors: &mut Vec<MergeError>,
+) {
+    match cli_overrides_from_matches(cli, matches) {
+        Ok(value) if !is_empty_value(&value) => {
+            // Log override keys only; values may echo user-supplied paths or
+            // host lists that do not belong in logs.
+            let override_keys = value
+                .as_object()
+                .map(|map| map.keys().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            tracing::debug!(
+                layer = "cli",
+                override_keys = ?override_keys,
+                "applied CLI override layer"
+            );
+            composer.push_cli(value);
+        }
+        Ok(_) => {
+            tracing::debug!(layer = "cli", "no explicit CLI overrides supplied");
+        }
+        Err(err) => {
+            tracing::debug!(layer = "cli", error = %err, "CLI override layer failed");
+            errors.push(err);
+        }
+    }
 }
 
 pub(crate) fn env_provider() -> Env {
@@ -90,6 +144,11 @@ fn validate_output_format_source(config: &CliConfig, matches: &ArgMatches) -> Or
     if matches!(config.output_format, Some(super::OutputFormat::Json))
         && matches.value_source("output_format") != Some(ValueSource::CommandLine)
     {
+        tracing::debug!(
+            key = "output_format",
+            reason = "json output format must be requested explicitly on the command line",
+            "validation rejected merged configuration"
+        );
         return Err(validation_error(
             "output_format",
             "output_format = \"json\" is not supported yet; pass --output-format json explicitly",

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,15 @@ fn run_with_args(
     };
     let mode = DiagMode::from_json_enabled(cli::resolve_merged_diag_json(&parsed_cli, &matches));
 
+    if !mode.is_json() && parsed_cli.verbose {
+        // Initialise tracing before the merge so the configuration
+        // pipeline's debug events are visible under a command-line
+        // `--verbose`. Diagnostic JSON mode skips initialisation to keep
+        // stderr machine-readable, and config-file-driven verbosity still
+        // takes effect from `configure_runtime` after the merge.
+        init_tracing(Level::DEBUG);
+    }
+
     let merged_cli = match merge_cli_or_exit(&parsed_cli, &matches, mode) {
         Ok(merged) => merged,
         Err(code) => return code,
@@ -73,10 +82,15 @@ fn run_with_args(
 }
 
 fn init_tracing(max_level: Level) {
-    fmt()
-        .with_max_level(max_level)
-        .with_writer(io::stderr)
-        .init();
+    // `try_init` keeps repeated calls harmless: the first initialisation
+    // (e.g. the early `--verbose` setup before the configuration merge)
+    // wins and later calls become no-ops.
+    drop(
+        fmt()
+            .with_max_level(max_level)
+            .with_writer(io::stderr)
+            .try_init(),
+    );
 }
 
 fn startup_localizer(

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -16,6 +16,8 @@ anyhow = "1"
 thiserror = "1"
 assert_cmd = "2.0.0"
 netsuke = { path = ".." }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/test_support/src/lib.rs
+++ b/test_support/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ninja;
 pub mod ninja_gen;
 pub mod path_guard;
 pub mod stdlib_assert;
+pub mod tracing_capture;
 /// Re-export the SHA-256 helper for concise call sites.
 pub use hash::sha256_hex;
 /// Re-export of [`PathGuard`] for crate-level ergonomics in tests.

--- a/test_support/src/tracing_capture.rs
+++ b/test_support/src/tracing_capture.rs
@@ -1,0 +1,98 @@
+//! Capture tracing events emitted during a test closure.
+//!
+//! Installs a thread-local subscriber for the duration of a closure and
+//! records each event's fields as a single `name=value`-joined string, so
+//! tests can assert on structured log output without touching the global
+//! subscriber. Intended for any test that verifies observability behaviour;
+//! prefer this over per-test bespoke capture layers.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use test_support::tracing_capture::with_test_subscriber;
+//!
+//! let events = with_test_subscriber(|captured| {
+//!     tracing::debug!(layer = "defaults", "applied layer");
+//!     captured.snapshot()
+//! });
+//! assert!(events.iter().any(|event| event.contains("layer=\"defaults\"")));
+//! ```
+
+use std::sync::{Arc, Mutex};
+use tracing::{
+    Event, Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::{
+    Layer, filter::LevelFilter, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
+};
+
+/// Handle for reading events captured by [`with_test_subscriber`].
+#[derive(Debug, Clone, Default)]
+pub struct CapturedEvents {
+    fields: Arc<Mutex<Vec<String>>>,
+}
+
+impl CapturedEvents {
+    /// Return a copy of the captured event field strings.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<String> {
+        self.fields.lock().expect("captured events lock").clone()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct CapturedEventsLayer {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S> Layer<S> for CapturedEventsLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: LayerContext<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("captured events lock")
+            .push(visitor.fields.join(" "));
+    }
+}
+
+#[derive(Debug, Default)]
+struct FieldVisitor {
+    fields: Vec<String>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields.push(format!("{}={value}", field.name()));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields.push(format!("{}={value:?}", field.name()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields.push(format!("{}={value:?}", field.name()));
+    }
+}
+
+/// Run `test` with a thread-local subscriber capturing DEBUG+ events.
+pub fn with_test_subscriber<T>(test: impl FnOnce(CapturedEvents) -> T) -> T {
+    let layer = CapturedEventsLayer::default();
+    let captured = CapturedEvents {
+        fields: Arc::clone(&layer.events),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer.with_filter(LevelFilter::DEBUG));
+    tracing::subscriber::with_default(subscriber, || test(captured))
+}

--- a/tests/cli_tests/merge_logging.rs
+++ b/tests/cli_tests/merge_logging.rs
@@ -1,0 +1,74 @@
+//! Structured debug-logging tests for the configuration merge pipeline.
+//!
+//! Verifies that `merge_with_config` emits a debug event at each layer
+//! boundary (defaults, file discovery, environment, CLI overrides) and that
+//! validation rejections carry structured `key`/`reason` fields.
+
+use anyhow::{Context, Result, ensure};
+use rstest::rstest;
+use std::sync::Arc;
+use test_support::tracing_capture::with_test_subscriber;
+
+fn merge_and_capture(cli_args: &[&str]) -> Result<(Vec<String>, bool)> {
+    let _env_lock = test_support::env_lock::EnvLock::acquire();
+    let localizer = Arc::from(netsuke::cli_localization::build_localizer(None));
+    let (cli, matches) = netsuke::cli::parse_with_localizer_from(cli_args, &localizer)
+        .context("parse CLI args for merge logging test")?;
+    Ok(with_test_subscriber(|captured| {
+        let merge_ok = netsuke::cli::merge_with_config(&cli, &matches).is_ok();
+        (captured.snapshot(), merge_ok)
+    }))
+}
+
+fn assert_contains(events: &[String], needle: &str) -> Result<()> {
+    ensure!(
+        events.iter().any(|event| event.contains(needle)),
+        "expected a captured event containing {needle:?}; got {events:#?}"
+    );
+    Ok(())
+}
+
+#[rstest]
+fn merge_emits_debug_event_per_layer() -> Result<()> {
+    let (events, merge_ok) = merge_and_capture(&["netsuke"])?;
+    ensure!(merge_ok, "merge should succeed for plain invocation");
+    assert_contains(&events, "layer=\"defaults\"")?;
+    assert_contains(&events, "layer=\"file\"")?;
+    assert_contains(&events, "layer=\"environment\"")?;
+    assert_contains(&events, "layer=\"cli\"")?;
+    Ok(())
+}
+
+#[rstest]
+fn merge_logs_explicit_cli_override_keys() -> Result<()> {
+    let (events, merge_ok) = merge_and_capture(&["netsuke", "--jobs", "3"])?;
+    ensure!(merge_ok, "merge should succeed with --jobs override");
+    assert_contains(&events, "override_keys")?;
+    assert_contains(&events, "jobs")?;
+    Ok(())
+}
+
+#[rstest]
+fn merge_logs_validation_rejection_with_key_and_reason() -> Result<()> {
+    let _env_lock = test_support::env_lock::EnvLock::acquire();
+    let temp_dir = tempfile::tempdir().context("create temporary config directory")?;
+    let config_path = temp_dir.path().join("netsuke.toml");
+    std::fs::write(&config_path, "output_format = \"json\"\n").context("write netsuke.toml")?;
+    let _config_guard =
+        test_support::EnvVarGuard::set("NETSUKE_CONFIG_PATH", config_path.as_os_str());
+
+    let localizer = Arc::from(netsuke::cli_localization::build_localizer(None));
+    let (cli, matches) = netsuke::cli::parse_with_localizer_from(["netsuke"], &localizer)
+        .context("parse CLI args")?;
+    let (events, merge_ok) = with_test_subscriber(|captured| {
+        let merge_ok = netsuke::cli::merge_with_config(&cli, &matches).is_ok();
+        (captured.snapshot(), merge_ok)
+    });
+    ensure!(
+        !merge_ok,
+        "file-sourced output_format=json must be rejected"
+    );
+    assert_contains(&events, "key=\"output_format\"")?;
+    assert_contains(&events, "reason=")?;
+    Ok(())
+}

--- a/tests/cli_tests/mod.rs
+++ b/tests/cli_tests/mod.rs
@@ -7,5 +7,6 @@ mod config_selection;
 mod helpers;
 mod locale;
 mod merge;
+mod merge_logging;
 mod parsing;
 mod policy;


### PR DESCRIPTION
## Summary

Closes #318

Makes the four-layer configuration merge auditable, as proposed:

- `tracing::debug!` at each layer push (defaults, file, environment, CLI), including the failure paths that previously accumulated errors silently.
- Config file discovery logs the explicit path vs discovery mode, each discovered layer's path, and the no-layers case.
- Validation rejections log structured `key`/`reason` fields.
- CLI override logging records override **keys only** — values may echo user-supplied paths/host lists that do not belong in logs.
- Suppression in `diag_json` mode: the subscriber is never initialised when JSON diagnostics are active, so stderr stays machine-readable. For operators, tracing now initialises **before** the merge when `--verbose` is passed on the command line (`init_tracing` switched to `try_init`, making later init calls no-ops). Config-file-driven verbosity still applies post-merge as before.

## Testing

- New `test_support::tracing_capture` module (reusable thread-local event capture, mirroring the pattern used by the manifest-expansion tracing tests).
- `tests/cli_tests/merge_logging.rs`: asserts one event per layer, override-key logging for `--jobs`, and `key`/`reason` fields when a file-sourced `output_format = "json"` is rejected.

## Validation

- `make check-fmt` / `make lint` / `make test` — pass (37 suites; complexity ceiling respected via extracted per-layer helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add structured debug logging and observability around the configuration merge pipeline and its validation.

Enhancements:
- Emit structured debug events for each configuration layer (defaults, files, environment, CLI) and for validation rejections, including key and reason metadata.
- Ensure CLI override logging records only override keys to avoid leaking user-supplied values in logs.
- Initialize tracing earlier for --verbose runs while keeping diagnostic JSON mode stderr output machine-readable via try_init-based tracing setup.
- Refactor merge logic into per-layer helper functions and improve file layer discovery logging, including explicit-path and no-layer cases.

Build:
- Add tracing and tracing-subscriber dependencies to the test_support crate for use in observability tests.

Tests:
- Introduce a reusable tracing_capture utility to capture tracing events in tests without modifying the global subscriber.
- Add CLI merge_logging tests that assert per-layer debug events, CLI override-key logging, and structured key/reason validation logging for rejected configurations.