### PR TITLE
Hand shared-actions SHA ownership to Dependabot in contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -109,6 +109,41 @@ For documentation changes, also run:
 - `make markdownlint`
 - `make nixie`
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Spelling enforcement
 
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,10 +3,14 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; netsuke's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the Kani-module excludes or
-the feature args) fails CI on the pull request rather than surfacing in
-a scheduled or manual run.
+PyYAML and pin the contract it must uphold, so drift (repointing the
+reference at a branch, widening permissions, or losing the Kani-module
+excludes or the feature args) fails CI on the pull request rather than
+surfacing in a scheduled or manual run.
+
+The caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so this test asserts the shape of the pin
+(a 40-character lowercase hex commit SHA) rather than a specific SHA.
 
 Run via ``make test-workflow-contracts``.
 """
@@ -21,13 +25,7 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The pinned commit of leynos/shared-actions (the merge commit of its
-#: PR #319). Bump the workflow and this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
-)
+EXPECTED_USES_PATH = "leynos/shared-actions/.github/workflows/mutation-cargo.yml"
 
 #: Kani-only verification modules gated behind ``#[cfg(kani)]`` mod
 #: declarations; cargo-mutants does not evaluate that cfg, so their
@@ -69,12 +67,17 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml, pinned to a full commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (the correct reusable-workflow path, at a 40-character lowercase hex
+    commit SHA) rather than a specific commit.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
     path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+    assert path == EXPECTED_USES_PATH, (
         f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
     )
     assert len(ref) == 40, (
@@ -84,10 +87,6 @@ def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
     assert all(c in "0123456789abcdef" for c in ref), (
         f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
         f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump this test together with the workflow"
     )
 
 

--- a/tests/workflow_shared_actions_pins.rs
+++ b/tests/workflow_shared_actions_pins.rs
@@ -1,9 +1,17 @@
-//! Verify shared-actions pinning remains consistent across workflows.
+//! Verify shared-actions references are pinned to a full commit SHA.
+//!
+//! Dependabot owns the SHA value for each `leynos/shared-actions` action
+//! reference and bumps callers one at a time, so this test does not assert
+//! that every reference shares an identical pin. It only asserts the shape
+//! of each reference: the correct `.github/actions/<name>` path, pinned to a
+//! 40-character lowercase-hex commit SHA rather than a mutable branch or tag
+//! such as `main`.
 
 use anyhow::{Context, Result, ensure};
-use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/.github/actions/";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -18,41 +26,72 @@ fn read_workflow(path: &Path) -> Result<String> {
         .with_context(|| format!("workflow file {} should be readable", path.display()))
 }
 
-fn extract_shared_actions_pins(contents: &str) -> Vec<String> {
+fn extract_shared_actions_uses(contents: &str) -> Vec<String> {
     contents
         .lines()
         .filter_map(|line| {
-            let marker = "leynos/shared-actions/.github/actions/";
-            if !line.contains(marker) {
-                return None;
-            }
-            let pin = line
-                .split('@')
-                .nth(1)
-                .map(str::trim)
-                .and_then(|segment| segment.split_whitespace().next())
-                .filter(|value| !value.is_empty())?;
-            Some(pin.to_owned())
+            let start = line.find(SHARED_ACTIONS_MARKER)?;
+            let rest = line.get(start..)?;
+            let token = rest.split_whitespace().next()?;
+            (!token.is_empty()).then(|| token.to_owned())
         })
         .collect()
 }
 
-#[test]
-fn unit_extracts_pins_from_workflow_lines() {
-    let sample = r"
-      - uses: leynos/shared-actions/.github/actions/setup-rust@abc123
-      - uses: leynos/shared-actions/.github/actions/generate-coverage@abc123
-    ";
-
-    let pins = extract_shared_actions_pins(sample);
-
-    assert_eq!(pins, vec!["abc123", "abc123"]);
+/// Returns true when `reference` is `leynos/shared-actions/.github/actions/<name>`
+/// pinned to a full 40-character lowercase-hex commit SHA.
+fn is_pinned_shared_action_ref(reference: &str) -> bool {
+    let Some(rest) = reference.strip_prefix(SHARED_ACTIONS_MARKER) else {
+        return false;
+    };
+    let Some((name, pin)) = rest.split_once('@') else {
+        return false;
+    };
+    !name.is_empty()
+        && pin.len() == 40
+        && pin
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 #[test]
-fn behavioural_shared_actions_pins_are_consistent() -> Result<()> {
+fn unit_extracts_uses_from_workflow_lines() {
+    let sample = r"
+      - uses: leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567
+      - uses: leynos/shared-actions/.github/actions/generate-coverage@0123456789abcdef0123456789abcdef01234567
+    ";
+
+    let uses = extract_shared_actions_uses(sample);
+
+    assert_eq!(
+        uses,
+        vec![
+            "leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567",
+            "leynos/shared-actions/.github/actions/generate-coverage@0123456789abcdef0123456789abcdef01234567",
+        ]
+    );
+}
+
+#[test]
+fn unit_rejects_refs_not_pinned_to_a_commit_sha() {
+    assert!(is_pinned_shared_action_ref(
+        "leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567"
+    ));
+    assert!(!is_pinned_shared_action_ref(
+        "leynos/shared-actions/.github/actions/setup-rust@main"
+    ));
+    assert!(!is_pinned_shared_action_ref(
+        "leynos/shared-actions/.github/actions/setup-rust@0123456789ABCDEF0123456789ABCDEF01234567"
+    ));
+    assert!(!is_pinned_shared_action_ref(
+        "leynos/shared-actions/.github/workflows/mutation-cargo.yml@0123456789abcdef0123456789abcdef01234567"
+    ));
+}
+
+#[test]
+fn behavioural_shared_actions_pins_are_full_commit_shas() -> Result<()> {
     let workflows = fs::read_dir(workflow_dir()).context("workflow directory should exist")?;
-    let mut pins = BTreeSet::new();
+    let mut refs = Vec::new();
 
     for entry in workflows {
         let workflow_entry = entry.context("workflow directory entries should be readable")?;
@@ -60,18 +99,18 @@ fn behavioural_shared_actions_pins_are_consistent() -> Result<()> {
         if path.extension().and_then(|ext| ext.to_str()) != Some("yml") {
             continue;
         }
-        for pin in extract_shared_actions_pins(&read_workflow(&path)?) {
-            pins.insert(pin);
-        }
+        refs.extend(extract_shared_actions_uses(&read_workflow(&path)?));
     }
 
     ensure!(
-        !pins.is_empty(),
-        "expected at least one shared-actions pin in workflows"
+        !refs.is_empty(),
+        "expected at least one shared-actions action reference in workflows"
     );
-    ensure!(
-        pins.len() == 1,
-        "shared-actions pins should be identical across workflows, found {pins:?}"
-    );
+    for reference in &refs {
+        ensure!(
+            is_pinned_shared_action_ref(reference),
+            "shared-actions action reference should be pinned to a 40-hex commit SHA, found {reference:?}"
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Convert the Python `mutation_testing_test.py` contract's exact-SHA
  assertion (`EXPECTED_USES` pinned to a documented `PINNED_SHA`) into a
  shape assertion: the caller must reference
  `mutation-cargo.yml`, pinned to a full 40-character lowercase-hex commit
  SHA, but the specific SHA value is no longer checked.
- Relax the Rust `workflow_shared_actions_pins` test's "all shared-actions
  pins must be identical" invariant. It now asserts each
  `leynos/shared-actions/.github/actions/<name>` reference is pinned to a
  40-character lowercase-hex commit SHA, without requiring every reference
  to share the same value.
- Document the policy in `docs/developers-guide.md` under a new "Workflow
  pins and Dependabot" subsection, so future contract tests follow the same
  shape-not-value pattern.

## Why

Both tests previously hard-coded (or cross-checked) an exact
`leynos/shared-actions` commit SHA. Dependabot bumps one `uses:` reference
at a time, so both shapes broke on the very first bump PR: the Python test
failed until a human edited `PINNED_SHA`, and the Rust test failed the
"all pins identical" check the moment one reference moved and others had
not yet caught up. This PR hands SHA ownership to Dependabot while keeping
every other structural guard (path, hex-and-length format instead of a
branch/tag, triggers, permissions, `with:` inputs, exclude/feature
configuration).

`.github/dependabot.yml` already has a `github-actions` ecosystem entry
covering `directory: "/"` (and `/.github/actions/*`), so no dependabot
configuration change was needed.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: drop `PINNED_SHA`
  and `EXPECTED_USES`; add `EXPECTED_USES_PATH`; rename and rewrite
  `test_uses_reference_is_pinned_to_the_documented_sha` to
  `test_uses_reference_is_pinned_to_a_commit_sha`, asserting path, length,
  and lowercase-hex charset without an equality check against a specific
  SHA. All other assertions (permissions, concurrency, triggers, `with:`
  block) are unchanged.
- `tests/workflow_shared_actions_pins.rs`: replace the `BTreeSet`-based
  "exactly one distinct pin" check with a per-reference shape check
  (`is_pinned_shared_action_ref`) requiring the correct
  `.github/actions/<name>` path and a 40-character lowercase-hex SHA.
  Updated unit tests cover extraction and the accept/reject cases
  (valid SHA, `@main`, uppercase hex, and a workflow-path reference that
  must not match the actions-path shape).
- `docs/developers-guide.md`: new "Workflow pins and Dependabot"
  subsection under "Quality gates", using the canonical policy wording.

## Validation

- `make test-workflow-contracts` (pytest) — 6 passed.
- `cargo test --test workflow_shared_actions_pins` — 3 passed.
- `cargo clippy --all-targets --all-features --tests` — clean (required a
  `line.get(start..)` fix in place of raw string indexing to satisfy
  `clippy::string_slice`).
- `cargo fmt --check` — clean.
- `markdownlint-cli2 docs/developers-guide.md` — 0 errors.
- Reasoned through the regex/shape logic against a hypothetical future
  SHA: both the Python character/length checks and the Rust
  `is_pinned_shared_action_ref` predicate accept any 40-character
  lowercase-hex string on the correct path, so a Dependabot bump to a new
  SHA continues to pass without editing the test.
