### PR TITLE
Remove clap::ValueEnum from domain config enums (#320)

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -16,7 +16,7 @@ use crate::host_pattern::HostPattern;
 use crate::theme::ThemePreference;
 
 /// Colour-output policy accepted by layered configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ColourPolicy {
     /// Follow the host environment.
@@ -42,12 +42,19 @@ impl FromStr for ColourPolicy {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        <Self as ValueEnum>::from_str(s, true).map_err(|_| format!("invalid colour policy '{s}'"))
+        // Mirror the case-insensitive matching previously provided by
+        // `clap::ValueEnum::from_str(s, true)`.
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "always" => Ok(Self::Always),
+            "never" => Ok(Self::Never),
+            _ => Err(format!("invalid colour policy '{s}'")),
+        }
     }
 }
 
 /// Spinner and progress rendering policy.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SpinnerMode {
     /// Follow Netsuke's default progress behaviour.
@@ -73,12 +80,17 @@ impl FromStr for SpinnerMode {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        <Self as ValueEnum>::from_str(s, true).map_err(|_| format!("invalid spinner mode '{s}'"))
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "enabled" => Ok(Self::Enabled),
+            "disabled" => Ok(Self::Disabled),
+            _ => Err(format!("invalid spinner mode '{s}'")),
+        }
     }
 }
 
 /// Top-level diagnostics and output format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum OutputFormat {
     /// Human-readable terminal output.
@@ -101,7 +113,11 @@ impl FromStr for OutputFormat {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        <Self as ValueEnum>::from_str(s, true).map_err(|_| format!("invalid output format '{s}'"))
+        match s.to_ascii_lowercase().as_str() {
+            "human" => Ok(Self::Human),
+            "json" => Ok(Self::Json),
+            _ => Err(format!("invalid output format '{s}'")),
+        }
     }
 }
 

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -12,7 +12,6 @@
 //! - Shared dispatch logic lives in [`parse_value_enum`] (called by the three
 //!   enum-valued parsers via [`ParseEnumSpec`]).
 
-use clap::ValueEnum;
 use ortho_config::{LanguageIdentifier, LocalizationArgs, Localizer};
 use std::str::FromStr;
 
@@ -173,9 +172,9 @@ struct ParseEnumSpec {
 
 fn parse_value_enum<T>(localizer: &dyn Localizer, s: &str, spec: ParseEnumSpec) -> Result<T, String>
 where
-    T: ValueEnum,
+    T: FromStr,
 {
-    T::from_str(s, true).map_err(|_| {
+    s.parse::<T>().map_err(|_| {
         let mut args = LocalizationArgs::default();
         args.insert(spec.arg_name, s.to_owned().into());
         super::parser::validation_message(

--- a/tests/bdd/steps/configuration_preferences.rs
+++ b/tests/bdd/steps/configuration_preferences.rs
@@ -77,23 +77,17 @@ fn write_theme_config(world: &TestWorld, theme: Theme) -> Result<()> {
 
 /// Write a colour policy value to the config file.
 fn write_colour_policy_config(world: &TestWorld, policy: ColourPolicy) -> Result<()> {
-    write_config(
-        world,
-        &format!("colour_policy = \"{}\"\n", enum_name(&policy)),
-    )
+    write_config(world, &format!("colour_policy = \"{policy}\"\n"))
 }
 
 /// Write a spinner mode value to the config file.
 fn write_spinner_mode_config(world: &TestWorld, mode: SpinnerMode) -> Result<()> {
-    write_config(world, &format!("spinner_mode = \"{}\"\n", enum_name(&mode)))
+    write_config(world, &format!("spinner_mode = \"{mode}\"\n"))
 }
 
 /// Write an output format value to the config file.
 fn write_output_format_config(world: &TestWorld, format: OutputFormat) -> Result<()> {
-    write_config(
-        world,
-        &format!("output_format = \"{}\"\n", enum_name(&format)),
-    )
+    write_config(world, &format!("output_format = \"{format}\"\n"))
 }
 
 /// Set the `NETSUKE_THEME` environment variable.
@@ -104,7 +98,7 @@ fn set_env_theme(world: &TestWorld, theme: Theme) -> Result<()> {
 
 /// Set the `NETSUKE_COLOUR_POLICY` environment variable.
 fn set_env_colour_policy(world: &TestWorld, policy: ColourPolicy) -> Result<()> {
-    let value = enum_name(&policy);
+    let value = policy.to_string();
     mutate_env_var(
         world,
         EnvVarKey::from("NETSUKE_COLOUR_POLICY"),
@@ -114,7 +108,7 @@ fn set_env_colour_policy(world: &TestWorld, policy: ColourPolicy) -> Result<()> 
 
 /// Set the `NETSUKE_SPINNER_MODE` environment variable.
 fn set_env_spinner_mode(world: &TestWorld, mode: SpinnerMode) -> Result<()> {
-    let value = enum_name(&mode);
+    let value = mode.to_string();
     mutate_env_var(world, EnvVarKey::from("NETSUKE_SPINNER_MODE"), Some(&value))
 }
 
@@ -152,7 +146,8 @@ fn set_environment_locale_override(world: &TestWorld, locale: &str) -> Result<()
 
 #[given("the Netsuke config file sets output format to {format:string}")]
 fn config_sets_output_format(world: &TestWorld, format: &str) -> Result<()> {
-    let typed = OutputFormat::from_str(format, true)
+    let typed: OutputFormat = format
+        .parse()
         .map_err(|err| anyhow!("invalid output format '{format}': {err}"))?;
     write_output_format_config(world, typed)
 }
@@ -171,14 +166,16 @@ fn config_sets_theme(world: &TestWorld, theme: &str) -> Result<()> {
 
 #[given("the Netsuke config file sets colour policy to {policy:string}")]
 fn config_sets_colour_policy(world: &TestWorld, policy: &str) -> Result<()> {
-    let typed = ColourPolicy::from_str(policy, true)
+    let typed: ColourPolicy = policy
+        .parse()
         .map_err(|err| anyhow!("invalid colour policy '{policy}': {err}"))?;
     write_colour_policy_config(world, typed)
 }
 
 #[given("the Netsuke config file sets spinner mode to {mode:string}")]
 fn config_sets_spinner_mode(world: &TestWorld, mode: &str) -> Result<()> {
-    let typed = SpinnerMode::from_str(mode, true)
+    let typed: SpinnerMode = mode
+        .parse()
         .map_err(|err| anyhow!("invalid spinner mode '{mode}': {err}"))?;
     write_spinner_mode_config(world, typed)
 }
@@ -192,14 +189,16 @@ fn set_environment_theme_override(world: &TestWorld, theme: &str) -> Result<()> 
 
 #[given("the NETSUKE_COLOUR_POLICY environment variable is {policy:string}")]
 fn set_environment_colour_policy_override(world: &TestWorld, policy: &str) -> Result<()> {
-    let typed = ColourPolicy::from_str(policy, true)
+    let typed: ColourPolicy = policy
+        .parse()
         .map_err(|err| anyhow!("invalid colour policy '{policy}': {err}"))?;
     set_env_colour_policy(world, typed)
 }
 
 #[given("the NETSUKE_SPINNER_MODE environment variable is {mode:string}")]
 fn set_environment_spinner_mode_override(world: &TestWorld, mode: &str) -> Result<()> {
-    let typed = SpinnerMode::from_str(mode, true)
+    let typed: SpinnerMode = mode
+        .parse()
         .map_err(|err| anyhow!("invalid spinner mode '{mode}': {err}"))?;
     set_env_spinner_mode(world, typed)
 }


### PR DESCRIPTION
## Summary

Closes #320

Decouples the domain configuration schema from the Clap parsing layer:

- `src/cli/config.rs`: drop `#[derive(clap::ValueEnum)]` from `ColourPolicy`, `SpinnerMode`, and `OutputFormat`; each `FromStr` now matches kebab-case names case-insensitively, mirroring the previous `ValueEnum::from_str(s, true)` behaviour exactly.
- `src/cli/parsing.rs`: `parse_value_enum` dispatches via `FromStr` instead of `ValueEnum`, keeping the Clap-facing dispatch centralised in `ParseEnumSpec` as proposed.
- `tests/bdd/steps/configuration_preferences.rs`: the steps for the three enums use `Display`/`str::parse` instead of `to_possible_value`/`ValueEnum::from_str`.

`Theme` keeps its derive — it parses through `ThemePreference::parse_raw` and is outside this issue's scope.

No behaviour change: clap's derived parser inference falls back to `FromStr`, and the runtime parsers were already the localised `parse_*` functions.

## Validation

- `make check-fmt` / `make lint` / `make test` — pass (37 suites, including all CLI parsing and configuration-preference BDD scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Decouple configuration enums from clap by parsing them via `FromStr` instead of `clap::ValueEnum` while preserving existing CLI behaviour.

Enhancements:
- Implement manual `FromStr` parsing for `ColourPolicy`, `SpinnerMode`, and `OutputFormat` enums with case-insensitive, kebab-case matching and remove their `ValueEnum` derives.
- Update generic CLI enum parsing to rely on `FromStr`-based parsing rather than `clap::ValueEnum` to reduce coupling to the argument parser.

Tests:
- Adjust configuration preference BDD steps to use enum `Display` and `FromStr`/`str::parse` instead of `ValueEnum` utilities, keeping test behaviour aligned with the new parsing model.