### PR TITLE
Add trybuild test for Captured::state lifetime correctness (#314)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1458,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
  "ureq",
  "url",
  "wait-timeout",
@@ -2562,6 +2569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,6 +2585,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2889,6 +2911,22 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "dissimilar",
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.10+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ strip-ansi-escapes = "0.2"
 toml = "0.8"
 serde_yaml = "0.9"
 proptest = "1.11.0"
+trybuild = { version = "1", features = ["diff"] }
 
 # Target-specific dev-deps
 [target.'cfg(unix)'.dev-dependencies]

--- a/tests/compile_fail_tests.rs
+++ b/tests/compile_fail_tests.rs
@@ -1,0 +1,13 @@
+//! Compile-time UI tests for `Captured::state()` lifetime correctness.
+//!
+//! `MacroStateGuard` (in `src/manifest/jinja_macros/cache.rs`) relies on the
+//! borrow checker rejecting any programme that lets a `&State` outlive the
+//! owning `Captured`. These trybuild cases pin that guarantee: the dangling
+//! case must fail to compile, and the well-scoped case must compile.
+
+#[test]
+fn captured_state_lifetime_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/captured_state_outlives_captured.rs");
+    t.pass("tests/ui/captured_state_within_scope.rs");
+}

--- a/tests/ui/captured_state_outlives_captured.rs
+++ b/tests/ui/captured_state_outlives_captured.rs
@@ -1,0 +1,15 @@
+//! Attempting to hold a `&State` beyond the owning `Captured`'s lifetime
+//! must be rejected by the borrow checker.
+
+use minijinja::Environment;
+
+fn main() {
+    let mut env = Environment::new();
+    env.add_template("greeting", "{{ 1 }}").expect("template");
+    let template = env.get_template("greeting").expect("template");
+    let state_ref = {
+        let captured = template.render_captured(()).expect("render");
+        captured.state()
+    };
+    let _ = state_ref;
+}

--- a/tests/ui/captured_state_outlives_captured.stderr
+++ b/tests/ui/captured_state_outlives_captured.stderr
@@ -1,0 +1,11 @@
+error[E0597]: `captured` does not live long enough
+  --> tests/ui/captured_state_outlives_captured.rs:12:9
+   |
+10 |     let state_ref = {
+   |         --------- borrow later stored here
+11 |         let captured = template.render_captured(()).expect("render");
+   |             -------- binding `captured` declared here
+12 |         captured.state()
+   |         ^^^^^^^^ borrowed value does not live long enough
+13 |     };
+   |     - `captured` dropped here while still borrowed

--- a/tests/ui/captured_state_within_scope.rs
+++ b/tests/ui/captured_state_within_scope.rs
@@ -1,0 +1,13 @@
+//! Using `Captured::state()` strictly within the owning `Captured`'s
+//! lifetime compiles cleanly.
+
+use minijinja::Environment;
+
+fn main() {
+    let mut env = Environment::new();
+    env.add_template("greeting", "{{ 1 }}").expect("template");
+    let template = env.get_template("greeting").expect("template");
+    let captured = template.render_captured(()).expect("render");
+    let state = captured.state();
+    let _ = state.lookup("missing");
+}


### PR DESCRIPTION
## Summary

Closes #314

Adds the trybuild scaffolding the issue specifies:

1. `tests/compile_fail_tests.rs` with `captured_state_lifetime_tests` running both UI cases.
2. `tests/ui/captured_state_outlives_captured.rs` — holds a `&State` beyond the owning `Captured`; rejected by the borrow checker (E0597, "`captured` does not live long enough").
3. `tests/ui/captured_state_within_scope.rs` — uses `captured.state()` only within the owning `Captured`'s lifetime; compiles.
4. `trybuild = { version = "1", features = ["diff"] }` dev-dependency.
5. Expected `.stderr` recorded once with `TRYBUILD=overwrite` and committed.

Acceptance checks: `fd -e rs . tests/ui | wc -l` → 2; `rg trybuild Cargo.toml` → the new dev-dependency.

## Validation

- `make check-fmt` / `make lint` / `make test` — pass (38 suites, including the new compile-fail target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add compile-time UI tests to validate the lifetime correctness of `Captured::state()` using trybuild.

Build:
- Add `trybuild` as a dev-dependency with the `diff` feature enabled.

Tests:
- Introduce a trybuild-based compile-fail test suite covering `Captured::state()` lifetime behavior, including a failing outlives case and a passing well-scoped case.