### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
         run: make check-fmt
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test
         run: make test
       - name: Test and Measure Coverage

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,42 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "5 3 * * *" # Daily, 03:05 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # Path dependency outside the root package's workspace; its
+      # coverage lives mainly in the root crate's tests, so treat its
+      # survivors table as advisory. test_support is deliberately
+      # omitted: it is a test-fixture crate whose survivors are noise.
+      extra-crate-dirs: "ninja_env"
+      # Kani-only verification modules gated behind #[cfg(kani)] mod
+      # declarations; cargo-mutants does not evaluate that cfg, so
+      # mutants there would compile to nothing and survive as noise.
+      exclude-globs: "src/ir/cycle_verification.rs,src/ir/from_manifest_verification.rs,src/ir/graph_kani_map.rs"
+      # Match the CI baseline (`make test` runs --all-features) so
+      # feature-gated tests (legacy-digests) run against mutants.
+      extra-args: "--all-features"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build.ninja
 *:Zone.Identifier
 /graph.dot
 /graph.html
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt typecheck markdownlint nixie install-kani kani-check kani-full kani-ir install-verus verus formal-pr
+.PHONY: help all clean test test-workflow-contracts build release lint fmt check-fmt typecheck markdownlint nixie install-kani kani-check kani-full kani-ir install-verus verus formal-pr
 
 APP ?= netsuke
 CARGO ?= $(shell command -v cargo 2>/dev/null || printf '%s' "$$HOME/.cargo/bin/cargo")
@@ -29,6 +29,9 @@ clean: ## Remove build artefacts
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 target/%/$(APP): ## Build binary in debug or release mode
 	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,152 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; netsuke's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the ninja_env target, the
+Kani-module excludes, or the feature args) fails CI on the pull request
+rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The pinned commit of leynos/shared-actions (the merge commit of its
+#: PR #319). Bump the workflow and this test together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: Kani-only verification modules gated behind ``#[cfg(kani)]`` mod
+#: declarations; cargo-mutants does not evaluate that cfg, so their
+#: survivors would be noise.
+KANI_EXCLUDES = (
+    "src/ir/cycle_verification.rs",
+    "src/ir/from_manifest_verification.rs",
+    "src/ir/graph_kani_map.rs",
+)
+
+#: The exact caller configuration; assert the whole block so an added or
+#: dropped input fails loudly.
+EXPECTED_WITH = {
+    "extra-crate-dirs": "ninja_env",
+    "exclude-globs": ",".join(KANI_EXCLUDES),
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump this test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "5 3 * * *"}], (
+        f"on.schedule must be the daily 03:05 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the ninja_env target, excludes, and args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"(ninja_env as an extra crate, the #[cfg(kani)] module excludes, "
+        f"and --all-features to match the CI baseline); expected "
+        f"{EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adopts the shared mutation-testing reusable workflow as a thin caller of [`leynos/shared-actions` `mutation-cargo.yml`](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md), pinned to commit `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only and never gate pull requests: a daily guard (03:05 UTC) mutates only files changed within the detection window, making quiet days a cheap no-op, while manual dispatch runs a full mutation sweep fanned out across shards.

## Configuration for this repository

- **`extra-crate-dirs: "ninja_env"`** — netsuke is not a Cargo workspace; `ninja_env` is a path dependency living outside the root package, so it is mutated as a separate target. Its coverage lives mainly in the root crate's tests, so its survivors table is advisory. The `test_support` crate is deliberately omitted: it is a test-fixture crate whose survivors would be pure noise.
- **`exclude-globs`** — `src/ir/cycle_verification.rs`, `src/ir/from_manifest_verification.rs` and `src/ir/graph_kani_map.rs` are Kani-only verification modules declared behind `#[cfg(kani)]` mod attributes. cargo-mutants does not evaluate that cfg, so mutants there would never be compiled and would survive as noise. All other test scaffolding under `src/` sits behind `#[cfg(test)]`, which cargo-mutants skips natively.
- **`extra-args: "--all-features"`** — mirrors the CI baseline (`make test` runs `--all-targets --all-features`) so the feature-gated `legacy-digests` tests run against mutants.
- **`paths`** is left at its default (`src/,examples/,benches/`), which already covers all mutable root-crate Rust source; `examples/` contains no Rust.

A contract test suite (`tests/workflow_contracts/mutation_testing_test.py`) pins the caller's shape — the exact commit SHA, least-privilege permissions, concurrency, triggers and the full `with:` block — so drift fails CI on the pull request rather than surfacing in a scheduled run. It runs in the `build-test` CI job through the new `test-workflow-contracts` Makefile target, with a pinned `astral-sh/setup-uv` step.

## Validation

- YAML parse of both edited workflows passes.
- `actionlint` on `mutation-testing.yml` and `ci.yml` reports no findings.
- `make test-workflow-contracts`: 6 passed, including a negative check — temporarily repointing the pin at `@v1` fails the SHA test as intended, and the suite returns to green once restored.

## References

- Caller guide: <https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md>
- Estate template: leynos/wireframe#572
