### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -88,7 +88,7 @@ jobs:
           cargo-orthohelp --version | grep '0\.8\.0'
 
       - name: Build release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/rust-build-release@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ env.BIN_NAME }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Stage artefacts
         id: stage
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           config-file: .github/release-staging.toml
           target: ${{ inputs['stage-target'] }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Package Linux artefacts with dependencies
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/linux-packages@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           project-dir: .
           package-name: ${{ inputs['bin-name'] }}
@@ -151,7 +151,7 @@ jobs:
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
-        uses: leynos/shared-actions/.github/actions/windows-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/windows-package@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           product-name: ${{ inputs['bin-name'] }}
           manufacturer: Leynos
@@ -169,7 +169,7 @@ jobs:
       - name: Build macOS installer package
         if: inputs.platform == 'macos'
         id: package_macos
-        uses: leynos/shared-actions/.github/actions/macos-package@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/macos-package@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           name: ${{ inputs['bin-name'] }}
           identifier: com.leynos.${{ inputs['bin-name'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           # the pull request's merge base once the gate is wired in.
           fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -97,7 +97,7 @@ jobs:
         run: make test
       - name: Test and Measure Coverage
         if: matrix.rust == 'stable'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: lcov.info
           format: lcov
@@ -108,7 +108,7 @@ jobs:
         if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           mode: check
@@ -131,7 +131,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
       - name: Install uv

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: stable
           components: rustfmt, clippy
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: lcov.info
           format: lcov
@@ -36,7 +36,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       # test_support is deliberately omitted from extra crates: it is a
       # test-fixture crate whose survivors are noise.

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633  # v4.1.2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           toolchain: ${{ matrix.rust }}
       - name: Show rustc version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+          leynos/shared-actions/.github/actions/determine-release-modes@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+          leynos/shared-actions/.github/actions/ensure-cargo-version@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs['should-publish']) }}
       - id: wix_extension_version
@@ -107,7 +107,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+          leynos/shared-actions/.github/actions/export-cargo-metadata@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -239,7 +239,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+          leynos/shared-actions/.github/actions/upload-release-assets@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}


### PR DESCRIPTION
## Summary
Bumps every `leynos/shared-actions` workflow and action reference to
`18bed1ca49a6de3d8882bd72635a32ae3f023d57` (current upstream main at
the time of the estate sweep).

This picks up the coverage-ratchet fix from shared-actions#353: the
baseline can now advance (cache save-key fix) and a symmetric ±1pp
dead-band absorbs coverage measurement noise. It also carries the
whitaker-installer 0.2.6 bump and the mutation-run workspace
relocation.

## Review walkthrough
Mechanical SHA substitution in `.github/workflows/` only. References
already at or beyond the fix commit are left untouched. Dependabot
retains ownership of future bumps; contract tests assert shape (path @
40-hex SHA), not the value.

## Validation
CI on this pull request exercises the bumped references directly.

## Summary by Sourcery

Align GitHub Actions workflows with the latest leynos/shared-actions revision for build, release, coverage, mutation testing, and Dependabot automerge automation.

Bug Fixes:
- Update shared-actions coverage workflows to pick up latest coverage baseline and noise-handling fixes.

Build:
- Update all leynos/shared-actions action references in build and release workflows to the latest pinned SHA.

CI:
- Update CI workflows, including coverage, mutation testing, and Dependabot automerge, to use the latest leynos/shared-actions pinned SHA.