### PR TITLE
Pin shared-actions SHA in CI to current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/setup-rust@4b35232
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -48,7 +48,7 @@ jobs:
         run: make test
       - name: Test and Measure Coverage
         if: matrix.rust == 'stable'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/generate-coverage@4b35232
         with:
           output-path: lcov.info
           format: lcov
@@ -56,7 +56,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@4b35232
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/setup-rust@4b35232
         with:
           toolchain: stable
       - name: Install uv


### PR DESCRIPTION
Update the four leynos/shared-actions references in .github/workflows/ci.yml to pin to commit 4b35232.