### PR TITLE
Pin shared actions to nextest checksum fix

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -88,7 +88,7 @@ jobs:
           cargo-orthohelp --version | grep '0\.8\.0'
 
       - name: Build release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/rust-build-release@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ env.BIN_NAME }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Stage artefacts
         id: stage
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           config-file: .github/release-staging.toml
           target: ${{ inputs['stage-target'] }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Package Linux artefacts with dependencies
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/linux-packages@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           project-dir: .
           package-name: ${{ inputs['bin-name'] }}
@@ -151,7 +151,7 @@ jobs:
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
-        uses: leynos/shared-actions/.github/actions/windows-package@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/windows-package@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           product-name: ${{ inputs['bin-name'] }}
           manufacturer: Leynos
@@ -169,7 +169,7 @@ jobs:
       - name: Build macOS installer package
         if: inputs.platform == 'macos'
         id: package_macos
-        uses: leynos/shared-actions/.github/actions/macos-package@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/macos-package@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           name: ${{ inputs['bin-name'] }}
           identifier: com.leynos.${{ inputs['bin-name'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -48,7 +48,7 @@ jobs:
         run: make test
       - name: Test and Measure Coverage
         if: matrix.rust == 'stable'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/generate-coverage@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           output-path: lcov.info
           format: lcov
@@ -56,7 +56,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           toolchain: stable
       - name: Install uv

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           toolchain: ${{ matrix.rust }}
       - name: Show rustc version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+          leynos/shared-actions/.github/actions/determine-release-modes@7da7c6d89033d13cbb1c64803d108ddca97e69c2
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+          leynos/shared-actions/.github/actions/ensure-cargo-version@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs['should-publish']) }}
       - id: wix_extension_version
@@ -107,7 +107,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+          leynos/shared-actions/.github/actions/export-cargo-metadata@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -239,7 +239,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@718c4f2eadaf95d527814862fd7cb85d91c8a8fc
+          leynos/shared-actions/.github/actions/upload-release-assets@7da7c6d89033d13cbb1c64803d108ddca97e69c2
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}


### PR DESCRIPTION
## Summary

This branch updates the pinned `leynos/shared-actions` commit across Netsuke's GitHub workflows to `7da7c6d89033d13cbb1c64803d108ddca97e69c2`, the shared-actions commit that corrects the `cargo-nextest` Linux checksum entries.

The requested CI workflow pins are updated, and the remaining shared-actions workflow references are moved to the same commit because Netsuke's existing workflow pin consistency test requires a single shared-actions SHA across all workflows.

## Review walkthrough

- Start with [`.github/workflows/ci.yml`](https://github.com/leynos/netsuke/blob/pin-shared-actions-nextest-shas/.github/workflows/ci.yml) to review the CI setup, coverage generation and CodeScene upload pins.
- Then review [`.github/workflows/build-and-package.yml`](https://github.com/leynos/netsuke/blob/pin-shared-actions-nextest-shas/.github/workflows/build-and-package.yml) for the release build, staging and package action pins.
- Finish with [`.github/workflows/release.yml`](https://github.com/leynos/netsuke/blob/pin-shared-actions-nextest-shas/.github/workflows/release.yml) and [`.github/workflows/netsukefile-test.yml`](https://github.com/leynos/netsuke/blob/pin-shared-actions-nextest-shas/.github/workflows/netsukefile-test.yml) to confirm the remaining shared-actions references stay aligned.

## Validation

- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: passed

## Notes

The upstream shared-actions change landed in leynos/shared-actions#290 as `7da7c6d89033d13cbb1c64803d108ddca97e69c2`.