### PR TITLE
Document the template standard library (#443)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ cat hello.txt
 ```
 
 The second command prints `Hello from Netsuke!`. See the
-[quick-start guide](docs/quickstart.md) for variables, templates, and `foreach`.
+[quick-start guide](docs/quickstart.md) for variables, templates, and
+`foreach`, then use the
+[template standard-library guide]( docs/stdlib-yaml-and-jinja-guide.md) for
+every path, collection, filesystem, time, command, environment, glob, and
+network helper.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cat hello.txt
 The second command prints `Hello from Netsuke!`. See the
 [quick-start guide](docs/quickstart.md) for variables, templates, and
 `foreach`, then use the
-[template standard-library guide]( docs/stdlib-yaml-and-jinja-guide.md) for
+[template standard-library guide](docs/stdlib-yaml-and-jinja-guide.md) for
 every path, collection, filesystem, time, command, environment, glob, and
 network helper.
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -49,6 +49,8 @@ operator, user, and contributor references are easier to find.
 - [users-guide.md](users-guide.md): End-user reference for authoring and
   running Netsuke manifests, including executable discovery and
   `command_available` branch selection.
+- [stdlib-yaml-and-jinja-guide.md](stdlib-yaml-and-jinja-guide.md): Complete
+  template standard-library reference with executable YAML and Jinja examples.
 - [ortho-config-users-guide.md](ortho-config-users-guide.md): Configuration
   system guide and precedence reference.
 - [translators-guide.md](translators-guide.md): Localization workflow and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -470,8 +470,9 @@ the configured Dependabot directory patterns.
 
 ### User-facing documentation examples
 
-Every fenced example in `README.md` and `docs/users-guide.md` has a stable
-`tested-example` marker immediately before its opening fence. The shared
+Every fenced example in `README.md`, `docs/users-guide.md`, and
+`docs/stdlib-yaml-and-jinja-guide.md` has a stable `tested-example` marker
+immediately before its opening fence. The shared
 `tests/documentation_examples/mod.rs` loader owns this marker format and may be
 called only by documentation-focused integration or behavioural tests. It
 rejects unmarked fences, duplicate identifiers and unterminated examples.
@@ -481,9 +482,12 @@ Ninja for every manifest fence and each complete manifest linked from the
 user's guide, and checks selected command and output contracts against the
 current binary. On Unix, `tests/documentation_examples_e2e_tests.rs` uses real
 Ninja to execute the documented first-run build and `cat hello.txt`, exercise
-the configured default target, and verify the photo-edit and writing outputs.
-`tests/documentation_examples_loader_tests.rs` covers concrete malformed-fence
-and non-YAML failure cases.
+the configured default target, verify the photo-edit and writing outputs, and
+run the standard-library manifests in isolated workspaces with controlled
+fixtures, environment variables, and stub executables. The registered `fetch`
+expression is intentionally checked without execution so this suite never makes
+a network request. `tests/documentation_examples_loader_tests.rs` covers
+concrete malformed-fence and non-YAML failure cases.
 
 The first-run README and user's guide examples also run through the
 `rstest-bdd` scenarios in `tests/features/documentation_examples.feature`.

--- a/docs/stdlib-yaml-and-jinja-guide.md
+++ b/docs/stdlib-yaml-and-jinja-guide.md
@@ -5,6 +5,84 @@ time, commands, executable discovery, environment variables, and globbing.
 These helpers run while Netsuke expands a `Netsukefile`, before Ninja runs the
 generated build graph.
 
+## Read YAML in a `Netsukefile`
+
+A `Netsukefile` is a YAML mapping. Write `key: value` for a field, indent
+nested content with spaces rather than tabs, and introduce each list item with
+`-`. Netsuke rejects duplicate keys, unknown fields, and missing required
+fields. The top-level `netsuke_version` and `targets` fields are required.
+
+Quote version numbers and strings containing Jinja. In particular, quote a
+value beginning with `{{` because an unquoted `{` has meaning in YAML. Use `|`
+for a multi-line string that preserves line breaks, or `>-` to fold lines into
+one string and remove the final newline. This example shows mappings, a list,
+quoted template text, and a folded command:
+
+<!-- tested-example: stdlib-yaml-syntax-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+vars:
+  greeting: Hello
+  recipients:
+    - Netsuke
+    - Ninja
+
+targets:
+  - name: greeting.txt
+    command: >-
+      printf '%s\n'
+      "{{ greeting }}, {{ recipients | first }}!"
+      > {{ outs }}
+
+defaults:
+  - greeting.txt
+```
+
+See the [yaml.info YAML tutorial](https://www.yaml.info/learn/index.html) for a
+deeper introduction to mappings, sequences, scalars, quoting, and block style.
+
+## Read Jinja inside YAML
+
+Netsuke uses MiniJinja to render string fields. Put an expression inside
+`{{ ... }}`, read values declared under `vars` by name, pass a value through a
+filter with `|`, call a function with parentheses, and apply a test with `is`.
+Undefined values are errors. Apart from `{{ ins }}` and `{{ outs }}`, rendered
+values are not automatically quoted for the host shell.
+
+The manifest control keys are deliberately different: `foreach` and `when` take
+direct Jinja expressions without `{{ ... }}`. Structural Jinja statements such
+as `{% for ... %}` cannot reshape the YAML document; use those control keys or
+Netsuke's declared macros instead.
+
+<!-- tested-example: stdlib-jinja-syntax-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+vars:
+  artifact: report.tmp
+  labels:
+    - alpha
+    - alpha
+    - beta
+
+targets:
+  - name: "{{ artifact | with_suffix('.txt') }}"
+    when: labels | length > 0
+    command: "printf '%s\n' '{{ labels | uniq | join(',') }}' > {{ outs }}"
+
+defaults:
+  - report.txt
+```
+
+The [Jinja introduction and variable-substitution tutorial][jinja-tutorial]
+provides a more detailed introduction. It describes Jinja2, so remember that
+Netsuke exposes MiniJinja plus Netsuke-specific manifest control keys.
+
+[jinja-tutorial]: https://ttl255.com/jinja2-tutorial-part-1-introduction-and-variable-substitution/
+
 Use host-observing helpers only in trusted manifests. Netsuke bounds output
 from network and command helpers, but it does not sandbox template evaluation.
 

--- a/docs/stdlib-yaml-and-jinja-guide.md
+++ b/docs/stdlib-yaml-and-jinja-guide.md
@@ -168,11 +168,10 @@ defaults:
   With no offset it uses UTC; `offset` accepts `Z` or a signed offset such as
   `+02:00`. The value exposes `iso8601`, `unix_timestamp`, and `offset`.
   Example: `{{ now(offset='+02:00').iso8601 }}`.
-- `timedelta([weeks=VALUE], [days=VALUE], [hours=VALUE], [minutes=VALUE],
-  [seconds=VALUE], [milliseconds=VALUE], [microseconds=VALUE],
-  [nanoseconds=VALUE])`
-  is pure. All components default to zero and may be negative. The result
-  exposes `iso8601`, whole `seconds`, and subsecond `nanoseconds`. Example:
+- `timedelta(**components)` is pure. It accepts `weeks`, `days`, `hours`,
+  `minutes`, `seconds`, `milliseconds`, `microseconds`, and `nanoseconds`.
+  Every component defaults to zero and may be negative. The result exposes
+  `iso8601`, whole `seconds`, and subsecond `nanoseconds`. Example:
   `{{ timedelta(days=1, minutes=30).iso8601 }}`.
 
 These helpers represent values during template expansion; they do not delay or

--- a/docs/stdlib-yaml-and-jinja-guide.md
+++ b/docs/stdlib-yaml-and-jinja-guide.md
@@ -113,8 +113,10 @@ split the same input identically.
   For example, `{{ 'reports/daily.csv' | relative_to('reports') }}` produces
   `daily.csv`.
 - `path | realpath` is host-observing. It canonicalizes an existing path,
-  resolving links, and fails when the path cannot be resolved. Relative input
-  remains workspace-relative; absolute input stays absolute. For example,
+  resolving links, and fails when the path cannot be resolved. The result may
+  be relative or absolute: `.` produces the canonical absolute workspace path,
+  and a relative link may resolve to an absolute target. Do not rely on the
+  input's relativity being preserved. For example,
   `{{ 'input-link' | realpath }}`.
 - `path | expanduser` is host-observing because it reads the home-directory
   environment. It expands `~` and `~/...`; named-user forms such as `~alice`
@@ -277,13 +279,17 @@ defaults:
 These helpers observe the host and should appear only in trusted manifests.
 
 - `value | shell(command[, options])` sends `value` to a host shell command's
-  standard input and returns standard output. Capture mode is the default. Pass
-  `{'mode': 'tempfile'}` (also spelled `stream` or `streaming`) for bounded
-  tempfile-backed output. Example: `{{ 'hello' | shell('uppercase') | trim }}`.
+  standard input. Capture mode is the default and returns the command's
+  standard output. Pass `{'mode': 'tempfile'}` (also spelled `stream` or
+  `streaming`) to write bounded output to a persisted temporary file; these
+  modes return the temporary file's path, not its contents. Example:
+  `{{ 'hello' | shell('uppercase') | trim }}`.
 - `value | grep(pattern[, flags[, options]])` runs the host `grep` executable
   over `value`. `flags` is a sequence such as `['-i']`; options have the same
-  modes as `shell`. Availability and flag spelling are platform-dependent.
-  Example: `{{ 'alpha\nbeta\n' | grep('beta') | trim }}`.
+  modes and return values as `shell`, including a persisted temporary-file path
+  in `tempfile`, `stream`, or `streaming` mode. Availability and flag spelling
+  are platform-dependent. Example:
+  `{{ 'alpha\nbeta\n' | grep('beta') | trim }}`.
 - `which(name, **options)` and `name | which(**options)` search for an
   executable and fail when none is found. Boolean options `all`, `canonical`,
   and `fresh` default to `false`; `cwd_mode` defaults to `auto` and also accepts

--- a/docs/stdlib-yaml-and-jinja-guide.md
+++ b/docs/stdlib-yaml-and-jinja-guide.md
@@ -1,0 +1,274 @@
+# Template standard library for YAML and Jinja
+
+Netsuke extends MiniJinja with helpers for paths, collections, host files,
+time, commands, executable discovery, environment variables, and globbing.
+These helpers run while Netsuke expands a `Netsukefile`, before Ninja runs the
+generated build graph.
+
+Use host-observing helpers only in trusted manifests. Netsuke bounds output
+from network and command helpers, but it does not sandbox template evaluation.
+
+## Read the signatures
+
+Signatures below use `value | filter(arguments)` for filters,
+`function(arguments)` for functions, and `value is test` for Jinja tests.
+Arguments in square brackets are optional. “Pure” means the result depends only
+on the supplied value and arguments. “Host-observing” helpers read the clock,
+environment, filesystem, network, or subprocess state; `fetch` with a cache may
+also write beneath Netsuke's cache directory.
+
+## Transform paths
+
+Path filters accept UTF-8 strings and return UTF-8 strings. Path parsing uses
+the host platform's separator rules, so do not assume that Windows and Unix
+split the same input identically.
+
+- `path | basename` is pure and returns the final path component. For example,
+  `{{ 'reports/daily.csv' | basename }}` produces `daily.csv`.
+- `path | dirname` is pure and returns the parent, using `.` when the path has
+  no explicit parent. For example, `{{ 'reports/daily.csv' | dirname }}`
+  produces `reports`.
+- `path | with_suffix(suffix[, count[, separator]])` is pure. `count` defaults
+  to `1`, and `separator` defaults to `.`. For example,
+  `{{ 'archive.tar.gz' | with_suffix('.zip', 2) }}` produces `archive.zip`.
+- `path | relative_to(root)` is pure and requires `path` to be beneath `root`.
+  For example, `{{ 'reports/daily.csv' | relative_to('reports') }}` produces
+  `daily.csv`.
+- `path | realpath` is host-observing. It canonicalizes an existing path,
+  resolving links, and fails when the path cannot be resolved. Relative input
+  remains workspace-relative; absolute input stays absolute. For example,
+  `{{ 'input-link' | realpath }}`.
+- `path | expanduser` is host-observing because it reads the home-directory
+  environment. It expands `~` and `~/...`; named-user forms such as `~alice`
+  are unsupported. For example, `{{ '~/cache' | expanduser }}`.
+
+## Read and identify files
+
+These filters inspect the host filesystem and fail when their input cannot be
+read. Relative paths are resolved from the workspace in which Netsuke runs.
+
+- `path | contents([encoding])` returns file text. The default is `utf-8`;
+  `utf8` is accepted as an alias, and no other encoding is currently supported.
+  Example: `{{ 'fixtures/message.txt' | contents }}`.
+- `path | size` returns the file length in bytes. Example:
+  `{{ 'fixtures/message.txt' | size }}`.
+- `path | linecount` counts text lines using Rust's line semantics. Example:
+  `{{ 'fixtures/message.txt' | linecount }}`.
+- `path | hash([algorithm])` returns the full hexadecimal digest. The default
+  is `sha256`; `sha512` is also available. Example:
+  `{{ 'fixtures/message.txt' | hash('sha512') }}`.
+- `path | digest([length[, algorithm]])` returns a prefix of the hash. Length
+  defaults to `8` and the algorithm defaults to `sha256`. Example:
+  `{{ 'fixtures/message.txt' | digest(12, 'sha512') }}`.
+
+MD5 and SHA-1 are available only in builds compiled with Cargo feature
+`legacy-digests`. Without that feature, `hash('md5')`, `hash('sha1')`, and their
+`digest` equivalents fail with a feature-specific diagnostic. New manifests
+should use SHA-256 or SHA-512.
+
+## Transform collections
+
+Collection filters are pure and preserve input order.
+
+- `values | uniq` removes later duplicate values. Example:
+  `{{ ['alpha', 'alpha', 'beta'] | uniq | join(',') }}` produces `alpha,beta`.
+- `values | flatten` recursively flattens nested sequences and rejects scalar
+  members. Example: `{{ [[1, 2], [3]] | flatten | join(',') }}` produces
+  `1,2,3`.
+- `values | group_by(attribute)` groups objects by an attribute while
+  preserving first-seen key order. Missing attributes are errors. Example:
+  `{{ ([{'kind': 'tool'}, {'kind': 'tool'}] | group_by('kind')).tool | length }}`
+  produces `2`.
+
+The following complete manifest exercises every path and collection filter. Its
+filesystem inputs are created by the documentation test before Netsuke is run.
+
+<!-- tested-example: stdlib-path-and-collection-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+vars:
+  records:
+    - kind: tool
+    - kind: tool
+    - kind: input
+
+targets:
+  - name: stdlib-paths.txt
+    command: >-
+      printf '%s\n'
+      "{{ 'fixtures/report.tmp' | basename }}"
+      "{{ 'fixtures/report.tmp' | dirname }}"
+      "{{ 'fixtures/report.tmp' | with_suffix('.txt') }}"
+      "{{ 'fixtures/report.tmp' | relative_to('fixtures') }}"
+      "{{ 'fixtures/message-link' | realpath }}"
+      "{{ '~/notes.txt' | expanduser }}"
+      "{{ 'fixtures/message.txt' | contents }}"
+      "{{ 'fixtures/message.txt' | size }}"
+      "{{ 'fixtures/message.txt' | linecount }}"
+      "{{ 'fixtures/message.txt' | hash }}"
+      "{{ 'fixtures/message.txt' | digest }}"
+      "{{ ['alpha', 'alpha', 'beta'] | uniq | join(',') }}"
+      "{{ [[1, 2], [3]] | flatten | join(',') }}"
+      "{{ (records | group_by('kind')).tool | length }}"
+      > {{ outs }}
+
+defaults:
+  - stdlib-paths.txt
+```
+
+## Test file types
+
+File tests are host-observing and have signature `path is test`. A missing path
+or a non-string value yields `false`; an inspection error is reported.
+
+- `path is file` identifies regular files: `{{ 'input.txt' is file }}`.
+- `path is dir` identifies directories: `{{ 'fixtures' is dir }}`.
+- `path is symlink` identifies symbolic links without following them:
+  `{{ 'input-link' is symlink }}`.
+- `path is pipe` identifies named pipes on Unix:
+  `{{ 'events.pipe' is pipe }}`.
+- `path is block_device` identifies Unix block devices:
+  `{{ '/dev/loop0' is block_device }}`.
+- `path is char_device` identifies Unix character devices:
+  `{{ '/dev/null' is char_device }}`.
+- `path is device` identifies either block or character devices on Unix:
+  `{{ '/dev/null' is device }}`.
+
+The four special-file tests (`pipe`, `block_device`, `char_device`, and
+`device`) always return `false` on non-Unix platforms. The runnable example
+therefore demonstrates the portable tests and the Unix behaviour separately.
+
+<!-- tested-example: stdlib-file-tests-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+targets:
+  - name: stdlib-file-tests.txt
+    command: >-
+      printf '%s\n'
+      "{{ 'fixtures/message.txt' is file }}"
+      "{{ 'fixtures' is dir }}"
+      "{{ 'fixtures/message-link' is symlink }}"
+      "{{ 'fixtures/events.pipe' is pipe }}"
+      "{{ 'fixtures/message.txt' is block_device }}"
+      "{{ '/dev/null' is char_device }}"
+      "{{ '/dev/null' is device }}"
+      > {{ outs }}
+
+defaults:
+  - stdlib-file-tests.txt
+```
+
+## Work with time
+
+- `now([offset=...])` is host-observing and returns the current timestamp.
+  With no offset it uses UTC; `offset` accepts `Z` or a signed offset such as
+  `+02:00`. The value exposes `iso8601`, `unix_timestamp`, and `offset`.
+  Example: `{{ now(offset='+02:00').iso8601 }}`.
+- `timedelta([weeks=VALUE], [days=VALUE], [hours=VALUE], [minutes=VALUE],
+  [seconds=VALUE], [milliseconds=VALUE], [microseconds=VALUE],
+  [nanoseconds=VALUE])`
+  is pure. All components default to zero and may be negative. The result
+  exposes `iso8601`, whole `seconds`, and subsecond `nanoseconds`. Example:
+  `{{ timedelta(days=1, minutes=30).iso8601 }}`.
+
+These helpers represent values during template expansion; they do not delay or
+schedule build work.
+
+<!-- tested-example: stdlib-time-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+targets:
+  - name: stdlib-time.txt
+    command: >-
+      printf '%s\n'
+      "{{ now(offset='+02:00').iso8601 }}"
+      "{{ timedelta(days=1, hours=2, minutes=30).iso8601 }}"
+      > {{ outs }}
+
+defaults:
+  - stdlib-time.txt
+```
+
+## Run commands and inspect the host
+
+These helpers observe the host and should appear only in trusted manifests.
+
+- `value | shell(command[, options])` sends `value` to a host shell command's
+  standard input and returns standard output. Capture mode is the default. Pass
+  `{'mode': 'tempfile'}` (also spelled `stream` or `streaming`) for bounded
+  tempfile-backed output. Example: `{{ 'hello' | shell('uppercase') | trim }}`.
+- `value | grep(pattern[, flags[, options]])` runs the host `grep` executable
+  over `value`. `flags` is a sequence such as `['-i']`; options have the same
+  modes as `shell`. Availability and flag spelling are platform-dependent.
+  Example: `{{ 'alpha\nbeta\n' | grep('beta') | trim }}`.
+- `which(name, **options)` and `name | which(**options)` search for an
+  executable and fail when none is found. Boolean options `all`, `canonical`,
+  and `fresh` default to `false`; `cwd_mode` defaults to `auto` and also accepts
+  `always` or `never`. With `all=true`, the result is a list. Example:
+  `{{ which('guide-tool', canonical=true) }}`.
+- `command_available(name, **options)` accepts the same options as `which` but
+  returns `true` or `false` for ordinary misses. Example:
+  `{{ command_available('guide-tool', cwd_mode='never') }}`.
+- `env(name)` returns one required Unicode environment variable. There is no
+  default-value argument; a missing or non-Unicode value is an error. Example:
+  `{{ env('NETSUKE_STDLIB_TOKEN') }}`.
+- `glob(pattern)` returns matching workspace paths. It is host-observing;
+  matches and separator syntax depend on workspace contents and platform.
+  Example: `{{ glob('fixtures/*.txt') | join(',') }}`.
+
+The executable example uses stub commands and a controlled `PATH`, environment
+variable, and fixture directory, so it never depends on developer-installed
+tools.
+
+<!-- tested-example: stdlib-host-context-manifest -->
+
+```yaml
+netsuke_version: "1.0.0"
+
+targets:
+  - name: stdlib-host-context.txt
+    command: >-
+      printf '%s\n'
+      "{{ 'hello' | shell('uppercase') | trim }}"
+      "{{ 'alpha\nbeta\n' | grep('beta') | trim }}"
+      "{{ which('guide-tool') }}"
+      "{{ command_available('guide-tool', cwd_mode='never') }}"
+      "{{ env('NETSUKE_STDLIB_TOKEN') }}"
+      "{{ glob('fixtures/*.txt') | join(',') }}"
+      > {{ outs }}
+
+defaults:
+  - stdlib-host-context.txt
+```
+
+## Fetch network content
+
+`fetch(url[, cache=false])` is host-observing and retrieves a URL, returning
+text for UTF-8 responses and bytes otherwise. HTTPS is the only allowed scheme
+by default. `cache=true` enables the on-disk response cache. Network policy can
+be narrowed or extended with Netsuke's `--fetch-*` options; see
+[Configure network access](users-guide.md#configure-network-access).
+
+The expression below is registry-tested for documentation drift but
+deliberately not executed by the test suite: documentation tests must not make
+network requests. Use a stable, policy-approved URL in a trusted manifest.
+
+<!-- tested-example: stdlib-fetch-expression -->
+
+```jinja
+{{ fetch('https://example.com/toolchain.json', cache=true) }}
+```
+
+## Choose pure planning where practical
+
+Pure helpers make generated build graphs reproducible. Host-observing helpers
+are useful for discovery and conditional planning, but their results can vary
+between machines or invocations. Prefer explicit manifest inputs when a value
+is part of the build's reproducibility contract, and keep network or command
+execution out of untrusted `Netsukefile` content.

--- a/docs/stdlib-yaml-and-jinja-guide.md
+++ b/docs/stdlib-yaml-and-jinja-guide.md
@@ -52,9 +52,12 @@ Undefined values are errors. Apart from `{{ ins }}` and `{{ outs }}`, rendered
 values are not automatically quoted for the host shell.
 
 The manifest control keys are deliberately different: `foreach` and `when` take
-direct Jinja expressions without `{{ ... }}`. Structural Jinja statements such
-as `{% for ... %}` cannot reshape the YAML document; use those control keys or
-Netsuke's declared macros instead.
+direct Jinja expressions without `{{ ... }}`. Netsuke evaluates them before
+typed AST deserialization, IR generation, and Ninja execution. They select
+manifest entries rather than branch at build time; put build-time branching in
+recipe commands or scripts unless a separate feature explicitly models runtime
+conditions. Structural Jinja statements such as `{% for ... %}` cannot reshape
+the YAML document; use those control keys or Netsuke's declared macros instead.
 
 <!-- tested-example: stdlib-jinja-syntax-manifest -->
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -292,85 +292,14 @@ not accept a default argument; an absent or non-Unicode value is an error.
 ## Use the template standard library
 
 Netsuke registers focused path, collection, command, network, and time helpers
-alongside MiniJinja's built-ins.
+alongside MiniJinja's built-ins. The library covers path and collection
+filters, file tests, clocks and durations, host commands, executable discovery,
+environment variables, globbing, and policy-controlled network retrieval.
 
-### Path filters
-
-The path filters are:
-
-- `basename`
-- `dirname`
-- `with_suffix(suffix[, count[, separator]])`
-- `relative_to(root)`
-- `realpath`
-- `expanduser`
-- `contents([encoding])`
-- `size`
-- `linecount`
-- `hash([algorithm])`
-- `digest([length[, algorithm]])`
-
-`with_suffix` defaults to replacing one dot-separated suffix. `contents`
-defaults to UTF-8, `hash` defaults to SHA-256, and `digest` defaults to the
-first eight characters of a SHA-256 digest. Hashing supports SHA-256 and
-SHA-512. MD5 and SHA-1 require the `legacy-digests` Cargo feature.
-
-### Collection filters
-
-Netsuke adds `uniq`, `flatten`, and `group_by(attribute)`. MiniJinja also
-provides general filters such as `join`, `map`, `select`, and `sort`.
-
-This complete manifest exercises string-only helpers without depending on
-external files:
-
-<!-- tested-example: guide-stdlib-manifest -->
-
-```yaml
-netsuke_version: "1.0.0"
-
-vars:
-  names:
-    - alpha
-    - alpha
-    - beta
-
-targets:
-  - name: "{{ 'report.tmp' | with_suffix('.txt') }}"
-    command: "echo {{ names | uniq | join(',') }} > {{ outs }}"
-
-defaults:
-  - report.txt
-```
-
-### File tests
-
-Jinja `is` expressions can test `file`, `dir`, `symlink`, `pipe`,
-`block_device`, `char_device`, and `device`. Filesystem tests inspect the host,
-so results depend on the current workspace and platform.
-
-### Time helpers
-
-`now(offset=...)` returns the current timestamp, optionally at an offset such as
-`"+01:00"`. `timedelta(...)` constructs a duration from keyword components:
-weeks, days, hours, minutes, seconds, milliseconds, microseconds, and
-nanoseconds. These helpers read the clock or perform duration arithmetic; they
-do not schedule work.
-
-### Impure helpers
-
-The following helpers can observe or modify the outside world:
-
-- `fetch(url, cache=false)` retrieves a URL. HTTPS is the only allowed scheme
-  by default.
-- `value | shell(command, options)` sends a value to a host shell command.
-- `value | grep(pattern, flags, options)` filters lines through `grep`.
-- `now(offset=...)` reads the clock.
-- File-reading and path-canonicalization filters inspect the filesystem.
-
-`fetch`, `shell`, and `grep` enforce bounded output. These internal limits are
-not currently user-configurable from `Netsukefile`.
-
-Use impure helpers only in trusted manifests. Netsuke does not sandbox them.
+See the [template standard-library guide](stdlib-yaml-and-jinja-guide.md) for
+every helper's signature, defaults, purity, platform caveats, and executable
+examples. Host-observing helpers belong only in trusted manifests: Netsuke
+bounds command and network output, but does not sandbox template evaluation.
 
 ## Use the command-line interface
 
@@ -394,9 +323,9 @@ The commands are:
 - `graph`: render the build graph as DOT or self-contained HTML without
   invoking Ninja.
 - `generate`: write Ninja without invoking it. Outside JSON mode, the generated
-  Ninja manifest is the only content written to stdout; use `--output <FILE>` to
-  write it to a file instead. In JSON mode (`--json`) the manifest is carried in
-  the result document's `result.content` field instead.
+  Ninja manifest is the only content written to stdout; use `--output <FILE>`
+  to write it to a file instead. In JSON mode (`--json`) the manifest is
+  carried in the result document's `result.content` field instead.
 
 Running `netsuke` without a subcommand is the same as `netsuke build` with no
 explicit targets. A bare target such as `netsuke hello` is not accepted; use

--- a/tests/documentation_examples/mod.rs
+++ b/tests/documentation_examples/mod.rs
@@ -1,8 +1,9 @@
 //! Loads fenced examples from user-facing Markdown for executable tests.
 //!
-//! Each fence in `README.md` and `docs/users-guide.md` must be preceded by a
-//! `tested-example` marker. Integration and behavioural tests share this
-//! module so they exercise the published text rather than copied fixtures.
+//! Each fence in `README.md`, `docs/users-guide.md`, and the template
+//! standard-library guide must be preceded by a `tested-example` marker.
+//! Integration and behavioural tests share this module so they exercise the
+//! published text rather than copied fixtures.
 
 use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
@@ -11,7 +12,11 @@ use tempfile::{TempDir, tempdir};
 use test_support::fs as test_fs;
 use test_support::netsuke::NetsukeRun;
 
-const DOCUMENT_PATHS: &[&str] = &["README.md", "docs/users-guide.md"];
+const DOCUMENT_PATHS: &[&str] = &[
+    "README.md",
+    "docs/users-guide.md",
+    "docs/stdlib-yaml-and-jinja-guide.md",
+];
 const MARKER_PREFIX: &str = "<!-- tested-example: ";
 const MARKER_SUFFIX: &str = " -->";
 static EMPTY_MARKER: std::sync::LazyLock<String> =

--- a/tests/documentation_examples_e2e_tests.rs
+++ b/tests/documentation_examples_e2e_tests.rs
@@ -6,8 +6,10 @@ mod documentation_examples;
 
 use anyhow::{Context, Result, ensure};
 use camino::{Utf8Path, Utf8PathBuf};
+use cap_std::{ambient_authority, fs_utf8::Dir};
 use documentation_examples::{assert_success, documented_example, manifest_workspace};
 use rstest::rstest;
+use rustix::fs::{Dev, FileType, Mode, mknodat};
 use std::path::Path;
 use std::process::Command;
 use test_support::fs as test_fs;
@@ -196,6 +198,148 @@ fn writing_example_combines_chapters_into_the_declared_pdf() -> Result<()> {
     ensure!(
         test_fs::exists(workspace.path().join("build/book.pdf")),
         "writing example should produce build/book.pdf"
+    );
+    Ok(())
+}
+
+#[test]
+fn stdlib_path_and_collection_example_reports_fixture_values() -> Result<()> {
+    let Ok(_ninja_probe) = ninja_integration_workspace() else {
+        return Ok(());
+    };
+    let workspace = manifest_workspace("stdlib-path-and-collection-manifest")?;
+    test_fs::create_dir(workspace.path().join("fixtures"))?;
+    test_fs::write(workspace.path().join("fixtures/message.txt"), "alpha")?;
+    let root_path = Utf8PathBuf::from_path_buf(workspace.path().to_path_buf())
+        .map_err(|_| anyhow::anyhow!("path example workspace should be UTF-8"))?;
+    let root = Dir::open_ambient_dir(&root_path, ambient_authority())?;
+    root.symlink("message.txt", "fixtures/message-link")?;
+    let home = workspace.path().to_string_lossy().into_owned();
+    let run = run_netsuke_in_with_env(
+        workspace.path(),
+        &[],
+        &[("NETSUKE_NINJA", "ninja"), ("HOME", home.as_str())],
+    )?;
+    assert_success(&run, "stdlib path and collection example")?;
+
+    let expected = format!(
+        concat!(
+            "report.tmp\nfixtures\nfixtures/report.txt\nreport.tmp\nfixtures/message.txt\n",
+            "{}/notes.txt\nalpha\n5\n1\n",
+            "8ed3f6ad685b959ead7022518e1af76cd816f8e8ec7ccdda1ed4018e8f2223f8\n",
+            "8ed3f6ad\nalpha,beta\n1,2,3\n2\n"
+        ),
+        workspace.path().display(),
+    );
+    let output = test_fs::read_to_string(workspace.path().join("stdlib-paths.txt"))?;
+    ensure!(
+        output == expected,
+        "stdlib path output mismatch; expected {expected:?}, got {output:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn stdlib_file_test_example_identifies_unix_fixture_types() -> Result<()> {
+    let Ok(_ninja_probe) = ninja_integration_workspace() else {
+        return Ok(());
+    };
+    let workspace = manifest_workspace("stdlib-file-tests-manifest")?;
+    test_fs::create_dir(workspace.path().join("fixtures"))?;
+    test_fs::write(workspace.path().join("fixtures/message.txt"), "alpha")?;
+    let root_path = Utf8PathBuf::from_path_buf(workspace.path().to_path_buf())
+        .map_err(|_| anyhow::anyhow!("file-test workspace should be UTF-8"))?;
+    let root = Dir::open_ambient_dir(&root_path, ambient_authority())?;
+    root.symlink("message.txt", "fixtures/message-link")?;
+    let fixtures = root.open_dir("fixtures")?;
+    mknodat(
+        &fixtures,
+        "events.pipe",
+        FileType::Fifo,
+        Mode::RUSR | Mode::WUSR,
+        Dev::default(),
+    )?;
+
+    let run = run_build(workspace.path(), &[], None)?;
+    assert_success(&run, "stdlib file-test example")?;
+    ensure!(
+        test_fs::read_to_string(workspace.path().join("stdlib-file-tests.txt"))?
+            == "true\ntrue\ntrue\ntrue\nfalse\ntrue\ntrue\n",
+        "stdlib file tests should report the documented Unix fixture types"
+    );
+    Ok(())
+}
+
+#[test]
+fn stdlib_time_example_emits_timestamp_and_duration() -> Result<()> {
+    let Ok(_ninja_probe) = ninja_integration_workspace() else {
+        return Ok(());
+    };
+    let workspace = manifest_workspace("stdlib-time-manifest")?;
+    let run = run_build(workspace.path(), &[], None)?;
+    assert_success(&run, "stdlib time example")?;
+    let output = test_fs::read_to_string(workspace.path().join("stdlib-time.txt"))?;
+    let mut lines = output.lines();
+    let timestamp = lines
+        .next()
+        .context("time example should emit a timestamp")?;
+    ensure!(
+        timestamp.contains('T') && timestamp.ends_with("+02:00"),
+        "time example should preserve the documented +02:00 offset: {timestamp}"
+    );
+    ensure!(
+        lines.next() == Some("P1DT2H30M") && lines.next().is_none(),
+        "time example should emit the documented duration: {output}"
+    );
+    Ok(())
+}
+
+#[test]
+fn stdlib_host_context_example_uses_controlled_process_state() -> Result<()> {
+    let Ok(_ninja_probe) = ninja_integration_workspace() else {
+        return Ok(());
+    };
+    let workspace = manifest_workspace("stdlib-host-context-manifest")?;
+    test_fs::create_dir(workspace.path().join("fixtures"))?;
+    test_fs::write(workspace.path().join("fixtures/a.txt"), "a")?;
+    test_fs::write(workspace.path().join("fixtures/b.txt"), "b")?;
+    let stub_directory = Utf8PathBuf::from_path_buf(workspace.path().join("bin"))
+        .map_err(|_| anyhow::anyhow!("stub directory should be UTF-8"))?;
+    test_fs::create_dir(stub_directory.as_std_path())?;
+    write_stub(
+        &stub_directory,
+        "uppercase",
+        "#!/bin/sh\nset -eu\ntr '[:lower:]' '[:upper:]'\n",
+    )?;
+    write_stub(
+        &stub_directory,
+        "grep",
+        concat!(
+            "#!/bin/sh\nset -eu\npattern=$1\n",
+            "while IFS= read -r line; do\n",
+            "  [ \"$line\" = \"$pattern\" ] && printf '%s\\n' \"$line\" || :\n",
+            "done\n"
+        ),
+    )?;
+    write_exec(&stub_directory, "guide-tool")?;
+    let path = executable_path(&stub_directory)?;
+    let run = run_netsuke_in_with_env(
+        workspace.path(),
+        &[],
+        &[
+            ("NETSUKE_NINJA", "ninja"),
+            ("PATH", path.as_str()),
+            ("NETSUKE_STDLIB_TOKEN", "from-env"),
+        ],
+    )?;
+    assert_success(&run, "stdlib host-context example")?;
+    let output = test_fs::read_to_string(workspace.path().join("stdlib-host-context.txt"))?;
+    ensure!(
+        output
+            == format!(
+                "HELLO\nbeta\n{stub_directory}/guide-tool\ntrue\nfrom-env\nfixtures/a.txt,fixtures/b.txt\n"
+            ),
+        "stdlib host-context output should use only controlled fixtures: {output}"
     );
     Ok(())
 }

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -39,8 +39,10 @@ const EXPECTED_EXAMPLE_IDS: &[&str] = &[
     "stdlib-fetch-expression",
     "stdlib-file-tests-manifest",
     "stdlib-host-context-manifest",
+    "stdlib-jinja-syntax-manifest",
     "stdlib-path-and-collection-manifest",
     "stdlib-time-manifest",
+    "stdlib-yaml-syntax-manifest",
 ];
 
 fn assert_default_edges_exist(ninja: &str, context: &str) -> Result<()> {
@@ -98,6 +100,8 @@ fn every_documented_fence_has_a_known_unique_identifier() -> Result<()> {
 #[case("guide-foreach-manifest")]
 #[case("guide-macro-manifest")]
 #[case("guide-command-available-manifest")]
+#[case("stdlib-yaml-syntax-manifest")]
+#[case("stdlib-jinja-syntax-manifest")]
 fn documented_manifest_generates_ninja(#[case] example_id: &str) -> Result<()> {
     let workspace = manifest_workspace(example_id)?;
     let run = run_netsuke_in(workspace.path(), &["--progress", "never", "generate"])?;

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -1,4 +1,4 @@
-//! Executable contracts for examples in the README and user's guide.
+//! Executable contracts for examples in the public user documentation.
 
 mod documentation_examples;
 
@@ -31,12 +31,16 @@ const EXPECTED_EXAMPLE_IDS: &[&str] = &[
     "guide-project-anchor",
     "guide-project-config",
     "guide-source-install",
-    "guide-stdlib-manifest",
     "guide-utility-commands",
     "guide-windows-help",
     "readme-first-build-commands",
     "readme-first-build-manifest",
     "readme-source-install",
+    "stdlib-fetch-expression",
+    "stdlib-file-tests-manifest",
+    "stdlib-host-context-manifest",
+    "stdlib-path-and-collection-manifest",
+    "stdlib-time-manifest",
 ];
 
 fn assert_default_edges_exist(ninja: &str, context: &str) -> Result<()> {
@@ -94,12 +98,25 @@ fn every_documented_fence_has_a_known_unique_identifier() -> Result<()> {
 #[case("guide-foreach-manifest")]
 #[case("guide-macro-manifest")]
 #[case("guide-command-available-manifest")]
-#[case("guide-stdlib-manifest")]
 fn documented_manifest_generates_ninja(#[case] example_id: &str) -> Result<()> {
     let workspace = manifest_workspace(example_id)?;
     let run = run_netsuke_in(workspace.path(), &["--progress", "never", "generate"])?;
 
     assert_generates_valid_ninja(&run, example_id)
+}
+
+#[test]
+fn documented_fetch_expression_is_registered_but_not_executed() -> Result<()> {
+    let example = documented_example("stdlib-fetch-expression")?;
+    ensure!(
+        example.language == "jinja",
+        "fetch example should remain an expression, not an executable manifest"
+    );
+    ensure!(
+        example.body == "{{ fetch('https://example.com/toolchain.json', cache=true) }}\n",
+        "fetch expression drifted"
+    );
+    Ok(())
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

This branch adds brief Netsuke-focused YAML and Jinja syntax primers followed by a complete template standard-library reference, so readers can understand manifest structure before using every registered helper. Each helper has a concrete signature, defaults, purity classification, platform caveats, and copy-pasteable usage, while the documented examples remain executable contracts against the real Netsuke binary.

The guide distinguishes manifest-time control from build-time behaviour: `foreach` and `when` select entries before typed AST deserialization, IR generation, and Ninja execution, while direct build-time branching belongs in recipe commands or scripts unless runtime conditions are explicitly modelled. It also makes host-dependent return contracts explicit: `realpath` may return an absolute path for relative input, while `shell` and `grep` return a persisted temporary-file path in `tempfile`, `stream`, and `streaming` modes.

Closes #443

## Review walkthrough

- Start with [the dedicated standard-library guide](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/docs/stdlib-yaml-and-jinja-guide.md) for the YAML and Jinja primers, manifest-control timing, and the complete path, collection, file-test, time, host-context, and network reference.
- Then review [the documentation-example loader](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/tests/documentation_examples/mod.rs) and [registry contracts](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/tests/documentation_examples_tests.rs) for drift detection across the guide, including both syntax-primer manifests.
- Finish with [the end-to-end documentation tests](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/tests/documentation_examples_e2e_tests.rs), which run the standard-library examples through the real binary in isolated workspaces with controlled fixtures and stub executables.
- The shorter entrypoints in [the users' guide](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/docs/users-guide.md), [README](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/README.md), and [documentation index](https://github.com/leynos/netsuke/blob/089a67d6b68ac433fabbe58044b65ef36002c892/docs/contents.md) route readers to the complete reference.

## Validation

- `make check-fmt`: passed
- `make test`: passed
- `make typecheck`: passed
- `make lint`: passed
- `make markdownlint`: passed
- `make nixie`: passed
- `coderabbit review --agent`: passed with 0 findings on the final branch

## Notes

The registered `fetch` expression is checked for documentation and registry drift but deliberately not executed, so the documentation suite never makes a network request. All newly marked manifests compile through the real binary with deterministic local fixtures where required.

## References

- Issue: [#443](https://github.com/leynos/netsuke/issues/443)
- Lody session: [53aea663-c306-435b-ae5d-2ae10811cc90](https://lody.ai/leynos/sessions/53aea663-c306-435b-ae5d-2ae10811cc90)