### PR TITLE
Wire CodeScene coverage upload on push to main

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -88,7 +88,7 @@ jobs:
           cargo-orthohelp --version | grep '0\.8\.0'
 
       - name: Build release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/rust-build-release@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ env.BIN_NAME }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Stage artefacts
         id: stage
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           config-file: .github/release-staging.toml
           target: ${{ inputs['stage-target'] }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Package Linux artefacts with dependencies
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/linux-packages@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           project-dir: .
           package-name: ${{ inputs['bin-name'] }}
@@ -151,7 +151,7 @@ jobs:
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
-        uses: leynos/shared-actions/.github/actions/windows-package@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/windows-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           product-name: ${{ inputs['bin-name'] }}
           manufacturer: Leynos
@@ -169,7 +169,7 @@ jobs:
       - name: Build macOS installer package
         if: inputs.platform == 'macos'
         id: package_macos
-        uses: leynos/shared-actions/.github/actions/macos-package@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/macos-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           name: ${{ inputs['bin-name'] }}
           identifier: com.leynos.${{ inputs['bin-name'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,12 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+        with:
+          # Full history so the deferred cs-coverage check step can reach
+          # the pull request's merge base once the gate is wired in.
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -57,19 +61,23 @@ jobs:
         run: make test
       - name: Test and Measure Coverage
         if: matrix.rust == 'stable'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@7da7c6d89033d13cbb1c64803d108ddca97e69c2
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          # Compare changed-line coverage against the baseline written by
+          # coverage-main.yml (caches saved on main are readable by every PR).
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 69281 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint and chutoro hit the byte-identical error). Add the
+      # check step in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate
+      # is enabled.
 
   kani-smoke:
     if: github.event_name == 'pull_request'
@@ -86,7 +94,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           toolchain: stable
       - name: Install uv

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,43 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Test and Measure Coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           toolchain: ${{ matrix.rust }}
       - name: Show rustc version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+          leynos/shared-actions/.github/actions/determine-release-modes@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+          leynos/shared-actions/.github/actions/ensure-cargo-version@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs['should-publish']) }}
       - id: wix_extension_version
@@ -107,7 +107,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+          leynos/shared-actions/.github/actions/export-cargo-metadata@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -239,7 +239,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@7da7c6d89033d13cbb1c64803d108ddca97e69c2
+          leynos/shared-actions/.github/actions/upload-release-assets@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}


### PR DESCRIPTION
## Summary

netsuke is the estate's reference pattern for the CodeScene coverage
gate, but its own onboarding was broken: `CS_ACCESS_TOKEN` was unset so
the guarded upload step skipped silently, and its shared-actions pin
predated the fixed coverage actions. This PR repairs the wiring.

It lands the **upload half** of the onboarding only. The pull-request
changed-line gate (`mode: check`) is deliberately deferred. CodeScene
project 69281 currently lacks the coverage-gates configuration, so
`cs-coverage check` fails with `Lacks the gates configuration` and
would turn the required `build-test (ubuntu-latest, stable)` job
permanently red. The byte-identical failure was observed on ddlint
(project 69278) and chutoro (71838), confirming the gate is a
per-CodeScene-project toggle that is off for every project except mxd.
A push-to-main `cs-coverage upload` needs no gates configuration and is
the candidate that may provision it, so it goes first; the `mode: check`
step is a fast-follow once the gate resolves.

Note on the CodeScene check: `CodeScene Code Coverage` is **not** a
required status check in the branch ruleset (the required checks are
`build-test (ubuntu-latest, stable)`, `kani-smoke`,
`netsukefile (stable)` and `release / metadata`). CodeScene posts its
checks independently; they influence merges only through the
status-check rollup that Dependabot automerge reads.

## Review walkthrough

- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/netsuke/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml):
  a new push-to-main workflow that uploads coverage with the default
  `mode: upload` (CodeScene accepts uploads only from analysed
  branches) and writes the ratchet baseline that pull-request runs
  compare against. Caches saved on main are readable by every PR, so
  the baseline lives here.
- [`.github/workflows/ci.yml`](https://github.com/leynos/netsuke/blob/codescene-coverage-gate/.github/workflows/ci.yml):
  the pull-request coverage step keeps generating LCOV under nextest
  (netsuke's coverage already ran under nextest) and gains
  `with-ratchet: 'true'`. The previous `mode: upload` CodeScene step —
  which CodeScene rejects from pull-request branches — is removed; a
  comment records that the `mode: check` gate is deferred until the
  project's coverage gate is enabled.
- Shared-actions pins across `ci.yml`, `build-and-package.yml`,
  `netsukefile-test.yml` and `release.yml` all move to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`, which carries the fixed
  `generate-coverage`/`upload-codescene-coverage` actions. A single
  action pin is kept, as the `workflow_shared_actions_pins` contract
  test requires. The Dependabot-managed reusable-workflow pins
  (`dependabot-automerge.yml`, `mutation-cargo.yml`) are unrelated to
  coverage, sit outside that contract, and are left to Dependabot.

## Validation

- `python3 -c "import yaml; ..."` parses all nine workflows cleanly.
- `make test-workflow-contracts` passes (6 passed).
- The `workflow_shared_actions_pins` invariant holds: exactly one
  action pin across all workflows.
- `CS_ACCESS_TOKEN` is set in both the Actions and Dependabot secret
  stores.
- After merge, `coverage-main.yml` runs on push to main; its
  `mode: upload` and ratchet-baseline save confirm the upload path end
  to end and test whether the first upload provisions the coverage gate.
