### PR TITLE
Update stale source path references in documentation (#345)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -42,7 +42,7 @@ the hexagonal port/adapter pattern:
   `render(&self, view: &GraphView, sink: &mut dyn io::Write) -> Result<(), GraphRenderError>`.
   Adapters consume `GraphView` only — they never touch `BuildGraph` directly.
 - [`DotRenderer`](../src/graph_view/render_dot.rs) emits Graphviz DOT.
-- [`HtmlRenderer`](../src/graph_view/render_html.rs) emits a self-contained
+- [`HtmlRenderer`](../src/graph_view/render_html/mod.rs) emits a self-contained
   HTML page (server-rendered SVG, accessible textual outline, and a
   `<noscript>` fallback containing the DOT source verbatim).
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -892,7 +892,7 @@ accept optional `phony` and `always` booleans. They default to `false`, making
 it explicit when an action should run regardless of file timestamps. Targets
 listed in the `actions` section are deserialized using a custom helper so they
 are always treated as `phony` tasks. This ensures preparation actions never
-generate build artefacts. Convenience functions in `src/manifest.rs` load a
+generate build artefacts. Convenience functions in `src/manifest/mod.rs` load a
 manifest from a string or a file path, returning `anyhow::Result` for
 straightforward error handling. Diagnostics now wrap source and manifest
 identifiers in the `ManifestSource` and `ManifestName` newtypes, allowing
@@ -2433,9 +2433,10 @@ manifest parsing, stdlib template errors, and runner failures) use the same
 Fluent localizer so the locale selection is consistent across user-facing
 output. A build-time audit in `build.rs` validates that all referenced Fluent
 message keys exist in the bundled catalogues, ensuring missing strings fail CI
-before release. CLI execution and dispatch live in `src/runner.rs`, keeping
+before release. CLI execution and dispatch live in `src/runner/mod.rs`, keeping
 `main.rs` focused on parsing. Process management, Ninja invocation, argument
-redaction, and the temporary file helpers reside in `src/runner/process.rs`,
+redaction, and the temporary file helpers reside in
+`src/runner/process/mod.rs`,
 allowing the runner entry point to delegate low-level concerns. The working
 directory flag mirrors Ninja's `-C` option but is resolved internally: Netsuke
 runs Ninja with a configured working directory and resolves relative output

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1126,9 +1126,9 @@ for maintainability and scalability.
     (in the `tests/` directory), consider creating a common module within the
     `tests/` directory (e.g., `tests/common/fixtures.rs`) and re-exporting
     public fixtures.
-  - Alternatively, define shared fixtures in the library crate itself (e.g., in
-    `src/lib.rs` or `src/fixtures.rs` under `#[cfg(test)]`) and `use` them in
-    integration tests.
+  - Alternatively, define shared fixtures in the library crate itself (e.g.,
+    in `src/lib.rs` or a dedicated fixtures module under `#[cfg(test)]`) and
+    `use` them in integration tests.
 - **Naming Conventions:** Use clear, descriptive names for fixtures that
   indicate what they provide or set up. Test function names should clearly
   state what behaviour they are verifying.


### PR DESCRIPTION
## Summary

Closes #345

Corrects every stale source path the issue lists:

- `docs/netsuke-design.md:895` — `src/manifest.rs` → `src/manifest/mod.rs`
- `docs/netsuke-design.md:2436` — `src/runner.rs` → `src/runner/mod.rs`
- `docs/netsuke-design.md:2438` — `src/runner/process.rs` → `src/runner/process/mod.rs`
- `docs/developers-guide.md:45` — `src/graph_view/render_html.rs` → `src/graph_view/render_html/mod.rs`
- `docs/rust-testing-with-rstest-fixtures.md:1130` — removed the obsolete `src/fixtures.rs` example ("a dedicated fixtures module" instead)

`docs/contents.md` needs no change (no documentation structure changed).

## Validation

- `make markdownlint` — 0 errors
- `make check-fmt` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update documentation to reflect current Rust module file structure and fixture organization guidance.

Documentation:
- Correct source file path references in design and developer documentation to point to the current module-based layout.
- Revise testing guide wording to describe using a dedicated fixtures module instead of a specific src/fixtures.rs file.