### PR TITLE
Document v0.1.0 installation packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Pre-built installers are available from the
 
 The Linux packages install the `netsuke` manual page and declare `ninja-build`
 as a dependency. Ninja must be installed separately when using the macOS or
-Windows installer. SHA-256 checksum files accompany the downloadable release
-files. See the [user's guide](docs/users-guide.md#install-netsuke) for
-platform-specific commands.
+Windows installer. The Windows MSI installs to `C:\Program Files\netsuke` and
+does not update `PATH`. SHA-256 checksum files accompany standalone binaries
+and staged help and licence files. Installer packages do not have checksum
+sidecars in v0.1.0. See the [user's guide](docs/users-guide.md#install-netsuke)
+for platform-specific commands and Windows setup.
 
 To install the current source checkout with Cargo:
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,28 @@ Netsuke currently requires:
 
 ### Installation
 
-To install from crates.io:
+Netsuke v0.1.0 is available from crates.io:
 
 <!-- tested-example: readme-crates-io-install -->
 
 ```sh
 cargo install netsuke
 ```
+
+Pre-built installers are available from the
+[v0.1.0 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0):
+
+| Platform | Architectures                        | Packages                         |
+| -------- | ------------------------------------ | -------------------------------- |
+| Linux    | x86-64 (`amd64`) and Arm64 (`arm64`) | Debian (`.deb`) and RPM (`.rpm`) |
+| macOS    | Intel x86-64 and Apple silicon Arm64 | Installer package (`.pkg`)       |
+| Windows  | x64 and Arm64                        | Windows Installer (`.msi`)       |
+
+The Linux packages install the `netsuke` manual page and declare `ninja-build`
+as a dependency. Ninja must be installed separately when using the macOS or
+Windows installer. SHA-256 checksum files accompany the downloadable release
+files. See the [user's guide](docs/users-guide.md#install-netsuke) for
+platform-specific commands.
 
 To install the current source checkout with Cargo:
 
@@ -110,9 +125,8 @@ The core build-system compiler is implemented:
 - unit, behavioural, integration, property, snapshot, and initial Kani
   verification coverage.
 
-Release automation is configured to build packages for Linux, macOS, and
-Windows, including platform help artefacts. v0.1.0 will be the first public
-release of this work.
+The v0.1.0 release provides packages for Linux, macOS, and Windows, including
+platform help artefacts. It is the first public release of this work.
 
 ______________________________________________________________________
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -43,11 +43,13 @@ The Linux packages install the binary under `/usr/bin`, add the `netsuke.1`
 manual page and declare `ninja-build` as a dependency. The macOS packages
 install the binary under `/usr/local/bin`, along with the manual page and
 licence. Ninja must be installed separately when using the macOS or Windows
-installer.
+installer. The Windows MSI installs to `C:\Program Files\netsuke` and does not
+update `PATH`.
 
-SHA-256 checksum files accompany the downloadable release files. Windows
-PowerShell help files are published beside each MSI as sidecar artefacts rather
-than embedded in the installer.
+SHA-256 checksum files accompany standalone binaries and staged help and
+licence files. Installer packages do not have checksum sidecars in v0.1.0.
+Windows PowerShell help files are published beside each MSI as sidecar
+artefacts rather than embedded in the installer.
 
 To install the current source checkout with Cargo:
 
@@ -59,8 +61,80 @@ cd netsuke
 cargo install --path .
 ```
 
-After installing the Windows PowerShell help sidecars, inspect the external
-help with:
+### Complete Windows setup
+
+The MSI does not add its installation directory to `PATH`. Add it to the
+current user's persistent `PATH`, update the current PowerShell session, then
+verify that the command resolves:
+
+<!-- tested-example: guide-windows-path -->
+
+```powershell
+$netsukeDirectory = Join-Path $env:ProgramFiles 'netsuke'
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$userEntries = @($userPath -split ';' | Where-Object { $_ })
+if ($userEntries -notcontains $netsukeDirectory) {
+    $newUserPath = (($userEntries + $netsukeDirectory) -join ';')
+    [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+}
+if (($env:Path -split ';') -notcontains $netsukeDirectory) {
+    $env:Path = "$env:Path;$netsukeDirectory"
+}
+netsuke --version
+```
+
+The release publishes PowerShell help separately for each Windows architecture.
+The following script downloads the matching module script, manifest, Microsoft
+Assistance Markup Language (MAML) help, and about-help file. It then restores
+the versioned module layout under the current user's standard PowerShell module
+directory and imports the module. Set `$architecture` to match the downloaded
+MSI:
+
+<!-- tested-example: guide-windows-help-install -->
+
+```powershell
+$architecture = 'amd64' # Use 'arm64' for the Arm64 MSI.
+$releaseUri = 'https://api.github.com/repos/leynos/netsuke/releases/tags/v0.1.0'
+$release = Invoke-RestMethod -Uri $releaseUri
+
+$documents = [Environment]::GetFolderPath('MyDocuments')
+$editionDirectory = if ($PSVersionTable.PSEdition -eq 'Desktop') {
+    'WindowsPowerShell'
+} else {
+    'PowerShell'
+}
+$moduleRoot = Join-Path $documents "$editionDirectory\Modules"
+$moduleDirectory = Join-Path $moduleRoot 'Netsuke\0.1.0'
+$helpDirectory = Join-Path $moduleDirectory 'en-US'
+New-Item -ItemType Directory -Path $helpDirectory -Force | Out-Null
+
+$patterns = @{
+    'Netsuke.psm1' = '*Netsuke.psm1'
+    'Netsuke.psd1' = '*Netsuke.psd1'
+    'Netsuke-help.xml' = '*en-US-Netsuke-help.xml'
+    'about_Netsuke.help.txt' = '*en-US-about_Netsuke.help.txt'
+}
+$localizedFiles = @('Netsuke-help.xml', 'about_Netsuke.help.txt')
+foreach ($fileName in $patterns.Keys) {
+    $pattern = "*windows-$architecture*$($patterns[$fileName])"
+    $asset = $release.assets | Where-Object { $_.name -like $pattern } | Select-Object -First 1
+    if ($null -eq $asset) {
+        throw "Release asset not found: $pattern"
+    }
+    $destinationDirectory = if ($localizedFiles -contains $fileName) {
+        $helpDirectory
+    } else {
+        $moduleDirectory
+    }
+    $destination = Join-Path $destinationDirectory $fileName
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $destination -UseBasicParsing
+}
+
+Import-Module (Join-Path $moduleDirectory 'Netsuke.psd1') -Force
+```
+
+The versioned directory is discoverable in later PowerShell sessions. After the
+import, inspect the external help with:
 
 <!-- tested-example: guide-windows-help -->
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -13,13 +13,41 @@ change before 1.0. Pin the Netsuke version in automated workflows.
 Netsuke requires [Ninja](https://ninja-build.org/) on `PATH`. A source build
 also requires Rust 1.89 or later.
 
-To install a published release from crates.io:
+Netsuke v0.1.0 is available from crates.io:
 
 <!-- tested-example: guide-crates-io-install -->
 
 ```sh
 cargo install netsuke
 ```
+
+Pre-built installers are available from the
+[v0.1.0 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0):
+
+| Platform | Architectures                        | Packages                         |
+| -------- | ------------------------------------ | -------------------------------- |
+| Linux    | x86-64 (`amd64`) and Arm64 (`arm64`) | Debian (`.deb`) and RPM (`.rpm`) |
+| macOS    | Intel x86-64 and Apple silicon Arm64 | Installer package (`.pkg`)       |
+| Windows  | x64 and Arm64                        | Windows Installer (`.msi`)       |
+
+Download the package for the host architecture, then install it with the
+platform tool. Replace `PACKAGE` with the downloaded filename:
+
+- Debian or Ubuntu: `sudo apt install ./PACKAGE.deb`
+- Fedora, Rocky Linux, or another RPM-based distribution:
+  `sudo dnf install ./PACKAGE.rpm`
+- macOS: `sudo installer -pkg ./PACKAGE.pkg -target /`
+- Windows: `msiexec.exe /i PACKAGE.msi`
+
+The Linux packages install the binary under `/usr/bin`, add the `netsuke.1`
+manual page and declare `ninja-build` as a dependency. The macOS packages
+install the binary under `/usr/local/bin`, along with the manual page and
+licence. Ninja must be installed separately when using the macOS or Windows
+installer.
+
+SHA-256 checksum files accompany the downloadable release files. Windows
+PowerShell help files are published beside each MSI as sidecar artefacts rather
+than embedded in the installer.
 
 To install the current source checkout with Cargo:
 
@@ -31,9 +59,8 @@ cd netsuke
 cargo install --path .
 ```
 
-Release archives contain platform-specific packages and help artefacts. Unix
-archives include a `netsuke.1` manual page. Windows archives include PowerShell
-external help:
+After installing the Windows PowerShell help sidecars, inspect the external
+help with:
 
 <!-- tested-example: guide-windows-help -->
 

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -162,6 +162,24 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
         "user's guide crates.io install drifted"
     );
 
+    let expected_release_details = [
+        "https://github.com/leynos/netsuke/releases/tag/v0.1.0",
+        "Debian (`.deb`) and RPM (`.rpm`)",
+        "Installer package (`.pkg`)",
+        "Windows Installer (`.msi`)",
+        "x86-64 (`amd64`) and Arm64 (`arm64`)",
+        "SHA-256 checksum files",
+    ];
+    for path in ["README.md", "docs/users-guide.md"] {
+        let document = test_fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+        for expected in expected_release_details {
+            ensure!(
+                document.contains(expected),
+                "{path} should document v0.1.0 release detail: {expected}"
+            );
+        }
+    }
+
     let readme = documented_example("readme-source-install")?;
     let guide = documented_example("guide-source-install")?;
     let expected = concat!(

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -155,15 +155,8 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
     let readme_release = documented_example("readme-crates-io-install")?;
     let guide_release = documented_example("guide-crates-io-install")?;
     let expected_release = "cargo install netsuke\n";
-    ensure!(
-        readme_release.body == expected_release,
-        "README crates.io install drifted"
-    );
-    ensure!(
-        guide_release.body == expected_release,
-        "user's guide crates.io install drifted"
-    );
-
+    ensure!(readme_release.body == expected_release, "README drifted");
+    ensure!(guide_release.body == expected_release, "user guide drifted");
     let expected_release_details = [
         "https://github.com/leynos/netsuke/releases/tag/v0.1.0",
         "Debian (`.deb`) and RPM (`.rpm`)",
@@ -182,7 +175,6 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
             );
         }
     }
-
     let readme = documented_example("readme-source-install")?;
     let guide = documented_example("guide-source-install")?;
     let expected = concat!(
@@ -191,24 +183,32 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
         "cargo install --path .\n"
     );
     ensure!(readme.body == expected, "README source install drifted");
-    ensure!(
-        guide.body == expected,
-        "user's guide source install drifted"
-    );
-
+    ensure!(guide.body == expected, "user guide source install drifted");
     let windows = documented_example("guide-windows-help")?;
-    ensure!(
-        windows.body == "Get-Help Netsuke -Full\n",
-        "PowerShell help command drifted"
-    );
+    ensure!(windows.body == "Get-Help Netsuke -Full\n", "help drifted");
     let windows_path = documented_example("guide-windows-path")?;
+    let windows_path_fragments = [
+        "SetEnvironmentVariable",
+        "$netsukeDirectory",
+        "SetEnvironmentVariable('Path', $newUserPath, 'User')",
+    ];
     ensure!(
-        windows_path.body.contains("SetEnvironmentVariable"),
+        windows_path_fragments
+            .into_iter()
+            .all(|fragment| windows_path.body.contains(fragment)),
         "Windows PATH setup should persist the MSI installation directory"
     );
     let windows_help_install = documented_example("guide-windows-help-install")?;
+    let windows_help_fragments = [
+        "Import-Module",
+        "$moduleDirectory = Join-Path $moduleRoot 'Netsuke\\0.1.0'",
+        "Import-Module (Join-Path $moduleDirectory 'Netsuke.psd1')",
+        "*windows-$architecture*",
+    ];
     ensure!(
-        windows_help_install.body.contains("Import-Module"),
+        windows_help_fragments
+            .into_iter()
+            .all(|fragment| windows_help_install.body.contains(fragment)),
         "Windows help setup should import the downloaded sidecars"
     );
     let staging = test_fs::read_to_string(".github/release-staging.toml")

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -34,6 +34,8 @@ const EXPECTED_EXAMPLE_IDS: &[&str] = &[
     "guide-source-install",
     "guide-utility-commands",
     "guide-windows-help",
+    "guide-windows-help-install",
+    "guide-windows-path",
     "readme-crates-io-install",
     "readme-first-build-commands",
     "readme-first-build-manifest",
@@ -168,7 +170,8 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
         "Installer package (`.pkg`)",
         "Windows Installer (`.msi`)",
         "x86-64 (`amd64`) and Arm64 (`arm64`)",
-        "SHA-256 checksum files",
+        "Installer packages do not have checksum",
+        "The Windows MSI installs to `C:\\Program Files\\netsuke`",
     ];
     for path in ["README.md", "docs/users-guide.md"] {
         let document = test_fs::read_to_string(path).with_context(|| format!("read {path}"))?;
@@ -197,6 +200,16 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
     ensure!(
         windows.body == "Get-Help Netsuke -Full\n",
         "PowerShell help command drifted"
+    );
+    let windows_path = documented_example("guide-windows-path")?;
+    ensure!(
+        windows_path.body.contains("SetEnvironmentVariable"),
+        "Windows PATH setup should persist the MSI installation directory"
+    );
+    let windows_help_install = documented_example("guide-windows-help-install")?;
+    ensure!(
+        windows_help_install.body.contains("Import-Module"),
+        "Windows help setup should import the downloaded sidecars"
     );
     let staging = test_fs::read_to_string(".github/release-staging.toml")
         .context("read release staging configuration")?;


### PR DESCRIPTION
## Summary

PR #448 has merged; this branch is rebased onto `main`.

This branch documents Netsuke v0.1.0 as available through crates.io and as
pre-built installers for Linux, macOS, and Windows. It gives users the
architecture matrix, platform installation commands, Ninja dependency rules,
installed help details, and accurate checksum scope.

The Windows guidance records the MSI installation directory, provides a
persistent per-user PATH setup, and supplies an architecture-aware script that
downloads, lays out, and imports the separately published PowerShell help
module. PR #448 makes Netsuke publishable as a single crate; this PR keeps the
README and user's guide aligned with the resulting release and packaging
surfaces.

## Review walkthrough

- Start with [README.md](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/README.md) for the concise package matrix, Windows caveat, checksum scope, and post-release wording.
- Then review [docs/users-guide.md](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/docs/users-guide.md) for platform commands, persistent Windows PATH setup, and the complete PowerShell sidecar installation flow.
- Finish with [tests/documentation_examples_tests.rs](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/tests/documentation_examples_tests.rs) for the synchronization and Windows setup contracts, including the user-scoped PATH, versioned module import, and architecture-aware asset checks.

The documented matrix and caveats follow [.github/workflows/release.yml](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/.github/workflows/release.yml), [.github/workflows/build-and-package.yml](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/.github/workflows/build-and-package.yml), [.github/release-staging.toml](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/.github/release-staging.toml), and [installer/Package.wxs](https://github.com/leynos/netsuke/blob/20820651f4503544ea8b79b5c3d8336f05148c44/installer/Package.wxs).

## Validation

- `cargo test --test documentation_examples_tests installation_examples_match_source_and_release_contracts`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make test`: passed
- `make markdownlint`: passed
- `make nixie`: passed
- `mbake validate Makefile`: passed
- `cargo package --allow-dirty --no-verify --list`: passed
- `git diff --check origin/main...HEAD`: passed

## Summary by Sourcery

Document Netsuke v0.1.0 distribution channels and release details across README and the user’s guide, and keep them in sync via tests.

Documentation:
- Describe Netsuke v0.1.0 availability on crates.io and as pre-built installers for Linux, macOS, and Windows in both the README and user’s guide, including supported architectures, package formats, install locations, dependencies, and checksum guidance.
- Update documentation to note that v0.1.0 is the first public release and to point users to the user’s guide for platform-specific installation commands.

Tests:
- Extend documentation example tests to assert that key v0.1.0 release details are present in both the README and user’s guide, preventing the docs from drifting from the release packaging contract.
