### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -93,8 +93,8 @@ continuous integration (CI); `make lint-clippy` runs the Clippy-only subset.
 Whitaker is configured by `dylint.toml` at the repository root. The
 `no_std_fs_operations` lint currently ignores in-source `allow`/`expect`
 attributes, so deliberately ambient filesystem access is confined to the
-`ambient_fs` leaf crate and the `test_support` test-fixture crate, both of
-which `dylint.toml` excludes from that lint with a documented rationale.
+`ambient_fs` leaf crate and the `test_support` test-fixture crate, both of which
+`dylint.toml` excludes from that lint with a documented rationale.
 
 When command output is long, preserve exit codes and logs:
 
@@ -111,15 +111,15 @@ For documentation changes, also run:
 
 ### Workflow pins and Dependabot
 
-Dependabot owns the upgrade of GitHub Actions and reusable workflows,
-including calls into `leynos/shared-actions`. Contract tests that assert a
-caller's exact commit SHA create a lockstep dependency: every time Dependabot
-opens a bump PR, the test fails until a human edits the pinned constant to
-match. That defeats the purpose of automated dependency updates and turns a
-routine bump into a manual chore.
+Dependabot owns the upgrade of GitHub Actions and reusable workflows, including
+calls into `leynos/shared-actions`. Contract tests that assert a caller's exact
+commit SHA create a lockstep dependency: every time Dependabot opens a bump PR,
+the test fails until a human edits the pinned constant to match. That defeats
+the purpose of automated dependency updates and turns a routine bump into a
+manual chore.
 
-Contract tests may still verify the *shape* of a reusable-workflow caller.
-They must not verify the specific SHA value.
+Contract tests may still verify the *shape* of a reusable-workflow caller. They
+must not verify the specific SHA value.
 
 - Do assert the workflow references the correct reusable workflow path.
 - Do assert the ref is pinned to a full 40-character commit SHA, not a
@@ -150,8 +150,8 @@ This repository runs scheduled, informational mutation testing through a thin
 caller workflow,
 [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
 which delegates to the shared reusable workflow
-`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
-lifting — running `cargo-mutants` and summarizing survivors — lives in
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants` and summarizing survivors — lives in
 `shared-actions`; this repository carries only declarative configuration. The
 run is **informational only**: it never gates a pull request. Survivors are
 reported through the job summary and downloadable artefacts so they can be
@@ -160,43 +160,43 @@ triaged into tests, not enforced as a blocking check.
 The workflow runs in two modes. A **daily schedule** (03:05 UTC) fires a
 change-scoped run that mutates only the source files touched within the
 detection window, so quiet days are cheap no-ops. A **manual dispatch** (the
-Actions "Run workflow" control) mutates every target, fanned out across
-shards; select a branch in that control to exercise a feature branch.
+Actions "Run workflow" control) mutates every target, fanned out across shards;
+select a branch in that control to exercise a feature branch.
 
 The caller passes two configuration inputs, each carrying intent:
 
 - `exclude-globs` — `src/ir/cycle_verification.rs`,
   `src/ir/from_manifest_verification.rs`, and `src/ir/graph_kani_map.rs`:
   modules gated behind `#[cfg(kani)]` mod declarations. `cargo-mutants` does
-  not evaluate that cfg, so mutants inserted there would compile to nothing
-  and survive as noise rather than genuine test gaps.
-- `extra-args` — `--all-features`, so the mutation run matches the `make
-  test` CI baseline; a mismatch would report feature-gated code (the
+  not evaluate that cfg, so mutants inserted there would compile to nothing and
+  survive as noise rather than genuine test gaps.
+- `extra-args` — `--all-features`, so the mutation run matches the `make test`
+  CI baseline; a mismatch would report feature-gated code (the
   `legacy-digests` feature) as untested.
 
 The caller does not set `extra-crate-dirs`, the input reserved for crate
 directories outside the Cargo workspace. `ambient_fs`, the repository's
 sanctioned ambient-filesystem escape hatch, is a genuine workspace member
-(`[workspace] members = ["ambient_fs"]`, with `default-members = [".",
-"ambient_fs"]`), not a non-workspace companion crate, so it needs no separate
-mutation invocation here. `test_support` is deliberately excluded from the
-workspace (`exclude = ["test_support"]`) and this workflow does not mutate
-it.
+(`[workspace] members = ["ambient_fs"]`, with
+`default-members = [".", "ambient_fs"]`), not a non-workspace companion crate,
+so it needs no separate mutation invocation here. `test_support` is
+deliberately excluded from the workspace (`exclude = ["test_support"]`) and
+this workflow does not mutate it.
 
 The `uses:` reference pins the shared workflow to a full 40-character commit
 SHA rather than a branch or tag, so a force-push upstream cannot silently
 change what runs here. The contract test asserts only that the pin is a full
 lowercase-hex commit SHA, not a particular value — the shape-only pinning
-policy described above in "Workflow pins and Dependabot" — so Dependabot
-bumps it automatically without any accompanying test edit.
+policy described above in "Workflow pins and Dependabot" — so Dependabot bumps
+it automatically without any accompanying test edit.
 
 Because the caller is configuration rather than code, a contract test,
 [`tests/workflow_contracts/mutation_testing_test.py`](../tests/workflow_contracts/mutation_testing_test.py),
-pins the shape it must uphold, failing the pull request when the caller
-drifts — repointing the pin at a branch, widening the token scope, or
-dropping a configuration input — rather than letting the breakage surface
-only in a scheduled run. Run it locally with `make test-workflow-contracts`.
-The test validates:
+pins the shape it must uphold, failing the pull request when the caller drifts
+— repointing the pin at a branch, widening the token scope, or dropping a
+configuration input — rather than letting the breakage surface only in a
+scheduled run. Run it locally with `make test-workflow-contracts`. The test
+validates:
 
 - the `uses:` reference targets `mutation-cargo.yml` pinned to a full,
   lowercase-hex commit SHA;
@@ -214,8 +214,8 @@ The test validates:
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the
 repository's Markdown prose with [`typos`](https://github.com/crate-ci/typos),
 as required by the [documentation style guide](documentation-style-guide.md).
-The repository-root `typos.toml` is deterministically generated output assembled
-from two policy layers:
+The repository-root `typos.toml` is deterministically generated output
+assembled from two policy layers:
 
 1. The shared estate dictionary in `leynos/agent-helper-scripts` supplies
    generally valid Oxford forms, accepted technical terms, corrections, and
@@ -908,8 +908,8 @@ Versioning and compatibility rules:
 
 ## BDD command helpers and environment handling
 
-The BDD step module `tests/bdd/steps/manifest_command_helpers.rs` provides three
-helpers that launch the netsuke binary in a controlled environment:
+The BDD step module `tests/bdd/steps/manifest_command_helpers.rs` provides
+three helpers that launch the netsuke binary in a controlled environment:
 
 - **`netsuke_executable()`** — locates the compiled netsuke binary using
   `assert_cmd::cargo::cargo_bin!("netsuke")`. Returns the resolved `PathBuf` or

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -210,6 +210,17 @@ validates:
 - the triggers keep the daily schedule and a plain `workflow_dispatch` with
   no legacy branch input.
 
+Before merging this mutation-testing workflow documentation change, follow the
+authoritative [Quality gates](#quality-gates) guidance and record the output of
+every command in this completion checklist:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test`
+
 ## Spelling enforcement
 
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -92,9 +92,10 @@ the standalone installer described in the
 continuous integration (CI); `make lint-clippy` runs the Clippy-only subset.
 Whitaker is configured by `dylint.toml` at the repository root. The
 `no_std_fs_operations` lint currently ignores in-source `allow`/`expect`
-attributes, so deliberately ambient filesystem access is confined to the
-`ambient_fs` leaf crate and the `test_support` test-fixture crate, both of which
-`dylint.toml` excludes from that lint with a documented rationale.
+attributes, so `dylint.toml` excludes each sanctioned ambient-filesystem scope
+with a documented rationale: the `build_script_build` Cargo build-script crate,
+the `ambient_fs` application leaf crate, the `test_support` test-fixture crate,
+and the enumerated integration-test and workflow-contract crates.
 
 When command output is long, preserve exit codes and logs:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -144,6 +144,71 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants` and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** (03:05 UTC) fires a
+change-scoped run that mutates only the source files touched within the
+detection window, so quiet days are cheap no-ops. A **manual dispatch** (the
+Actions "Run workflow" control) mutates every target, fanned out across
+shards; select a branch in that control to exercise a feature branch.
+
+The caller passes two configuration inputs, each carrying intent:
+
+- `exclude-globs` — `src/ir/cycle_verification.rs`,
+  `src/ir/from_manifest_verification.rs`, and `src/ir/graph_kani_map.rs`:
+  modules gated behind `#[cfg(kani)]` mod declarations. `cargo-mutants` does
+  not evaluate that cfg, so mutants inserted there would compile to nothing
+  and survive as noise rather than genuine test gaps.
+- `extra-args` — `--all-features`, so the mutation run matches the `make
+  test` CI baseline; a mismatch would report feature-gated code (the
+  `legacy-digests` feature) as untested.
+
+The caller does not set `extra-crate-dirs`, the input reserved for crate
+directories outside the Cargo workspace. `ambient_fs`, the repository's
+sanctioned ambient-filesystem escape hatch, is a genuine workspace member
+(`[workspace] members = ["ambient_fs"]`, with `default-members = [".",
+"ambient_fs"]`), not a non-workspace companion crate, so it needs no separate
+mutation invocation here. `test_support` is deliberately excluded from the
+workspace (`exclude = ["test_support"]`) and this workflow does not mutate
+it.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+lowercase-hex commit SHA, not a particular value — the shape-only pinning
+policy described above in "Workflow pins and Dependabot" — so Dependabot
+bumps it automatically without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test,
+[`tests/workflow_contracts/mutation_testing_test.py`](../tests/workflow_contracts/mutation_testing_test.py),
+pins the shape it must uphold, failing the pull request when the caller
+drifts — repointing the pin at a branch, widening the token scope, or
+dropping a configuration input — rather than letting the breakage surface
+only in a scheduled run. Run it locally with `make test-workflow-contracts`.
+The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full,
+  lowercase-hex commit SHA;
+- the `with:` block carries exactly the expected configuration (the
+  `#[cfg(kani)]` module excludes and `--all-features`);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.
+
 ## Spelling enforcement
 
 `make markdownlint` enforces en-GB-oxendict (Oxford) spelling over the


### PR DESCRIPTION
## Summary

- Add a `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, placed immediately after the existing
  `### Workflow pins and Dependabot` subsection (the general shape-only
  pinning policy this contract test follows). No mutation-testing-specific
  section already existed, so this is a new top-level section rather than a
  merge into one.
- Documents `.github/workflows/mutation-testing.yml`, the thin caller that
  delegates to `leynos/shared-actions/.github/workflows/mutation-cargo.yml`,
  and its contract test,
  `tests/workflow_contracts/mutation_testing_test.py`.

## Findings reconciled against the repo

- **Contract-test style**: shape-only. The test asserts the `uses:` ref is
  the correct path pinned to a 40-character lowercase-hex commit SHA (no
  hard-coded `PINNED_SHA` constant), so Dependabot bumps freely with no
  test edit required. There is no `pytestmark = skipif(...)` guard — this
  is a Rust repo, so the test isn't run inside a mutmut sandbox that omits
  `.github/`.
- **`with:` inputs actually present**: only `exclude-globs` (the three
  `#[cfg(kani)]`-gated modules under `src/ir/`, which `cargo-mutants`
  cannot evaluate and would otherwise report as noisy survivors) and
  `extra-args: --all-features` (matching the `make test` CI baseline).
  `paths` is not set (uses the shared workflow's default).
- **`extra-crate-dirs` is *not* set**, and I deliberately did not document
  it as if it were. I re-read `Cargo.toml`'s `[workspace]` block:
  `ambient_fs` is a genuine workspace member (`members = ["ambient_fs"]`,
  `default-members = [".", "ambient_fs"]`), not a non-workspace companion
  crate — `extra-crate-dirs` is reserved (per
  `shared-actions/docs/mutation-cargo-workflow.md`) for crate directories
  *outside* the workspace, so it doesn't apply here. `test_support` is
  excluded from the workspace (`exclude = ["test_support"]`) and this
  workflow does not mutate it. This is a deviation from the "companion
  crate via extra-crate-dirs" framing I was initially briefed with; the
  section documents the repo's real configuration instead.
- **Local command**: `make test-workflow-contracts` (exists in the
  `Makefile`; runs
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q`).
  Ran it locally: 6 passed.
- **Roadmap/execplan**: no roadmap or execplan tracking applies. I checked
  `docs/roadmap.md` and `docs/execplans/`; the only "mutation" hits in the
  roadmap concern OrthoConfig's non-interactive/mutation-safety metadata
  and an unrelated `--dry-run` preview item, not this workflow.
- **TOC cross-link**: not applicable. `docs/developers-guide.md` has no
  table of contents or index list to link into; the guide is a flat
  sequence of `##`/`###` sections.

## Docs-lint result

`make markdownlint` (spelling/typos + `markdownlint-cli2`): passed after
fixing two spelling misses the linter caught in my first draft
(`summarising` → `summarizing`, `serialises` → `serializes` — this repo's
`typos.toml` enforces Oxford `-ize` spelling, consistent with
`analyse`/`behaviour` staying as-is elsewhere in the same paragraph). Final
run: 0 errors.

Per instructions, only the docs/markdown gates were run — not `make test`
or `make lint`.

## File changed

- [`docs/developers-guide.md`](../../blob/docs/mutation-contract-tests/docs/developers-guide.md)

## Latest review validation

- `make fmt`: passed.
- `make markdownlint`: passed (34 checks, 0 Markdown errors).
- `make nixie`: passed (all Mermaid diagrams valid).

## References

- https://lody.ai/leynos/sessions/98f58671-0ba4-410a-94b8-b4613bf6e990