### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       BUILD_PROFILE: debug
       # Override rust-toolchain.toml to actually use the matrix toolchain
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
         with:


### PR DESCRIPTION
This pull request bumps the pinned whitaker-installer version from `0.2.5` to `0.2.6` in the CI workflow. Installer `0.2.5` provisions cargo-dylint `4.1.0`, whose dylint driver cannot be compiled against the Whitaker Dylint suite's new `nightly-2026-05-28` toolchain pin, leaving the repository's CI lint step red. Installer `0.2.6` provisions cargo-dylint `6.0.1`, which compiles cleanly on that nightly, and its prebuilt dependency binaries are now published.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/netsuke/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)

## Test plan

- CI will confirm the lint step is green under the new installer pin.
