### PR TITLE
Enable the CodeScene mode: check coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,16 +104,17 @@ jobs:
           # Compare changed-line coverage against the baseline written by
           # coverage-main.yml (caches saved on main are readable by every PR).
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 69281 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint and chutoro hit the byte-identical error). Add the
-      # check step in a fast-follow PR once coverage-main.yml has
-      # uploaded to main at least once and the gate is confirmed to
-      # resolve, or once CodeScene confirms the project's coverage gate
-      # is enabled.
+      - name: Check coverage against CodeScene gates
+        if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/69281
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
   kani-smoke:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

- Project 69281's coverage-gate configuration is now populated in CodeScene, so `cs-coverage check` no longer errors with "Lacks the gates configuration".
- Replace the deferred-gate comment in `ci.yml`'s stable `build-test` leg with the guarded `mode: check` step, pinned to the same shared-actions SHA (`927edd4`) already used by the job's other steps.
- No other job gains the step (per the recipe, upload from one leg only); `coverage-main.yml` is untouched and stays on `mode: upload`.

## Review walkthrough

- `.github/workflows/ci.yml`: the `Check coverage against CodeScene gates` step runs only when `matrix.rust == 'stable'`, `CS_ACCESS_TOKEN` is set, and the run is a pull request, so non-stable legs and secret-less runs (forks) are unaffected.
- No workflow-contract test in `tests/workflow_contracts/` asserts the coverage-step shape, so none needed updating.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- Confirmed `CS_ACCESS_TOKEN` is present in both the Actions and Dependabot secret stores for this repo.
- Probed `GET /v2/code-coverage/projects/69281/config`: the `gates` array is now populated (was previously the empty 200 that caused the "Lacks the gates configuration" error).
- Awaiting this PR's own CI run to confirm the `Check coverage against CodeScene gates` step executes (not skipped) and passes, and that the `CodeScene Code Coverage` check completes.
