### PR TITLE
Migrate to Polonius and evolve internal APIs around borrowing (#465)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Enable the Polonius alpha borrow-checking analysis for every Cargo
+# invocation, including rust-analyzer and `cargo kani`, so editors and
+# verification tooling agree with CI about what borrows are legal.
+#
+# Note: an inherited `RUSTFLAGS` environment variable overrides this table.
+# Wrappers that set `RUSTFLAGS` (see the Makefile) must re-state
+# `-Zpolonius=next` themselves. See
+# docs/adr-006-adopt-polonius-nightly-toolchain.md.
+[build]
+rustflags = ["-Zpolonius=next"]

--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -67,6 +67,11 @@ jobs:
       BIN_NAME: ${{ inputs['bin-name'] }}
       VERSION: ${{ inputs.version }}
       MAN_ARCH: ${{ inputs['package-arch'] != '' && inputs['package-arch'] || 'unknown' }}
+      # Pre-set RUSTFLAGS so the setup-rust-toolchain step nested inside
+      # rust-build-release does not export its "-D warnings" default, which
+      # would shadow .cargo/config.toml and strip -Zpolonius=next (see
+      # docs/adr-006-adopt-polonius-nightly-toolchain.md).
+      RUSTFLAGS: -Zpolonius=next
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,16 @@ on:
 
 jobs:
   build-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        rust: [stable, '1.89.0']
-        # Nightly is experimental; stable and MSRV are the supported toolchains
-        include:
-          - os: ubuntu-latest
-            rust: nightly
-            experimental: true
-    continue-on-error: ${{ matrix.experimental || false }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      # Override rust-toolchain.toml to actually use the matrix toolchain
-      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
+      # The tree requires -Zpolonius=next (see
+      # docs/adr-006-adopt-polonius-nightly-toolchain.md), so CI builds with
+      # the dated nightly pinned in rust-toolchain.toml.
+      NETSUKE_RUST_TOOLCHAIN: nightly-2026-06-25
       WHITAKER_INSTALLER_VERSION: '0.2.6'
       # Single source of truth for the cargo-nextest pin. `make test` runs the
       # non-doctest suite through nextest, so every matrix leg needs it.
@@ -39,7 +30,7 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Install cargo-nextest
         uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68  # v2.85.3
@@ -55,7 +46,6 @@ jobs:
       - name: Format
         run: make check-fmt
       - name: Cache Whitaker installer
-        if: matrix.rust == 'stable'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
@@ -63,7 +53,6 @@ jobs:
             ~/.cache/cargo-binstall
           key: whitaker-installer-${{ runner.os }}-${{ runner.arch }}-${{ env.WHITAKER_INSTALLER_VERSION }}
       - name: Install Whitaker
-        if: matrix.rust == 'stable'
         run: |
           if ! command -v whitaker-installer >/dev/null 2>&1; then
             if cargo binstall --version >/dev/null 2>&1; then
@@ -75,13 +64,7 @@ jobs:
           fi
           whitaker-installer
       - name: Lint
-        if: matrix.rust == 'stable'
         run: make lint
-      # Whitaker lints under its own pinned toolchain, so re-running it per
-      # matrix leg repeats identical work; non-stable legs run Clippy only.
-      - name: Lint (Clippy only)
-        if: matrix.rust != 'stable'
-        run: make lint-clippy
       - name: Setup uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
@@ -93,9 +76,9 @@ jobs:
           path: |
             .typos-oxendict-base.json
             .typos-oxendict-base.toml
-          key: oxendict-${{ runner.os }}-${{ matrix.rust }}-${{ hashFiles('typos.local.toml') }}-${{ github.run_id }}
+          key: oxendict-${{ runner.os }}-${{ env.NETSUKE_RUST_TOOLCHAIN }}-${{ hashFiles('typos.local.toml') }}-${{ github.run_id }}
           restore-keys: |
-            oxendict-${{ runner.os }}-${{ matrix.rust }}-${{ hashFiles('typos.local.toml') }}-
+            oxendict-${{ runner.os }}-${{ env.NETSUKE_RUST_TOOLCHAIN }}-${{ hashFiles('typos.local.toml') }}-
       - name: Spelling
         run: make spelling
       - name: Workflow contract tests
@@ -103,7 +86,6 @@ jobs:
       - name: Test
         run: make test
       - name: Test and Measure Coverage
-        if: matrix.rust == 'stable'
         uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: lcov.info
@@ -112,7 +94,7 @@ jobs:
           # coverage-main.yml (caches saved on main are readable by every PR).
           with-ratchet: 'true'
       - name: Check coverage against CodeScene gates
-        if: matrix.rust == 'stable' && env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       RUSTFLAGS: -D warnings -Zpolonius=next
       WHITAKER_INSTALLER_VERSION: '0.2.6'
       # Single source of truth for the cargo-nextest pin. `make test` runs the
-      # non-doctest suite through nextest, so every matrix leg needs it.
+      # non-doctest suite through nextest, so the job installs it up front.
       NEXTEST_VERSION: '0.9.133'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
       # docs/adr-006-adopt-polonius-nightly-toolchain.md), so CI builds with
       # the dated nightly pinned in rust-toolchain.toml.
       NETSUKE_RUST_TOOLCHAIN: nightly-2026-06-25
+      # Pre-set RUSTFLAGS so setup-rust-toolchain's "-D warnings" default does
+      # not shadow .cargo/config.toml and strip -Zpolonius=next; tools such as
+      # cargo-llvm-cov append their own flags to this value.
+      RUSTFLAGS: -D warnings -Zpolonius=next
       WHITAKER_INSTALLER_VERSION: '0.2.6'
       # Single source of truth for the cargo-nextest pin. `make test` runs the
       # non-doctest suite through nextest, so every matrix leg needs it.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
         with:
-          toolchain: stable
+          # Match rust-toolchain.toml: the tree needs -Zpolonius=next (see
+          # docs/adr-006-adopt-polonius-nightly-toolchain.md).
+          toolchain: nightly-2026-06-25
           components: rustfmt, clippy
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -19,6 +19,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      # Pre-set RUSTFLAGS so setup-rust-toolchain's "-D warnings" default does
+      # not shadow .cargo/config.toml and strip -Zpolonius=next; cargo-llvm-cov
+      # appends its instrumentation flags to this value.
+      RUSTFLAGS: -D warnings -Zpolonius=next
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Setup Rust

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -25,6 +25,8 @@ jobs:
       RUSTFLAGS: -D warnings -Zpolonius=next
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
         with:

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
         with:

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -15,6 +15,9 @@ jobs:
       # Match rust-toolchain.toml: the tree needs -Zpolonius=next (see
       # docs/adr-006-adopt-polonius-nightly-toolchain.md).
       NETSUKE_RUST_TOOLCHAIN: nightly-2026-06-25
+      # Pre-set RUSTFLAGS so setup-rust-toolchain's "-D warnings" default does
+      # not shadow .cargo/config.toml and strip -Zpolonius=next.
+      RUSTFLAGS: -Zpolonius=next
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -9,21 +9,19 @@ on:
 jobs:
   netsukefile:
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        rust: [stable, '1.89.0']
     permissions:
       contents: read
     env:
-      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
+      # Match rust-toolchain.toml: the tree needs -Zpolonius=next (see
+      # docs/adr-006-adopt-polonius-nightly-toolchain.md).
+      NETSUKE_RUST_TOOLCHAIN: nightly-2026-06-25
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
       - name: Show rustc version
         run: |
           rustup show
@@ -36,9 +34,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ env.NETSUKE_RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.rust }}-
+            ${{ runner.os }}-cargo-${{ env.NETSUKE_RUST_TOOLCHAIN }}-
             ${{ runner.os }}-cargo-
       - name: Clean build artefacts
         run: make clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,8 +182,8 @@ references, clone keys only on insertion, and build error context lazily.
   - `make test` executes:
 
     ```sh
-    RUSTFLAGS="-D warnings" cargo nextest run --all-targets --all-features
-    RUSTFLAGS="-D warnings" cargo test --doc --all-features
+    RUSTFLAGS="-D warnings -Zpolonius=next" cargo nextest run --all-targets --all-features
+    RUSTFLAGS="-D warnings -Zpolonius=next" cargo test --doc --all-features
     ```
 
     running every unit, integration, and behavioural test through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,29 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
+### Borrow checker: Polonius, not NLL
+
+Netsuke compiles with the Polonius alpha analysis (`-Zpolonius=next`) on the
+dated nightly pinned in `rust-toolchain.toml` (see
+`docs/adr-006-adopt-polonius-nightly-toolchain.md` and `docs/polonius.md`).
+Internal APIs are borrow-centric: lookups and get-or-create accessors return
+references, clone keys only on insertion, and build error context lazily.
+
+- **Never** rewrite a site tagged `POLONIUS(...)` into a double lookup
+  (`contains_key` + `get_mut`), an `entry(key.clone())` call, or an
+  id/index round-trip. Those forms are the NLL-era workarounds this
+  codebase deliberately retired; the direct form is compiler-verified.
+- **Never** silence a borrow error by adding a defensive `.clone()`, an
+  eager error-context computation, or a snapshot `collect()` without first
+  compiling the natural borrow-returning form under the project toolchain —
+  it usually compiles.
+- Respect `POLONIUS-REFUSED(...)` tags: the named constraint (persistent
+  identity, lock boundaries, aliasing, suspension points, thread
+  boundaries) is permanent. Do not convert those sites to
+  reference-returning forms.
+- When adding a new borrow-centric API, verify it with and without
+  `-Zpolonius=next` and record the classification in `docs/polonius.md`.
+
 - Run `make check-fmt`, `make lint`, and `make test` before committing. These
   targets wrap the following commands, so contributors understand the exact
   behaviour and policy enforced:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Route graph-view node registration through a borrow-returning
+  `NodePathRegistry` accessor that looks paths up once on hits and clones a
+  path only on insertion
+  ([#465](https://github.com/leynos/netsuke/issues/465))
 - Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
   `nightly-2026-06-25` toolchain; building from source now requires that
   nightly, which `rustup` installs automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
+  `nightly-2026-06-25` toolchain; building from source now requires that
+  nightly, which `rustup` installs automatically
+  ([#465](https://github.com/leynos/netsuke/issues/465))
+- Remove the `rust-version = "1.89.0"` minimum-supported-Rust-version
+  declaration from `Cargo.toml`; `rust-toolchain.toml` is now the single
+  source of truth for the compiler contract
+  ([#465](https://github.com/leynos/netsuke/issues/465))
+
+## [0.1.0] - 2026-07-28
+
+_Initial release._
+
+[0.1.0]: https://github.com/leynos/netsuke/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@
   path only on insertion
   ([#465](https://github.com/leynos/netsuke/issues/465))
 - Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
-  `nightly-2026-06-25` toolchain; building from source now requires that
-  nightly, which `rustup` installs automatically
+  `nightly-2026-06-25` toolchain; checkout builds pick this up
+  automatically via `rustup`, while registry installs must pass the
+  toolchain and flag explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`)
   ([#465](https://github.com/leynos/netsuke/issues/465))
 - Remove the `rust-version = "1.89.0"` minimum-supported-Rust-version
   declaration from `Cargo.toml`; `rust-toolchain.toml` is now the single

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,6 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
- "trybuild",
  "ureq",
  "url",
  "wait-timeout",
@@ -2532,12 +2531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-triple"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,15 +2541,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2756,21 +2740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 1.0.3",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,15 +2753,6 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -2899,21 +2859,6 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "trybuild"
-version = "1.0.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
-dependencies = [
- "glob",
- "serde",
- "serde_derive",
- "serde_json",
- "target-triple",
- "termcolor",
- "toml 1.1.0+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "netsuke"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.89.0"
 include = [
     "src/**",
     "locales/**",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,6 @@ strip-ansi-escapes = "0.2"
 toml = "0.8"
 serde_yaml = "0.9"
 proptest = "1.11.0"
-trybuild = "1.0.116"
 
 # Target-specific dev-deps
 [target.'cfg(unix)'.dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 APP ?= netsuke
 CARGO ?= $(shell command -v cargo 2>/dev/null || printf '%s' "$$HOME/.cargo/bin/cargo")
+# The Polonius borrow-checker flag normally flows from .cargo/config.toml, but
+# any recipe that sets RUSTFLAGS overrides that table and must re-state it.
+POLONIUS_FLAGS ?= -Zpolonius=next
 # Extra build-parallelism flags for plain Cargo invocations, e.g. `-j 4`.
 BUILD_JOBS ?=
 # The same concept for cargo-nextest, which spells build parallelism
@@ -60,10 +63,10 @@ clean: ## Remove build artefacts
 test: test-nextest doctest ## Run every Rust test with warnings treated as errors
 
 test-nextest: ## Run all non-doctest Rust tests through cargo-nextest
-	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(NEXTEST_BUILD_JOBS)
+	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(CARGO) nextest run --all-targets --all-features $(NEXTEST_BUILD_JOBS)
 
 doctest: ## Run doctests, which cargo-nextest cannot execute
-	RUSTFLAGS="-D warnings" $(CARGO) test --doc --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(CARGO) test --doc --all-features $(BUILD_JOBS)
 
 test-workflow-contracts: ## Validate the mutation-testing caller contract
 	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
@@ -80,7 +83,7 @@ lint-clippy: ## Run rustdoc and Clippy with warnings denied
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 
 lint-whitaker: ## Run the Whitaker Dylint suite with warnings denied
-	RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
+	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(WHITAKER) --all -- --all-targets --all-features
 
 fmt: ## Format Rust and Markdown sources
 	$(CARGO) fmt --all
@@ -90,7 +93,7 @@ check-fmt: ## Verify formatting
 	$(CARGO) fmt --all -- --check
 
 typecheck: ## Typecheck all targets and features
-	RUSTFLAGS="-D warnings" $(CARGO) check --all-targets --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(CARGO) check --all-targets --all-features $(BUILD_JOBS)
 
 markdownlint: spelling ## Lint Markdown and enforce en-GB-oxendict spelling
 	$(MDLINT) "**/*.md"

--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,13 @@ test-workflow-contracts: ## Validate the mutation-testing caller contract
 test-typos-config: spelling-helper-test ## Verify the shared spelling-policy integration
 
 target/%/$(APP): ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
+	RUSTFLAGS="$${RUSTFLAGS-} $(POLONIUS_FLAGS)" $(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
 
 lint: lint-clippy lint-whitaker ## Run Clippy and the Whitaker Dylint suite with warnings denied
 
 lint-clippy: ## Run rustdoc and Clippy with warnings denied
-	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
-	$(CARGO) clippy $(CLIPPY_FLAGS)
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" RUSTFLAGS="$${RUSTFLAGS-} $(POLONIUS_FLAGS)" $(CARGO) doc --no-deps
+	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(CARGO) clippy $(CLIPPY_FLAGS)
 
 lint-whitaker: ## Run the Whitaker Dylint suite with warnings denied
 	RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)" $(WHITAKER) --all -- --all-targets --all-features

--- a/README.md
+++ b/README.md
@@ -41,9 +41,20 @@ Netsuke currently requires:
 
 ### Installation
 
-Netsuke v0.1.0 is available from crates.io. Registry installs build outside a
-repository checkout, so neither the pinned toolchain nor the Polonius flag is
-picked up automatically; supply both explicitly:
+Netsuke v0.1.0 is available from crates.io. Where
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
+available, prefer it: it fetches a prebuilt release binary and avoids the
+toolchain requirement below.
+
+<!-- tested-example: readme-binstall-install -->
+
+```sh
+cargo binstall netsuke
+```
+
+Building from the registry instead runs outside a repository checkout, so
+neither the pinned toolchain nor the Polonius flag is picked up
+automatically; supply both explicitly:
 
 <!-- tested-example: readme-crates-io-install -->
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ Netsuke currently requires:
 
 ### Installation
 
-Netsuke v0.1.0 is available from crates.io:
+Netsuke v0.1.0 is available from crates.io. Registry installs build outside a
+repository checkout, so neither the pinned toolchain nor the Polonius flag is
+picked up automatically; supply both explicitly:
 
 <!-- tested-example: readme-crates-io-install -->
 
 ```sh
-cargo install netsuke
+rustup toolchain install nightly-2026-06-25
+RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke
 ```
 
 Pre-built installers are available from the

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ ______________________________________________________________________
 Netsuke currently requires:
 
 - [Ninja](https://ninja-build.org/) on `PATH`;
-- Rust 1.89 or later when installing from source.
+- when installing from source, the dated Rust nightly toolchain pinned in
+  [`rust-toolchain.toml`](rust-toolchain.toml) (`rustup` installs it
+  automatically in a checkout). Netsuke builds with the Polonius borrow
+  checker (`-Zpolonius=next`), which is nightly-only until it stabilizes; see
+  [ADR-006](docs/adr-006-adopt-polonius-nightly-toolchain.md).
 
 ### Installation
 

--- a/docs/adr-006-adopt-polonius-nightly-toolchain.md
+++ b/docs/adr-006-adopt-polonius-nightly-toolchain.md
@@ -74,8 +74,16 @@ remains correct.
 
 ## Consequences
 
-- Publishing to crates.io remains possible but installs require a nightly
-  compiler until Polonius stabilizes; the README documents this.
+- Publishing to crates.io remains possible, but the packaged source excludes
+  `rust-toolchain.toml` and `.cargo/config.toml` (and Cargo would not apply
+  them to a registry build anyway), so a bare `cargo install netsuke` of a
+  Polonius-dependent release fails borrow checking on the user's default
+  toolchain. Registry installs must select the pinned nightly and pass the
+  flag explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`);
+  the README and users' guide document this command and a contract test pins
+  it. Source installs from a checkout are unaffected because the pinned
+  toolchain and workspace configuration apply there.
 - Release packaging builds from the pinned nightly. Binary artefacts are
   unaffected: the borrow checker changes what compiles, not what is
   generated.

--- a/docs/adr-006-adopt-polonius-nightly-toolchain.md
+++ b/docs/adr-006-adopt-polonius-nightly-toolchain.md
@@ -1,0 +1,91 @@
+# Architecture Decision Record (ADR): Adopt the Polonius borrow checker on a pinned nightly toolchain
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-07-29.
+
+## Context and problem statement
+
+Netsuke's internal APIs carry the shape that the non-lexical-lifetimes (NLL)
+borrow checker imposed on the whole Rust ecosystem: lookups that clone keys
+unconditionally, registries that hand back owned values, and error paths that
+compute context eagerly. The Polonius alpha analysis (`-Zpolonius=next`)
+accepts a strict superset of NLL and removes the lifetime limitation behind
+several of these shapes, so the natural borrow-returning form of an accessor
+can compile where NLL rejected it.
+
+Adopting those borrow-centric designs binds the source tree to a
+Polonius-enabled compiler, which is nightly-only until the analysis
+stabilizes. That conflicts with three standing policies:
+
+- `rust-toolchain.toml` pinned stable `1.89.0`;
+- `Cargo.toml` declared `rust-version = "1.89.0"` as a minimum supported Rust
+  version (MSRV);
+- continuous integration (CI) built a `stable`/`1.89.0` matrix with nightly as
+  an experimental leg.
+
+Netsuke is a pre-1.0 application whose only API consumers are its own crates,
+so internal API quality was judged to outweigh a stable-toolchain guarantee
+(issue #465).
+
+## Decision
+
+Adopt Polonius now, as a nightly-only source tree:
+
+- Pin the dated toolchain `nightly-2026-06-25` in `rust-toolchain.toml` so
+  builds stay reproducible.
+- Enable `-Zpolonius=next` in `.cargo/config.toml` under `[build] rustflags`,
+  so plain Cargo invocations, rust-analyzer, and `cargo kani` all borrow-check
+  with the same analysis. Makefile recipes that set `RUSTFLAGS` (which
+  overrides that table) re-state the flag via the `POLONIUS_FLAGS` variable.
+- Collapse the CI matrices in `ci.yml` and `netsukefile-test.yml` to the
+  pinned nightly, and align `coverage-main.yml`. Stable and MSRV legs are
+  removed because the tree no longer compiles without Polonius.
+- Remove the `rust-version` field from `Cargo.toml`. Cargo cannot express a
+  nightly requirement there, and advertising `1.89.0` would misstate the
+  contract; `rust-toolchain.toml` is now the single source of truth.
+
+Every borrow-centric rewrite that depends on the flag is verified both with
+and without `-Zpolonius=next` and recorded in
+[polonius migration notes](polonius.md), including refusals where owned style
+remains correct.
+
+## Rationale
+
+- **Design over deployment breadth.** Netsuke ships binaries, not a library
+  API. Consumers install packaged artefacts or build from source; the
+  toolchain pin costs contributors one `rustup` fetch, whereas NLL-era
+  double lookups and key clones cost every call site, forever.
+- **Reproducibility.** A dated nightly behaves like a release: the same
+  compiler bits build the tree everywhere. `rustup` provisions it
+  automatically from `rust-toolchain.toml`.
+- **Coherent tooling.** Putting the flag in `.cargo/config.toml` keeps
+  rust-analyzer, Clippy, Whitaker (whose Dylint driver is nightly-based), and
+  Kani borrow-checking the same dialect, avoiding phantom editor errors on
+  correct code.
+- **Stabilization path.** Polonius is a Rust project goal for stabilization.
+  When `-Zpolonius=next` becomes default behaviour on stable, the pin and the
+  flag can be dropped without touching the migrated code, and an MSRV can be
+  re-declared at that release.
+
+## Consequences
+
+- Publishing to crates.io remains possible but installs require a nightly
+  compiler until Polonius stabilizes; the README documents this.
+- Release packaging builds from the pinned nightly. Binary artefacts are
+  unaffected: the borrow checker changes what compiles, not what is
+  generated.
+- Dependabot-style toolchain drift is impossible; moving the pin is a
+  deliberate act. Move it forward periodically (and especially once Polonius
+  stabilizes), re-running the full gate suite, and update this ADR's
+  references when doing so.
+- Sites that genuinely require Polonius are tagged `POLONIUS(...)` in source
+  and must not be rewritten into NLL-era defensive forms; `AGENTS.md` and
+  [polonius migration notes](polonius.md) carry the anti-regression guidance.
+- `cargo +stable` invocations fail on `-Zpolonius=next`. This is intentional:
+  the failure is loud and immediate rather than a confusing borrowck error
+  later.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -41,6 +41,8 @@ operator, user, and contributor references are easier to find.
 - [adr-005-typed-which-resolve-error.md](adr-005-typed-which-resolve-error.md):
   Typed executable resolver error decision record for `which` and
   `command_available`.
+- [adr-006-adopt-polonius-nightly-toolchain.md](adr-006-adopt-polonius-nightly-toolchain.md):
+  Pinned-nightly Polonius borrow-checker adoption decision record.
 
 ## User and operator guides
 
@@ -60,6 +62,8 @@ operator, user, and contributor references are easier to find.
 
 - [developers-guide.md](developers-guide.md): Engineering workflow, quality
   gates, testing strategy, and stdlib resolver-boundary conventions.
+- [polonius.md](polonius.md): Polonius migration audit, borrow-centric API
+  evolution log, and principled refusals.
 - [documentation-style-guide.md](documentation-style-guide.md): Documentation
   conventions, roadmap-writing rules, and Markdown requirements.
 - [execplans/](execplans/): Execution plans and implementation handoff notes.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -82,8 +82,9 @@ construction.
 Netsuke builds on the dated nightly toolchain pinned in `rust-toolchain.toml`
 with the Polonius alpha borrow-checking analysis (`-Zpolonius=next`) enabled.
 `rustup` provisions the toolchain automatically, and `.cargo/config.toml`
-applies the flag to every Cargo invocation, including rust-analyzer and
-`cargo kani`. Makefile recipes that set `RUSTFLAGS` re-state the flag through
+supplies the flag by default, covering Cargo invocations such as
+rust-analyzer and `cargo kani` that run without `RUSTFLAGS` in the
+environment. Makefile recipes that set `RUSTFLAGS` re-state the flag through
 the `POLONIUS_FLAGS` variable because an inherited `RUSTFLAGS` environment
 variable overrides `.cargo/config.toml`.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -76,6 +76,25 @@ they are per-invocation arguments tagged `#[serde(skip)]` on
 would silently change the artefact destination — a footgun the design avoids by
 construction.
 
+
+## Toolchain and borrow checker
+
+Netsuke builds on the dated nightly toolchain pinned in `rust-toolchain.toml`
+with the Polonius alpha borrow-checking analysis (`-Zpolonius=next`) enabled.
+`rustup` provisions the toolchain automatically, and `.cargo/config.toml`
+applies the flag to every Cargo invocation, including rust-analyzer and
+`cargo kani`. Makefile recipes that set `RUSTFLAGS` re-state the flag through
+the `POLONIUS_FLAGS` variable because an inherited `RUSTFLAGS` environment
+variable overrides `.cargo/config.toml`.
+
+[ADR-006](adr-006-adopt-polonius-nightly-toolchain.md) records the policy
+decision, and the [polonius migration notes](polonius.md) track every site
+whose design depends on the analysis. Sites tagged `POLONIUS(...)` fail to
+compile under plain non-lexical lifetimes (NLL); do not rewrite them into
+double lookups, unconditional key clones, or id indirection, and do not pad
+new code with defensive clones that only NLL required. When a borrow-centric
+form fails to compile, consult the migration notes before restructuring.
+
 ## Quality gates
 
 Run these commands before finalizing any change:
@@ -364,7 +383,10 @@ make install-kani
 `cargo install --locked kani-verifier --version <version>`, runs
 `cargo kani setup`, and verifies that `cargo kani` is callable. Kani may manage
 its own supporting Rust nightly toolchain during setup. That toolchain must not
-replace the repository's ordinary stable Rust workflow.
+replace the repository's pinned nightly workflow (see
+[ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)). Kani builds pick up
+`-Zpolonius=next` from `.cargo/config.toml`, so Polonius-dependent code
+verifies unchanged.
 
 Delegated prover targets print maintainer diagnostics to standard error before
 invoking `rust-prover-tools`. Expect `prover-tools:` lines containing the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -503,8 +503,9 @@ home plus Kani support-file home.
 
 - `make test-nextest` —
   `cargo nextest run --all-targets --all-features`, with
-  `RUSTFLAGS="-D warnings"`. This runs every unit, integration, `rstest`, and
-  `rstest-bdd` test.
+  `RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)"` (the Makefile re-states the
+  Polonius flag because a set `RUSTFLAGS` overrides `.cargo/config.toml`).
+  This runs every unit, integration, `rstest`, and `rstest-bdd` test.
 - `make doctest` — `cargo test --doc --all-features`, with the same
   `RUSTFLAGS`. nextest cannot execute doctests, so they need their own pass.
   Note that the previous `cargo test --all-targets` invocation never ran

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -76,7 +76,6 @@ they are per-invocation arguments tagged `#[serde(skip)]` on
 would silently change the artefact destination — a footgun the design avoids by
 construction.
 
-
 ## Toolchain and borrow checker
 
 Netsuke builds on the dated nightly toolchain pinned in `rust-toolchain.toml`

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2941,6 +2941,18 @@ selected for this project and the rationale for their inclusion.
 | Logging        | tracing                     | Structured, levelled diagnostic output for debugging and insight.                                                               |
 | Versioning     | semver                      | The standard library for parsing and evaluating Semantic Versioning strings, essential for the `netsuke_version` field.         |
 
+Netsuke compiles with the Polonius alpha borrow-checking analysis
+(`-Zpolonius=next`) on the dated nightly toolchain pinned in
+`rust-toolchain.toml`
+([ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)). Internal APIs
+follow a borrow-centric design contract: lookups and registries return
+references (`&mut V` accessors with clone-on-miss keys), mutation happens in
+place, and error context is built lazily on the failure path. Owned-value
+style is reserved for genuine constraints — aliasing, suspension points,
+thread and process boundaries, and persistent identity — and each such
+refusal is recorded in the [polonius migration notes](polonius.md) alongside
+the sites that depend on the analysis.
+
 ### 9.3 Future Enhancements
 
 The architecture described in this document provides a solid foundation for a

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -119,9 +119,9 @@ Polonius flag or avoid compiling the crate:
   The README and users' guide document the command and
   `tests/documentation_examples_tests.rs` pins it.
 - **cargo-mutants** (scheduled, informational) runs through the shared
-  `mutation-cargo.yml` workflow, which controls its own environment; if its
-  runs regress with E0499 at tagged sites, the shared workflow needs the
-  same `RUSTFLAGS` treatment.
+  `mutation-cargo.yml` workflow, which controls its own environment; if
+  those runs regress with E0499 at tagged sites, the shared workflow needs
+  the same `RUSTFLAGS` treatment.
 
 ## Clone counts
 

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -87,6 +87,21 @@ Scanner suspects that turned out not to be NLL residue:
 - Test-suite `drop()` calls (environment guards, HTTP fixture teardown) are
   semantic Drop effects, not borrow appeasement.
 
+## Harness consequences
+
+Tooling that rebuilds the crate with its own flags must propagate the
+Polonius flag or avoid compiling the crate:
+
+- **trybuild** discards ambient `RUSTFLAGS` and workspace `build.rustflags`,
+  replacing them via `--config` on its scratch project, and it always builds
+  the host crate as a fixture dependency. The Kani cfg policy fixture is
+  therefore compiled and run directly with the workspace `rustc`
+  (`tests/kani_cfg_ui_tests.rs`); do not reintroduce trybuild cases that
+  depend on the `netsuke` crate while the tree is Polonius-only.
+- **Kani** and **Whitaker** run under their own toolchains but read the
+  workspace `.cargo/config.toml` or the Makefile `RUSTFLAGS`, so they
+  borrow-check with `-Zpolonius=next` and need no special handling.
+
 ## Clone counts
 
 Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -111,6 +111,13 @@ Polonius flag or avoid compiling the crate:
   line of defence. `cargo-llvm-cov` appends its instrumentation flags to
   the ambient value, so coverage inherits the flag from the job
   environment.
+- **Registry installs**: the crates.io package excludes
+  `rust-toolchain.toml` and `.cargo/config.toml`, and registry builds run
+  outside the checkout, so `cargo install netsuke` must select the pinned
+  nightly and pass the flag explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`).
+  The README and users' guide document the command and
+  `tests/documentation_examples_tests.rs` pins it.
 - **cargo-mutants** (scheduled, informational) runs through the shared
   `mutation-cargo.yml` workflow, which controls its own environment; if its
   runs regress with E0499 at tagged sites, the shared workflow needs the

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -1,0 +1,134 @@
+# Polonius migration notes
+
+Netsuke compiles with the Polonius alpha borrow-checking analysis
+(`-Zpolonius=next`) on the dated nightly pinned in `rust-toolchain.toml`.
+[ADR-006](adr-006-adopt-polonius-nightly-toolchain.md) records the toolchain
+policy; this document records the audit that motivated it, the API
+evolutions it enabled, and the refusals that bound it. Issue
+[#465](https://github.com/leynos/netsuke/issues/465) tracked the migration.
+
+## Method
+
+The migration ran the `nll-to-polonius` two-pass audit with the compiler as
+the oracle:
+
+1. **Workaround scan** — mechanical sweep for local non-lexical-lifetimes
+   (NLL) workaround shapes: double lookups, `entry()` with unconditionally
+   cloned keys, re-lookup after insert, index-returning finders,
+   borrow-killing `drop()` calls, and eager error context.
+2. **Design-pressure scan** — structural sweep for owned lookup results,
+   id/index indirection, clone-modify-writeback, snapshot-collect loops, and
+   per-module clone hotspots.
+
+Every change was compiled twice on `nightly-2026-06-25`: once with
+`-Zpolonius=next` (must pass) and once without (the outcome classifies the
+change). A failure without the flag proves the design genuinely depends on
+Polonius and the site is tagged `POLONIUS(...)`; success means the old form
+was habit rather than necessity and the improvement carries no toolchain
+caveat. Behavioural test suites were required to pass unchanged in either
+case.
+
+## Polonius-dependent sites
+
+| Site | Tag | Verification |
+| --- | --- | --- |
+| `src/graph_view/mod.rs` — `NodePathRegistry::ensure_node_mut` | `POLONIUS(case-3)` | Passes with `-Zpolonius=next`; rejected by NLL with E0499 on nightly-2026-06-25 |
+
+`ensure_node_mut` is the get-or-insert accessor behind graph projection: it
+returns `&mut NodeKind`, performs a single lookup on the hit path, and
+clones the path only on insertion. It replaced three
+`entry(path.clone()).or_insert(NodeKind::Source)` sites that cloned every
+input, implicit-dependency, and order-only path on every registration. The
+`get_mut` loan escapes only via the early return, which is the canonical
+Polonius problem-case-3 shape (conditional early return of a borrow).
+
+## Evolutions that compile under both checkers
+
+These came out of the design-pressure scan. Each compiles under plain NLL as
+well — the owned style was habit, so they carry no toolchain caveat:
+
+- `src/stdlib/collections.rs` — `group_by_filter` consumed its resolved key
+  in `entry(key_value)` instead of cloning it first.
+- `src/ir/cycle.rs` — `detect_targets` snapshots borrowed
+  `&'targets Utf8Path` keys for its deterministic sort instead of cloning
+  every target path per analysis. The snapshot exists for sorting, not to
+  end a borrow, so it stays.
+- `src/stdlib/which/env.rs` — `EnvSnapshot::resolved_dirs` returns
+  `Vec<&Utf8Path>` borrowed from the snapshot; the search loop reads
+  borrowed directories and the paths are copied into the owned
+  `ResolveError::NotFound` only at the error boundary.
+
+## Refusals
+
+Owned style retained deliberately. The constraint, not the borrow checker,
+is load-bearing; each site carries the matching source tag:
+
+| Site | Tag | Constraint |
+| --- | --- | --- |
+| `src/ir/from_manifest_support.rs` — `register_action` | `POLONIUS-REFUSED(id-is-data)` | The action hash is persistent IR identity: stored on every `BuildEdge` and named in the generated Ninja file. Remains owned unless callers demonstrate a need for the canonical interned value. |
+| `src/stdlib/which/cache.rs` — `WhichResolver::try_cache` | `POLONIUS-REFUSED(lock-boundary)` | Cache hits are cloned out of the LRU because references cannot outlive the `MutexGuard`; the resolver is shared across evaluation sites. |
+| `src/stdlib/collections.rs` — `GroupedValues::new` | `POLONIUS-REFUSED(miss-dominant)` | First-wins string-key registration almost always inserts, so the owned-key `entry` form pays nothing on the rare hit. |
+
+## Non-candidates reviewed and cleared
+
+Scanner suspects that turned out not to be NLL residue:
+
+- `src/ir/from_manifest_support.rs` — the `contains_key`/`insert` guard in
+  `register_action` keeps no reference, so it already compiles under NLL
+  (write-only guarding); the refusal above covers the owned hash it returns.
+- `src/ir/cycle.rs:238` — the doc comment on `visit_known_edge` blaming the
+  borrow checker describes the `'targets` borrow discipline accurately and
+  needs no Polonius caveat.
+- `src/cli/merge.rs` — clones construct the resolved `Cli` from borrowed
+  layers; owned construction of a new value, not clone-modify-writeback.
+- `build_l10n_audit.rs` — `find_matching_brace` and `find_raw_string_end`
+  return byte offsets into source text; the index is the result (a data id),
+  not a borrow dodge.
+- Test-suite `drop()` calls (environment guards, HTTP fixture teardown) are
+  semantic Drop effects, not borrow appeasement.
+
+## Clone counts
+
+Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where
+they live in `src/`):
+
+| Scope | Before | After |
+| --- | --- | --- |
+| `src/` total | 158 | 151 |
+| `src/graph_view/mod.rs` | 17 | 14 |
+| `src/ir/cycle.rs` (non-test) | 1 | 0 |
+| `src/stdlib/which/env.rs` | 4 | 1 |
+| `src/stdlib/collections.rs` | 4 | 3 |
+
+The scanner's clone-modify-writeback section was empty before and after the
+migration. The remaining graph_view clones construct owned keys for the two
+projection maps and owned metadata — data ownership, not workaround shapes.
+
+## Stabilization
+
+When `-Zpolonius=next` (or its successor) reaches stable Rust:
+
+1. Move `rust-toolchain.toml` to the stabilizing release and delete the
+   `[build] rustflags` entry in `.cargo/config.toml` plus the Makefile
+   `POLONIUS_FLAGS` variable.
+2. Re-declare `rust-version` in `Cargo.toml` at that release.
+3. Keep the `POLONIUS(...)` tags: they still explain why the shape exists;
+   reword "nightly-only" phrasing in the ADR and guides.
+
+## Anti-regression guidance
+
+The contract for new code and reviews (also summarized in `AGENTS.md` and
+the [developers' guide](developers-guide.md)):
+
+- Do not rewrite `POLONIUS(...)` sites into double lookups,
+  `entry(key.clone())`, or `contains_key` guards — the direct form is
+  intentional and compiler-verified.
+- Do not add defensive clones, id indirection, or eager error context to
+  satisfy a borrow error without first checking whether the natural
+  borrow-returning form compiles under the project toolchain.
+- Respect `POLONIUS-REFUSED(...)` tags: the named constraint (identity,
+  locks, aliasing, suspension points, thread boundaries) is permanent, and
+  "simplifying" those sites into reference-returning forms will not compile
+  or will break the design.
+- Classify any new borrow-centric API by compiling with and without the
+  flag, then record it here.

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -21,12 +21,13 @@ the oracle:
    per-module clone hotspots.
 
 Every change was compiled twice on `nightly-2026-06-25`: once with
-`-Zpolonius=next` (must pass) and once without (the outcome classifies the
-change). A failure without the flag proves the design genuinely depends on
-Polonius and the site is tagged `POLONIUS(...)`; success means the old form
-was habit rather than necessity and the improvement carries no toolchain
-caveat. Behavioural test suites were required to pass unchanged in either
-case.
+`-Zpolonius=next` (must pass) and once without. The no-flag compile exists
+only to classify the individual change: a failure proves the design
+genuinely depends on Polonius and the site is tagged `POLONIUS(...)`;
+success means the old form was habit rather than necessity and the
+improvement carries no toolchain caveat. The complete behavioural test
+suite runs under `-Zpolonius=next` — the tree's only supported
+configuration — and was required to pass unchanged after every change.
 
 ## Polonius-dependent sites
 

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -101,6 +101,19 @@ Polonius flag or avoid compiling the crate:
 - **Kani** and **Whitaker** run under their own toolchains but read the
   workspace `.cargo/config.toml` or the Makefile `RUSTFLAGS`, so they
   borrow-check with `-Zpolonius=next` and need no special handling.
+- **CI setup actions**: `actions-rust-lang/setup-rust-toolchain` exports
+  `RUSTFLAGS="-D warnings"` into the job environment when the variable is
+  unset, which shadows `.cargo/config.toml` for every later step. The
+  workflows therefore pre-set `RUSTFLAGS` (including `-Zpolonius=next`) at
+  job level — the action defers to an existing value — and the Makefile
+  recipes append `POLONIUS_FLAGS` to any ambient `RUSTFLAGS` as a second
+  line of defence. `cargo-llvm-cov` appends its instrumentation flags to
+  the ambient value, so coverage inherits the flag from the job
+  environment.
+- **cargo-mutants** (scheduled, informational) runs through the shared
+  `mutation-cargo.yml` workflow, which controls its own environment; if its
+  runs regress with E0499 at tagged sites, the shared workflow needs the
+  same `RUSTFLAGS` treatment.
 
 ## Clone counts
 

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -88,6 +88,13 @@ Scanner suspects that turned out not to be NLL residue:
 - Test-suite `drop()` calls (environment guards, HTTP fixture teardown) are
   semantic Drop effects, not borrow appeasement.
 
+The plumbing itself is contract-tested:
+`tests/polonius_toolchain_contract.rs` pins the dated-nightly channel, the
+`.cargo/config.toml` `build.rustflags` entry, the `POLONIUS_FLAGS` default
+and every RUSTFLAGS-setting Makefile recipe, and the `RUSTFLAGS` and
+toolchain presets in the CI, Netsukefile, coverage, and packaging
+workflows.
+
 ## Harness consequences
 
 Tooling that rebuilds the crate with its own flags must propagate the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,11 @@ minutes.
 
 Before beginning, ensure the following are available:
 
-- **Netsuke** installed (build from source with `cargo build --release` or
-  install via `cargo install netsuke`)
+- **Netsuke** installed — build from source inside a repository checkout with
+  `cargo build --release`, or follow the registry-install command in the
+  [users' guide](users-guide.md#install-netsuke). A bare `cargo install` is
+  unsupported: registry builds need the pinned nightly toolchain and the
+  Polonius borrow-checker flag supplied explicitly, as the guide shows.
 - **Ninja** build tool in the system PATH (install via the package manager,
   e.g., `apt install ninja-build` or `brew install ninja`)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,8 +10,9 @@ Before beginning, ensure the following are available:
 - **Netsuke** installed — install a prebuilt release binary with
   `cargo binstall netsuke` where
   [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
-  available, build from source inside a repository checkout with
-  `cargo build --release`, or follow the registry-install command in the
+  available, install from source inside a repository checkout with
+  `cargo install --path .` (which puts `netsuke` on `PATH` for the commands
+  below), or follow the registry-install command in the
   [users' guide](users-guide.md#install-netsuke). A bare `cargo install` is
   unsupported: registry builds need the pinned nightly toolchain and the
   Polonius borrow-checker flag supplied explicitly, as the guide shows.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,10 @@ minutes.
 
 Before beginning, ensure the following are available:
 
-- **Netsuke** installed — build from source inside a repository checkout with
+- **Netsuke** installed — install a prebuilt release binary with
+  `cargo binstall netsuke` where
+  [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
+  available, build from source inside a repository checkout with
   `cargo build --release`, or follow the registry-install command in the
   [users' guide](users-guide.md#install-netsuke). A bare `cargo install` is
   unsupported: registry builds need the pinned nightly toolchain and the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -16,9 +16,20 @@ also requires the dated Rust nightly toolchain pinned in
 checker (`-Zpolonius=next`); `rustup` installs it automatically inside a
 checkout.
 
-Netsuke v0.1.0 is available from crates.io. Registry installs build outside a
-repository checkout, so neither the pinned toolchain nor the Polonius flag is
-picked up automatically; supply both explicitly:
+Netsuke v0.1.0 is available from crates.io. Where
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
+available, prefer it: it fetches a prebuilt release binary and avoids the
+toolchain requirement below.
+
+<!-- tested-example: guide-binstall-install -->
+
+```sh
+cargo binstall netsuke
+```
+
+Building from the registry instead runs outside a repository checkout, so
+neither the pinned toolchain nor the Polonius flag is picked up
+automatically; supply both explicitly:
 
 <!-- tested-example: guide-crates-io-install -->
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,14 +11,20 @@ change before 1.0. Pin the Netsuke version in automated workflows.
 ## Install Netsuke
 
 Netsuke requires [Ninja](https://ninja-build.org/) on `PATH`. A source build
-also requires Rust 1.89 or later.
+also requires the dated Rust nightly toolchain pinned in
+`rust-toolchain.toml`, because Netsuke builds with the Polonius borrow
+checker (`-Zpolonius=next`); `rustup` installs it automatically inside a
+checkout.
 
-Netsuke v0.1.0 is available from crates.io:
+Netsuke v0.1.0 is available from crates.io. Registry installs build outside a
+repository checkout, so neither the pinned toolchain nor the Polonius flag is
+picked up automatically; supply both explicitly:
 
 <!-- tested-example: guide-crates-io-install -->
 
 ```sh
-cargo install netsuke
+rustup toolchain install nightly-2026-06-25
+RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke
 ```
 
 Pre-built installers are available from the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,7 @@
+# Netsuke builds with the Polonius alpha borrow-checking analysis
+# (`-Zpolonius=next`), which is nightly-only. The dated pin keeps builds
+# reproducible; see docs/adr-006-adopt-polonius-nightly-toolchain.md before
+# changing the channel.
 [toolchain]
-channel = "1.89.0"
+channel = "nightly-2026-06-25"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/graph_view/mod.rs
+++ b/src/graph_view/mod.rs
@@ -102,7 +102,12 @@ impl GraphView {
 
         for edge in &edges_seen {
             register_outputs(graph, edge, &mut registry, &mut node_metadata);
-            register_inputs_and_edges(edge, &mut registry, &mut edges);
+            EdgeRegistrar {
+                edge,
+                registry: &mut registry,
+                edges: &mut edges,
+            }
+            .register();
         }
 
         let nodes = registry
@@ -203,11 +208,7 @@ fn register_outputs(
         .actions
         .get(&edge.action_id)
         .and_then(|action| action.description.clone());
-    let outputs = edge
-        .explicit_outputs
-        .iter()
-        .chain(edge.implicit_outputs.iter());
-    for out in outputs {
+    for out in all_outputs(edge) {
         registry.insert_target(
             out,
             NodeKind::Target {
@@ -225,57 +226,70 @@ fn register_outputs(
     }
 }
 
-fn register_inputs_and_edges(
-    edge: &BuildEdge,
-    registry: &mut NodePathRegistry,
-    edges: &mut BTreeSet<EdgeView>,
-) {
-    let implicit: BTreeSet<&Utf8PathBuf> = edge.implicit_outputs.iter().collect();
-    for input in &edge.inputs {
-        registry.ensure_node_mut(input);
-        for out in edge
-            .explicit_outputs
-            .iter()
-            .chain(edge.implicit_outputs.iter())
-        {
+/// Every output produced by `edge`, explicit first, then implicit.
+fn all_outputs(edge: &BuildEdge) -> impl Iterator<Item = &Utf8PathBuf> {
+    edge.explicit_outputs
+        .iter()
+        .chain(edge.implicit_outputs.iter())
+}
+
+/// Registers the dependency nodes and edges contributed by one build edge.
+///
+/// Groups the edge with the mutable projection state so the per-class
+/// helpers share one borrow of the registry and edge set.
+struct EdgeRegistrar<'a> {
+    edge: &'a BuildEdge,
+    registry: &'a mut NodePathRegistry,
+    edges: &'a mut BTreeSet<EdgeView>,
+}
+
+impl EdgeRegistrar<'_> {
+    /// Register the edge's inputs and dependencies with their edge classes.
+    fn register(&mut self) {
+        self.register_inputs();
+        let edge = self.edge;
+        self.register_dependencies(&edge.implicit_deps, EdgeClass::ImplicitDep);
+        self.register_dependencies(&edge.order_only_deps, EdgeClass::OrderOnly);
+    }
+
+    /// Register explicit inputs, classifying edges into implicit outputs.
+    fn register_inputs(&mut self) {
+        let edge = self.edge;
+        let implicit: BTreeSet<&Utf8PathBuf> = edge.implicit_outputs.iter().collect();
+        for input in &edge.inputs {
+            self.registry.ensure_node_mut(input);
+            self.register_input_edges(input, &implicit);
+        }
+    }
+
+    /// Add one edge from `input` to every output, classified by whether the
+    /// output is implicit.
+    fn register_input_edges(&mut self, input: &Utf8PathBuf, implicit: &BTreeSet<&Utf8PathBuf>) {
+        for out in all_outputs(self.edge) {
             let class = if implicit.contains(out) {
                 EdgeClass::ImplicitOutput
             } else {
                 EdgeClass::Explicit
             };
-            edges.insert(EdgeView {
+            self.edges.insert(EdgeView {
                 from: input.clone(),
                 to: out.clone(),
                 class,
             });
         }
     }
-    for dep in &edge.implicit_deps {
-        registry.ensure_node_mut(dep);
-        for out in edge
-            .explicit_outputs
-            .iter()
-            .chain(edge.implicit_outputs.iter())
-        {
-            edges.insert(EdgeView {
-                from: dep.clone(),
-                to: out.clone(),
-                class: EdgeClass::ImplicitDep,
-            });
-        }
-    }
-    for dep in &edge.order_only_deps {
-        registry.ensure_node_mut(dep);
-        for out in edge
-            .explicit_outputs
-            .iter()
-            .chain(edge.implicit_outputs.iter())
-        {
-            edges.insert(EdgeView {
-                from: dep.clone(),
-                to: out.clone(),
-                class: EdgeClass::OrderOnly,
-            });
+
+    /// Register `deps` as source nodes with a `class` edge to every output.
+    fn register_dependencies(&mut self, deps: &[Utf8PathBuf], class: EdgeClass) {
+        for dep in deps {
+            self.registry.ensure_node_mut(dep);
+            for out in all_outputs(self.edge) {
+                self.edges.insert(EdgeView {
+                    from: dep.clone(),
+                    to: out.clone(),
+                    class,
+                });
+            }
         }
     }
 }

--- a/src/graph_view/mod.rs
+++ b/src/graph_view/mod.rs
@@ -265,31 +265,31 @@ impl EdgeRegistrar<'_> {
     /// Add one edge from `input` to every output, classified by whether the
     /// output is implicit.
     fn register_input_edges(&mut self, input: &Utf8PathBuf, implicit: &BTreeSet<&Utf8PathBuf>) {
-        for out in all_outputs(self.edge) {
-            let class = if implicit.contains(out) {
+        self.insert_edges(input, |out| {
+            if implicit.contains(out) {
                 EdgeClass::ImplicitOutput
             } else {
                 EdgeClass::Explicit
-            };
-            self.edges.insert(EdgeView {
-                from: input.clone(),
-                to: out.clone(),
-                class,
-            });
-        }
+            }
+        });
     }
 
     /// Register `deps` as source nodes with a `class` edge to every output.
     fn register_dependencies(&mut self, deps: &[Utf8PathBuf], class: EdgeClass) {
         for dep in deps {
             self.registry.ensure_node_mut(dep);
-            for out in all_outputs(self.edge) {
-                self.edges.insert(EdgeView {
-                    from: dep.clone(),
-                    to: out.clone(),
-                    class,
-                });
-            }
+            self.insert_edges(dep, |_| class);
+        }
+    }
+
+    /// Insert one edge from `from` to every output, classified by `class_for`.
+    fn insert_edges(&mut self, from: &Utf8PathBuf, class_for: impl Fn(&Utf8PathBuf) -> EdgeClass) {
+        for out in all_outputs(self.edge) {
+            self.edges.insert(EdgeView {
+                from: from.clone(),
+                to: out.clone(),
+                class: class_for(out),
+            });
         }
     }
 }

--- a/src/graph_view/mod.rs
+++ b/src/graph_view/mod.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::ir::{BuildEdge, BuildGraph};
 
@@ -96,16 +96,17 @@ impl GraphView {
     pub fn from_build_graph(graph: &BuildGraph) -> Self {
         let edges_seen = collect_unique_edges(graph);
 
-        let mut node_paths: BTreeMap<Utf8PathBuf, NodeKind> = BTreeMap::new();
+        let mut registry = NodePathRegistry::default();
         let mut node_metadata: BTreeMap<Utf8PathBuf, NodeMetadata> = BTreeMap::new();
         let mut edges: BTreeSet<EdgeView> = BTreeSet::new();
 
         for edge in &edges_seen {
-            register_outputs(graph, edge, &mut node_paths, &mut node_metadata);
-            register_inputs_and_edges(edge, &mut node_paths, &mut edges);
+            register_outputs(graph, edge, &mut registry, &mut node_metadata);
+            register_inputs_and_edges(edge, &mut registry, &mut edges);
         }
 
-        let nodes = node_paths
+        let nodes = registry
+            .into_inner()
             .into_iter()
             .map(|(path, kind)| {
                 let meta = node_metadata.remove(&path).unwrap_or_default();
@@ -137,6 +138,46 @@ struct NodeMetadata {
     description: Option<String>,
 }
 
+/// Registry mapping node paths to their [`NodeKind`] classification.
+///
+/// Wraps the projection's path map behind borrow-returning accessors so
+/// callers work with references instead of cloning keys defensively.
+#[derive(Debug, Default)]
+struct NodePathRegistry {
+    paths: BTreeMap<Utf8PathBuf, NodeKind>,
+}
+
+impl NodePathRegistry {
+    /// Return the registered kind for `path`, recording a [`NodeKind::Source`]
+    /// node when the path is not yet known.
+    ///
+    /// Performs a single lookup on the hit path and clones `path` only when
+    /// inserting. An existing registration (for example a target produced by
+    /// an earlier edge) is returned unchanged.
+    // POLONIUS(case-3): the `get_mut` loan escapes only via the early return,
+    // so the insertion below is legal under `-Zpolonius=next` but rejected by
+    // NLL (E0499). Verified both ways on nightly-2026-06-25. Do not rewrite
+    // into `entry(path.clone())` or a `contains_key` double lookup.
+    fn ensure_node_mut(&mut self, path: &Utf8Path) -> &mut NodeKind {
+        if let Some(kind) = self.paths.get_mut(path) {
+            return kind;
+        }
+        self.paths
+            .entry(path.to_owned())
+            .or_insert(NodeKind::Source)
+    }
+
+    /// Record `path` as a target node, replacing any existing registration.
+    fn insert_target(&mut self, path: &Utf8Path, kind: NodeKind) {
+        self.paths.insert(path.to_owned(), kind);
+    }
+
+    /// Consume the registry, yielding the sorted path map.
+    fn into_inner(self) -> BTreeMap<Utf8PathBuf, NodeKind> {
+        self.paths
+    }
+}
+
 /// Deduplicate the build edges referenced by [`BuildGraph::targets`].
 ///
 /// `BuildGraph::targets` maps every output path back to a (cloned) `BuildEdge`,
@@ -155,7 +196,7 @@ fn collect_unique_edges(graph: &BuildGraph) -> Vec<BuildEdge> {
 fn register_outputs(
     graph: &BuildGraph,
     edge: &BuildEdge,
-    node_paths: &mut BTreeMap<Utf8PathBuf, NodeKind>,
+    registry: &mut NodePathRegistry,
     node_metadata: &mut BTreeMap<Utf8PathBuf, NodeMetadata>,
 ) {
     let description = graph
@@ -167,8 +208,8 @@ fn register_outputs(
         .iter()
         .chain(edge.implicit_outputs.iter());
     for out in outputs {
-        node_paths.insert(
-            out.clone(),
+        registry.insert_target(
+            out,
             NodeKind::Target {
                 phony: edge.phony,
                 always: edge.always,
@@ -186,12 +227,12 @@ fn register_outputs(
 
 fn register_inputs_and_edges(
     edge: &BuildEdge,
-    node_paths: &mut BTreeMap<Utf8PathBuf, NodeKind>,
+    registry: &mut NodePathRegistry,
     edges: &mut BTreeSet<EdgeView>,
 ) {
     let implicit: BTreeSet<&Utf8PathBuf> = edge.implicit_outputs.iter().collect();
     for input in &edge.inputs {
-        node_paths.entry(input.clone()).or_insert(NodeKind::Source);
+        registry.ensure_node_mut(input);
         for out in edge
             .explicit_outputs
             .iter()
@@ -210,7 +251,7 @@ fn register_inputs_and_edges(
         }
     }
     for dep in &edge.implicit_deps {
-        node_paths.entry(dep.clone()).or_insert(NodeKind::Source);
+        registry.ensure_node_mut(dep);
         for out in edge
             .explicit_outputs
             .iter()
@@ -224,7 +265,7 @@ fn register_inputs_and_edges(
         }
     }
     for dep in &edge.order_only_deps {
-        node_paths.entry(dep.clone()).or_insert(NodeKind::Source);
+        registry.ensure_node_mut(dep);
         for out in edge
             .explicit_outputs
             .iter()

--- a/src/graph_view/tests.rs
+++ b/src/graph_view/tests.rs
@@ -357,3 +357,24 @@ fn golden_html_output_matches_snapshot() -> Result<()> {
     });
     Ok(())
 }
+
+#[rstest]
+#[case::miss_registers_source(None, NodeKind::Source)]
+#[case::hit_preserves_target(
+    Some(NodeKind::Target { phony: true, always: false }),
+    NodeKind::Target { phony: true, always: false },
+)]
+fn ensure_node_mut_registers_or_returns_existing(
+    #[case] pre_registered: Option<NodeKind>,
+    #[case] expected: NodeKind,
+) {
+    let mut registry = super::NodePathRegistry::default();
+    let path = p("out/app");
+    if let Some(kind) = pre_registered {
+        registry.insert_target(&path, kind);
+    }
+    assert_eq!(*registry.ensure_node_mut(&path), expected);
+    let paths = registry.into_inner();
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths.get(&path), Some(&expected));
+}

--- a/src/ir/cycle.rs
+++ b/src/ir/cycle.rs
@@ -169,13 +169,18 @@ impl<'targets> CycleDetector<'targets> {
 
     #[cfg(not(kani))]
     fn detect_targets(&mut self, search: CycleSearch) -> CycleVisitResult {
-        let mut nodes: Vec<Utf8PathBuf> = self.targets.keys().cloned().collect();
+        // Snapshot borrowed keys (not clones): the `'targets` map outlives
+        // the traversal, so the collected references stay valid while `self`
+        // is mutated. The collection exists for sorting, not to appease the
+        // borrow checker.
+        let mut nodes: Vec<&'targets Utf8Path> =
+            self.targets.keys().map(Utf8PathBuf::as_path).collect();
         // Sort keys for deterministic traversal order.  The O(n log n) cost is
         // negligible for typical build graphs (100–10 000 targets) and is
         // outweighed by the benefit of stable, reproducible error messages.
-        nodes.sort_by(|left, right| path_cmp(left.as_path(), right.as_path()));
+        nodes.sort_by(|left, right| path_cmp(left, right));
         for node in nodes {
-            let Some((target, _)) = target_entry_for_path(self.targets, node.as_path()) else {
+            let Some((target, _)) = target_entry_for_path(self.targets, node) else {
                 continue;
             };
             if self.is_visited(target) {

--- a/src/ir/from_manifest_support.rs
+++ b/src/ir/from_manifest_support.rs
@@ -51,6 +51,13 @@ pub(super) fn register_action(
             .with_arg("details", err.to_string()),
         source: err,
     })?;
+    // POLONIUS-REFUSED(id-is-data): the action hash is persistent IR
+    // identity — callers store it on every `BuildEdge` and it names the
+    // action in the generated Ninja file. Returning the owned hash (rather
+    // than a reference to an interned key) is a data-model choice, not an
+    // NLL workaround; the write-only `contains_key` guard below already
+    // compiles under NLL. Convert to a borrow-returning accessor only if
+    // callers develop a demonstrated need for the canonical interned value.
     if !actions.contains_key(hash.as_str()) {
         actions.insert(hash.clone(), action);
     }

--- a/src/stdlib/collections.rs
+++ b/src/stdlib/collections.rs
@@ -130,7 +130,7 @@ fn group_by_filter(values: &Value, attr: &str) -> Result<Value, Error> {
 
     for item in iter {
         let key_value = resolve_group_key(&item, attr)?;
-        groups.entry(key_value.clone()).or_default().push(item);
+        groups.entry(key_value).or_default().push(item);
     }
 
     Ok(Value::from_object(GroupedValues::new(groups)))

--- a/src/stdlib/collections.rs
+++ b/src/stdlib/collections.rs
@@ -27,6 +27,10 @@ struct GroupedValues {
 impl GroupedValues {
     fn new(groups: IndexMap<Value, Vec<Value>>) -> Self {
         let mut string_keys = IndexMap::new();
+        // POLONIUS-REFUSED(miss-dominant): group keys are unique, so this
+        // first-wins registration almost always inserts; the owned-key
+        // `entry` form pays nothing on the rare duplicate-label hit and a
+        // borrow-returning accessor would buy nothing here.
         for key in groups.keys() {
             if let Some(label) = key.as_str() {
                 string_keys

--- a/src/stdlib/which/cache.rs
+++ b/src/stdlib/which/cache.rs
@@ -93,6 +93,10 @@ impl WhichResolver {
         Ok(matches)
     }
 
+    // POLONIUS-REFUSED(lock-boundary): the hit is cloned out of the LRU
+    // because a reference cannot outlive the `MutexGuard`, and the resolver
+    // is shared across template evaluation sites. Owned returns at this
+    // boundary are an aliasing/synchronization constraint, not NLL residue.
     fn try_cache(&self, key: &CacheKey) -> Option<Vec<Utf8PathBuf>> {
         let mut guard = self.lock_cache();
         guard.get(key).map(|entry| entry.matches.clone())

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -58,15 +58,19 @@ impl EnvSnapshot {
     /// boundary where the data outlives the snapshot.
     pub(super) fn resolved_dirs(&self, mode: CwdMode) -> Vec<&Utf8Path> {
         let mut dirs = Vec::new();
-        if matches!(mode, CwdMode::Always) {
+        let mut cwd_added = matches!(mode, CwdMode::Always);
+        if cwd_added {
             dirs.push(self.cwd.as_path());
         }
         for entry in &self.entries {
             match entry {
                 PathEntry::Dir(path) => dirs.push(path.as_path()),
-                // `Always` has already prepended the working directory, so a
-                // current-directory PATH entry would only duplicate it.
-                PathEntry::CurrentDir if matches!(mode, CwdMode::Auto) => {
+                // The working directory is searched at most once: `Always`
+                // has already prepended it, and repeated current-directory
+                // PATH entries (for example `::/usr/bin::`) collapse to the
+                // first occurrence.
+                PathEntry::CurrentDir if matches!(mode, CwdMode::Auto) && !cwd_added => {
+                    cwd_added = true;
                     dirs.push(self.cwd.as_path());
                 }
                 PathEntry::CurrentDir => {}

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -50,16 +50,22 @@ impl EnvSnapshot {
         })
     }
 
-    pub(super) fn resolved_dirs(&self, mode: CwdMode) -> Vec<Utf8PathBuf> {
+    /// List the directories to search, borrowing them from the snapshot.
+    ///
+    /// Returns references rather than owned paths: the search loop and the
+    /// miss diagnostics only read the directories, and the error path copies
+    /// them into the owned [`super::resolve_error::ResolveError`] at the
+    /// boundary where the data outlives the snapshot.
+    pub(super) fn resolved_dirs(&self, mode: CwdMode) -> Vec<&Utf8Path> {
         let mut dirs = Vec::new();
         if matches!(mode, CwdMode::Always) {
-            dirs.push(self.cwd.clone());
+            dirs.push(self.cwd.as_path());
         }
         for entry in &self.entries {
             match entry {
-                PathEntry::Dir(path) => dirs.push(path.clone()),
+                PathEntry::Dir(path) => dirs.push(path.as_path()),
                 PathEntry::CurrentDir if matches!(mode, CwdMode::Always | CwdMode::Auto) => {
-                    dirs.push(self.cwd.clone());
+                    dirs.push(self.cwd.as_path());
                 }
                 PathEntry::CurrentDir => {}
             }

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -64,7 +64,9 @@ impl EnvSnapshot {
         for entry in &self.entries {
             match entry {
                 PathEntry::Dir(path) => dirs.push(path.as_path()),
-                PathEntry::CurrentDir if matches!(mode, CwdMode::Always | CwdMode::Auto) => {
+                // `Always` has already prepended the working directory, so a
+                // current-directory PATH entry would only duplicate it.
+                PathEntry::CurrentDir if matches!(mode, CwdMode::Auto) => {
                     dirs.push(self.cwd.as_path());
                 }
                 PathEntry::CurrentDir => {}

--- a/src/stdlib/which/lookup/mod.rs
+++ b/src/stdlib/which/lookup/mod.rs
@@ -234,7 +234,7 @@ struct HandleMissContext<'a> {
     env: &'a EnvSnapshot,
     command: &'a str,
     options: &'a WhichOptions,
-    dirs: &'a [Utf8PathBuf],
+    dirs: &'a [&'a Utf8Path],
     workspace_skips: &'a WorkspaceSkipList,
 }
 

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -318,11 +318,18 @@ fn cwd_always_lists_current_directory_once(
     let bin = workspace.root().join("bin");
     test_fs::create_dir_all(bin.as_std_path()).context("mkdir bin")?;
 
-    // The leading empty component parses as a current-directory PATH entry.
-    let path_value = std::env::join_paths([std::path::Path::new(""), bin.as_std_path()])
-        .context("join PATH entries")?;
+    // Empty components parse as current-directory PATH entries; the
+    // repeated blanks mirror a `::/usr/bin::`-style value and must collapse
+    // to a single working-directory search.
+    let path_value = std::env::join_paths([
+        std::path::Path::new(""),
+        std::path::Path::new(""),
+        bin.as_std_path(),
+        std::path::Path::new(""),
+    ])
+    .context("join PATH entries")?;
     let snapshot = EnvSnapshot::capture(Some(workspace.root()), Some(path_value.as_os_str()))
-        .context("capture env with a current-directory PATH entry")?;
+        .context("capture env with repeated current-directory PATH entries")?;
 
     let always_dirs = snapshot.resolved_dirs(CwdMode::Always);
     let always_cwd_count = always_dirs

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -174,11 +174,11 @@ fn relative_path_entries_resolve_against_cwd(
     let resolved_dirs = snapshot.resolved_dirs(CwdMode::Never);
 
     ensure!(
-        resolved_dirs.contains(&bin),
+        resolved_dirs.contains(&bin.as_path()),
         "resolved_dirs missing bin: {resolved_dirs:?}"
     );
     ensure!(
-        resolved_dirs.contains(&tools),
+        resolved_dirs.contains(&tools.as_path()),
         "resolved_dirs missing tools: {resolved_dirs:?}"
     );
 

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -309,3 +309,41 @@ fn resolve_direct_appends_pathext(workspace: Result<TempWorkspace>) -> Result<()
     );
     Ok(())
 }
+
+#[rstest]
+fn cwd_always_lists_current_directory_once(
+    #[from(workspace)] workspace_res: Result<TempWorkspace>,
+) -> Result<()> {
+    let workspace = workspace_res?;
+    let bin = workspace.root().join("bin");
+    test_fs::create_dir_all(bin.as_std_path()).context("mkdir bin")?;
+
+    // The leading empty component parses as a current-directory PATH entry.
+    let path_value = std::env::join_paths([std::path::Path::new(""), bin.as_std_path()])
+        .context("join PATH entries")?;
+    let snapshot = EnvSnapshot::capture(Some(workspace.root()), Some(path_value.as_os_str()))
+        .context("capture env with a current-directory PATH entry")?;
+
+    let always_dirs = snapshot.resolved_dirs(CwdMode::Always);
+    let always_cwd_count = always_dirs
+        .iter()
+        .filter(|dir| **dir == snapshot.cwd)
+        .count();
+    ensure!(
+        always_cwd_count == 1,
+        "Always should list the working directory exactly once: {always_dirs:?}"
+    );
+    ensure!(
+        always_dirs.first() == Some(&snapshot.cwd.as_path()),
+        "Always should search the working directory first: {always_dirs:?}"
+    );
+
+    let auto_dirs = snapshot.resolved_dirs(CwdMode::Auto);
+    let auto_cwd_count = auto_dirs.iter().filter(|dir| **dir == snapshot.cwd).count();
+    ensure!(
+        auto_cwd_count == 1,
+        "Auto should honour the PATH-listed working directory once: {auto_dirs:?}"
+    );
+
+    Ok(())
+}

--- a/src/stdlib/which/resolve_error.rs
+++ b/src/stdlib/which/resolve_error.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, io};
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use walkdir;
 
 use super::options::CwdMode;
@@ -108,10 +108,10 @@ impl std::error::Error for ResolveError {
 ///
 /// `command` is the lookup key, `dirs` is the searched directory set, and
 /// `mode` records how the current directory contributed to the search.
-pub(super) fn not_found(command: &str, dirs: &[Utf8PathBuf], mode: CwdMode) -> ResolveError {
+pub(super) fn not_found(command: &str, dirs: &[&Utf8Path], mode: CwdMode) -> ResolveError {
     ResolveError::NotFound {
         command: command.to_owned(),
-        dirs: dirs.to_vec(),
+        dirs: dirs.iter().map(|dir| dir.to_path_buf()).collect(),
         cwd_mode: mode,
     }
 }

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -190,6 +190,11 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
     );
     ensure!(readme.body == expected, "README source install drifted");
     ensure!(guide.body == expected, "user guide source install drifted");
+    assert_windows_setup_examples()
+}
+
+/// Check the documented Windows help, PATH, and staging contracts.
+fn assert_windows_setup_examples() -> Result<()> {
     let windows = documented_example("guide-windows-help")?;
     ensure!(windows.body == "Get-Help Netsuke -Full\n", "help drifted");
     let windows_path = documented_example("guide-windows-path")?;

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -154,7 +154,13 @@ fn documented_first_run_flow_builds(
 fn installation_examples_match_source_and_release_contracts() -> Result<()> {
     let readme_release = documented_example("readme-crates-io-install")?;
     let guide_release = documented_example("guide-crates-io-install")?;
-    let expected_release = "cargo install netsuke\n";
+    // Registry installs run outside a checkout, so the packaged source sees
+    // neither rust-toolchain.toml nor .cargo/config.toml; the documented
+    // command must select the pinned nightly and the Polonius flag itself.
+    let expected_release = concat!(
+        "rustup toolchain install nightly-2026-06-25\n",
+        "RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke\n"
+    );
     ensure!(readme_release.body == expected_release, "README drifted");
     ensure!(guide_release.body == expected_release, "user guide drifted");
     let expected_release_details = [

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -152,6 +152,21 @@ fn documented_first_run_flow_builds(
 
 #[test]
 fn installation_examples_match_source_and_release_contracts() -> Result<()> {
+    assert_release_installation_contract()?;
+    let readme = documented_example("readme-source-install")?;
+    let guide = documented_example("guide-source-install")?;
+    let expected = concat!(
+        "git clone https://github.com/leynos/netsuke.git\n",
+        "cd netsuke\n",
+        "cargo install --path .\n"
+    );
+    ensure!(readme.body == expected, "README source install drifted");
+    ensure!(guide.body == expected, "user guide source install drifted");
+    assert_windows_setup_examples()
+}
+
+/// Check the documented crates.io install command and release details.
+fn assert_release_installation_contract() -> Result<()> {
     let readme_release = documented_example("readme-crates-io-install")?;
     let guide_release = documented_example("guide-crates-io-install")?;
     // Registry installs run outside a checkout, so the packaged source sees
@@ -181,16 +196,7 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
             );
         }
     }
-    let readme = documented_example("readme-source-install")?;
-    let guide = documented_example("guide-source-install")?;
-    let expected = concat!(
-        "git clone https://github.com/leynos/netsuke.git\n",
-        "cd netsuke\n",
-        "cargo install --path .\n"
-    );
-    ensure!(readme.body == expected, "README source install drifted");
-    ensure!(guide.body == expected, "user guide source install drifted");
-    assert_windows_setup_examples()
+    Ok(())
 }
 
 /// Check the documented Windows help, PATH, and staging contracts.

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -18,6 +18,7 @@ use test_support::netsuke::{NetsukeRun, run_netsuke_in};
 
 const EXPECTED_EXAMPLE_IDS: &[&str] = &[
     "guide-accessible-output",
+    "guide-binstall-install",
     "guide-cli-usage",
     "guide-command-available-manifest",
     "guide-complete-manifest",
@@ -36,6 +37,7 @@ const EXPECTED_EXAMPLE_IDS: &[&str] = &[
     "guide-windows-help",
     "guide-windows-help-install",
     "guide-windows-path",
+    "readme-binstall-install",
     "readme-crates-io-install",
     "readme-first-build-commands",
     "readme-first-build-manifest",
@@ -170,26 +172,27 @@ fn registry_install_examples_pin_toolchain_and_polonius() -> Result<()> {
     // Registry installs build outside a checkout, where neither
     // rust-toolchain.toml nor .cargo/config.toml applies, so every tagged
     // example installing from crates.io must select the pinned nightly and
-    // pass the Polonius flag itself. `cargo install --path .` examples run
-    // inside a checkout and are exempt.
+    // pass the Polonius flag itself. `cargo binstall` fetches a prebuilt
+    // binary and `cargo install --path .` runs inside a checkout, so both
+    // are exempt.
     let mut registry_install_ids = Vec::new();
     for example in load_documented_examples()? {
-        if !example.body.contains("install netsuke") {
-            continue;
+        for line in example.body.lines() {
+            if !line.contains("install netsuke") || line.contains("binstall") {
+                continue;
+            }
+            ensure!(
+                line.contains("cargo +nightly-2026-06-25 install netsuke"),
+                "{id} must install with the pinned nightly toolchain: {line}",
+                id = example.id
+            );
+            ensure!(
+                line.contains("RUSTFLAGS=-Zpolonius=next"),
+                "{id} must pass the Polonius borrow-checker flag: {line}",
+                id = example.id
+            );
+            registry_install_ids.push(example.id.clone());
         }
-        ensure!(
-            example
-                .body
-                .contains("cargo +nightly-2026-06-25 install netsuke"),
-            "{id} must install with the pinned nightly toolchain",
-            id = example.id
-        );
-        ensure!(
-            example.body.contains("RUSTFLAGS=-Zpolonius=next"),
-            "{id} must pass the Polonius borrow-checker flag",
-            id = example.id
-        );
-        registry_install_ids.push(example.id);
     }
     ensure!(
         registry_install_ids.len() >= 2,
@@ -208,6 +211,17 @@ fn registry_install_examples_pin_toolchain_and_polonius() -> Result<()> {
 
 /// Check the documented crates.io install command and release details.
 fn assert_release_installation_contract() -> Result<()> {
+    let readme_binstall = documented_example("readme-binstall-install")?;
+    let guide_binstall = documented_example("guide-binstall-install")?;
+    let expected_binstall = "cargo binstall netsuke\n";
+    ensure!(
+        readme_binstall.body == expected_binstall,
+        "README binstall drifted"
+    );
+    ensure!(
+        guide_binstall.body == expected_binstall,
+        "user guide binstall drifted"
+    );
     let readme_release = documented_example("readme-crates-io-install")?;
     let guide_release = documented_example("guide-crates-io-install")?;
     // Registry installs run outside a checkout, so the packaged source sees

--- a/tests/documentation_examples_tests.rs
+++ b/tests/documentation_examples_tests.rs
@@ -165,6 +165,47 @@ fn installation_examples_match_source_and_release_contracts() -> Result<()> {
     assert_windows_setup_examples()
 }
 
+#[test]
+fn registry_install_examples_pin_toolchain_and_polonius() -> Result<()> {
+    // Registry installs build outside a checkout, where neither
+    // rust-toolchain.toml nor .cargo/config.toml applies, so every tagged
+    // example installing from crates.io must select the pinned nightly and
+    // pass the Polonius flag itself. `cargo install --path .` examples run
+    // inside a checkout and are exempt.
+    let mut registry_install_ids = Vec::new();
+    for example in load_documented_examples()? {
+        if !example.body.contains("install netsuke") {
+            continue;
+        }
+        ensure!(
+            example
+                .body
+                .contains("cargo +nightly-2026-06-25 install netsuke"),
+            "{id} must install with the pinned nightly toolchain",
+            id = example.id
+        );
+        ensure!(
+            example.body.contains("RUSTFLAGS=-Zpolonius=next"),
+            "{id} must pass the Polonius borrow-checker flag",
+            id = example.id
+        );
+        registry_install_ids.push(example.id);
+    }
+    ensure!(
+        registry_install_ids.len() >= 2,
+        "expected registry-install examples in the README and users' guide, found {registry_install_ids:?}"
+    );
+    // The quickstart carries no tested-example fences, so guard its prose
+    // against reintroducing an unsupported bare registry install.
+    let quickstart =
+        test_fs::read_to_string("docs/quickstart.md").context("read docs/quickstart.md")?;
+    ensure!(
+        !quickstart.contains("cargo install netsuke"),
+        "docs/quickstart.md must defer to the users' guide install command"
+    );
+    Ok(())
+}
+
 /// Check the documented crates.io install command and release details.
 fn assert_release_installation_contract() -> Result<()> {
     let readme_release = documented_example("readme-crates-io-install")?;

--- a/tests/kani_cfg_ui_tests.rs
+++ b/tests/kani_cfg_ui_tests.rs
@@ -12,10 +12,34 @@ use std::{
 };
 
 /// Verify repository policy files used by the `cfg(kani)` compile contract.
+///
+/// The fixture is compiled with the workspace `rustc` and then executed, so
+/// its assertions run against the checked-in policy files. Trybuild
+/// previously drove this case, but trybuild discards ambient `RUSTFLAGS`
+/// and workspace `build.rustflags`, so it rebuilt the `netsuke` dependency
+/// without `-Zpolonius=next` and rejected the crate's `POLONIUS(...)`
+/// sites; the fixture needs no dependencies, so a direct compile preserves
+/// the contract (see docs/polonius.md).
 #[test]
-fn trybuild_validates_kani_cfg_policy_sources() {
-    let cases = trybuild::TestCases::new();
-    cases.pass("tests/ui/cfg_kani_policy_pass.rs");
+fn compiled_fixture_validates_kani_cfg_policy_sources() -> io::Result<()> {
+    let output_dir = tempfile::tempdir()?;
+    let binary = output_dir.path().join("cfg-kani-policy-pass");
+    let compile = compile_ui_fixture("tests/ui/cfg_kani_policy_pass.rs", &binary)?;
+    if !compile.status.success() {
+        return Err(io::Error::other(format!(
+            "policy fixture should compile:\n{}",
+            stderr(&compile),
+        )));
+    }
+
+    let run = Command::new(&binary).output()?;
+    if !run.status.success() {
+        return Err(io::Error::other(format!(
+            "policy fixture assertions should pass:\n{}",
+            stderr(&run),
+        )));
+    }
+    Ok(())
 }
 
 /// `cfg(kani)` compiles when the expected check-cfg declaration is active.
@@ -55,10 +79,13 @@ fn unknown_cfg_is_rejected_by_compile_time_policy() -> io::Result<()> {
 }
 
 fn rustc_with_kani_check_cfg(source: &str) -> io::Result<Output> {
+    let output_dir = tempfile::tempdir()?;
+    compile_ui_fixture(source, &output_dir.path().join("ui-test-bin"))
+}
+
+fn compile_ui_fixture(source: &str, output_path: &Path) -> io::Result<Output> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let source_path = manifest_dir.join(source);
-    let output_dir = tempfile::tempdir()?;
-    let output_path = output_dir.path().join("ui-test-bin");
 
     Command::new(rustc())
         .arg("--edition=2024")

--- a/tests/makefile_test_target.rs
+++ b/tests/makefile_test_target.rs
@@ -3,7 +3,8 @@
 //! `make test` is the single command local development and continuous
 //! integration (CI) both run. These tests pin the runner contract it encodes:
 //! non-doctest tests go through cargo-nextest, doctests run separately because
-//! nextest cannot execute them, and both passes deny warnings. They also assert
+//! nextest cannot execute them, and both passes deny warnings and re-state
+//! the Polonius flag that an inherited RUSTFLAGS would otherwise strip. They also assert
 //! that the checked-in nextest configuration still declares the narrow
 //! serialisation group the environment-mutating suites depend on.
 
@@ -124,8 +125,8 @@ fn behavioural_make_test_composes_the_nextest_and_doctest_passes() -> Result<()>
         "test-nextest should enable all features, found {nextest_recipe:?}"
     );
     ensure!(
-        nextest_recipe.contains(r#"RUSTFLAGS="-D warnings""#),
-        "test-nextest should deny warnings, found {nextest_recipe:?}"
+        nextest_recipe.contains(r#"RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)""#),
+        "test-nextest should deny warnings and enable Polonius, found {nextest_recipe:?}"
     );
 
     let doctest_recipe =
@@ -139,8 +140,8 @@ fn behavioural_make_test_composes_the_nextest_and_doctest_passes() -> Result<()>
         "doctests cannot run under nextest, found {doctest_recipe:?}"
     );
     ensure!(
-        doctest_recipe.contains(r#"RUSTFLAGS="-D warnings""#),
-        "doctest should deny warnings, found {doctest_recipe:?}"
+        doctest_recipe.contains(r#"RUSTFLAGS="-D warnings $(POLONIUS_FLAGS)""#),
+        "doctest should deny warnings and enable Polonius, found {doctest_recipe:?}"
     );
     Ok(())
 }

--- a/tests/polonius_toolchain_contract.rs
+++ b/tests/polonius_toolchain_contract.rs
@@ -1,0 +1,196 @@
+//! Contract tests pinning the Polonius toolchain plumbing.
+//!
+//! The tree only borrow-checks under `-Zpolonius=next` on the dated nightly
+//! pinned in `rust-toolchain.toml` (see ADR-006 and docs/polonius.md). An
+//! inherited `RUSTFLAGS` environment variable overrides the
+//! `.cargo/config.toml` `build.rustflags` table, so every Makefile recipe
+//! that sets `RUSTFLAGS` and every workflow that presets it must re-state
+//! the flag. These tests fail when any layer drops the pin or the flag, so
+//! a regression cannot reach CI as a confusing borrow-check error.
+
+use anyhow::{Context, Result, ensure};
+use camino::Utf8Path;
+use cap_std::{ambient_authority, fs_utf8::Dir};
+use rstest::rstest;
+use serde_yaml::Value as YamlValue;
+use toml::Value as TomlValue;
+
+const POLONIUS_FLAG: &str = "-Zpolonius=next";
+const POLONIUS_VAR: &str = "$(POLONIUS_FLAGS)";
+
+/// Opens the repository root as a capability-scoped directory handle.
+fn repo_root() -> Result<Dir> {
+    Dir::open_ambient_dir(env!("CARGO_MANIFEST_DIR"), ambient_authority())
+        .context("open the repository root as a capability-scoped directory")
+}
+
+fn read_repo_file(relative: &Utf8Path) -> Result<String> {
+    repo_root()?
+        .read_to_string(relative)
+        .with_context(|| format!("{relative} should be readable"))
+}
+
+/// Returns the dated nightly channel pinned in `rust-toolchain.toml`.
+///
+/// The workflow assertions compare against this value so a future pin move
+/// only has to update `rust-toolchain.toml` and the workflows together.
+fn pinned_toolchain() -> Result<String> {
+    let manifest: TomlValue = read_repo_file(Utf8Path::new("rust-toolchain.toml"))?
+        .parse()
+        .context("parse rust-toolchain.toml")?;
+    let channel = manifest
+        .get("toolchain")
+        .and_then(|toolchain| toolchain.get("channel"))
+        .and_then(TomlValue::as_str)
+        .context("rust-toolchain.toml should pin a toolchain channel")?;
+    Ok(channel.to_owned())
+}
+
+/// Returns the tab-indented recipe lines for `target`, joined by newlines.
+fn target_recipe(contents: &str, target: &str) -> Option<String> {
+    let mut lines = contents.lines().skip_while(|line| {
+        line.starts_with(['\t', ' ', '#', '.'])
+            || line
+                .split_once(':')
+                .is_none_or(|(name, rest)| name.trim() != target || rest.starts_with('='))
+    });
+    lines.next()?;
+    let recipe: Vec<&str> = lines
+        .take_while(|line| line.starts_with('\t') || line.trim().is_empty())
+        .filter(|line| line.starts_with('\t'))
+        .collect();
+    Some(recipe.join("\n"))
+}
+
+/// Walks nested YAML mappings and returns the string at the key path.
+fn yaml_str<'a>(value: &'a YamlValue, keys: &[&str]) -> Option<&'a str> {
+    let mut current = value;
+    for key in keys {
+        current = current.get(key)?;
+    }
+    current.as_str()
+}
+
+#[test]
+fn rust_toolchain_pins_dated_nightly() -> Result<()> {
+    let channel = pinned_toolchain()?;
+    ensure!(
+        channel.starts_with("nightly-20"),
+        "rust-toolchain.toml should pin a dated nightly, found {channel:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn cargo_config_enables_polonius_by_default() -> Result<()> {
+    let config: TomlValue = read_repo_file(Utf8Path::new(".cargo/config.toml"))?
+        .parse()
+        .context("parse .cargo/config.toml")?;
+    let rustflags = config
+        .get("build")
+        .and_then(|build| build.get("rustflags"))
+        .and_then(TomlValue::as_array)
+        .context(".cargo/config.toml should declare build.rustflags")?;
+    ensure!(
+        rustflags
+            .iter()
+            .any(|flag| flag.as_str() == Some(POLONIUS_FLAG)),
+        "build.rustflags should enable {POLONIUS_FLAG}, found {rustflags:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn makefile_declares_the_polonius_flags_variable() -> Result<()> {
+    let makefile = read_repo_file(Utf8Path::new("Makefile"))?;
+    ensure!(
+        makefile
+            .lines()
+            .any(|line| line.trim() == format!("POLONIUS_FLAGS ?= {POLONIUS_FLAG}")),
+        "the Makefile should default POLONIUS_FLAGS to {POLONIUS_FLAG}"
+    );
+    Ok(())
+}
+
+#[rstest]
+#[case::test_nextest("test-nextest")]
+#[case::doctest("doctest")]
+#[case::typecheck("typecheck")]
+#[case::lint_clippy("lint-clippy")]
+#[case::lint_whitaker("lint-whitaker")]
+#[case::build_binary("target/%/$(APP)")]
+fn rustflags_setting_recipes_restate_polonius(#[case] target: &str) -> Result<()> {
+    let makefile = read_repo_file(Utf8Path::new("Makefile"))?;
+    let recipe = target_recipe(&makefile, target)
+        .with_context(|| format!("the Makefile should declare a {target} target"))?;
+    let rustflags_lines: Vec<&str> = recipe
+        .lines()
+        .filter(|line| line.contains("RUSTFLAGS="))
+        .collect();
+    ensure!(
+        !rustflags_lines.is_empty(),
+        "{target} should set RUSTFLAGS, found {recipe:?}"
+    );
+    for line in rustflags_lines {
+        ensure!(
+            line.contains(POLONIUS_VAR),
+            "{target} sets RUSTFLAGS without {POLONIUS_VAR}: {line:?}"
+        );
+    }
+    Ok(())
+}
+
+#[rstest]
+#[case::ci(".github/workflows/ci.yml", "build-test", true)]
+#[case::netsukefile(".github/workflows/netsukefile-test.yml", "netsukefile", true)]
+#[case::coverage(".github/workflows/coverage-main.yml", "coverage-upload", false)]
+#[case::packaging(".github/workflows/build-and-package.yml", "build", false)]
+fn workflows_preset_polonius_rustflags(
+    #[case] path: &str,
+    #[case] job: &str,
+    #[case] pins_toolchain_env: bool,
+) -> Result<()> {
+    let workflow: YamlValue = serde_yaml::from_str(&read_repo_file(Utf8Path::new(path))?)
+        .with_context(|| format!("parse {path}"))?;
+    let rustflags = yaml_str(&workflow, &["jobs", job, "env", "RUSTFLAGS"])
+        .with_context(|| format!("{path} job {job} should preset RUSTFLAGS"))?;
+    ensure!(
+        rustflags.contains(POLONIUS_FLAG),
+        "{path} job {job} presets RUSTFLAGS without {POLONIUS_FLAG}: {rustflags:?}"
+    );
+    if pins_toolchain_env {
+        let expected = pinned_toolchain()?;
+        let toolchain = yaml_str(&workflow, &["jobs", job, "env", "NETSUKE_RUST_TOOLCHAIN"])
+            .with_context(|| format!("{path} job {job} should pin NETSUKE_RUST_TOOLCHAIN"))?;
+        ensure!(
+            toolchain == expected,
+            "{path} job {job} pins {toolchain:?}, but rust-toolchain.toml pins {expected:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn coverage_workflow_setup_matches_the_pinned_toolchain() -> Result<()> {
+    let path = ".github/workflows/coverage-main.yml";
+    let workflow: YamlValue = serde_yaml::from_str(&read_repo_file(Utf8Path::new(path))?)
+        .with_context(|| format!("parse {path}"))?;
+    let steps = workflow
+        .get("jobs")
+        .and_then(|jobs| jobs.get("coverage-upload"))
+        .and_then(|job| job.get("steps"))
+        .and_then(YamlValue::as_sequence)
+        .with_context(|| format!("{path} should declare coverage-upload steps"))?;
+    let setup = steps
+        .iter()
+        .find(|step| yaml_str(step, &["name"]) == Some("Setup Rust"))
+        .with_context(|| format!("{path} should include a Setup Rust step"))?;
+    let toolchain = yaml_str(setup, &["with", "toolchain"])
+        .with_context(|| format!("{path} Setup Rust should request a toolchain"))?;
+    let expected = pinned_toolchain()?;
+    ensure!(
+        toolchain == expected,
+        "{path} requests {toolchain:?}, but rust-toolchain.toml pins {expected:?}"
+    );
+    Ok(())
+}

--- a/tests/ui/cfg_kani_policy_pass.rs
+++ b/tests/ui/cfg_kani_policy_pass.rs
@@ -1,4 +1,4 @@
-//! Trybuild pass case for repository-level Kani cfg policy.
+//! Compile-and-run pass case for repository-level Kani cfg policy.
 
 const CARGO_TOML: &str = include_str!("../../Cargo.toml");
 const MAKEFILE: &str = include_str!("../../Makefile");


### PR DESCRIPTION
## Summary

This branch migrates Netsuke to the Polonius alpha borrow-checking analysis (`-Zpolonius=next`) and uses the migration to evolve internal APIs towards a borrow-centric ownership model (Mode E: model evolution).

Closes #465.

The dated nightly `nightly-2026-06-25` is pinned in [`rust-toolchain.toml`](https://github.com/leynos/netsuke/blob/f6769c4/rust-toolchain.toml), and the flag flows through every build path: [`.cargo/config.toml`](https://github.com/leynos/netsuke/blob/f6769c4/.cargo/config.toml) for plain Cargo, rust-analyzer, and `cargo kani`; the `POLONIUS_FLAGS` variable in the [`Makefile`](https://github.com/leynos/netsuke/blob/f6769c4/Makefile) for recipes that set `RUSTFLAGS`; and the pinned toolchain in [`ci.yml`](https://github.com/leynos/netsuke/blob/f6769c4/.github/workflows/ci.yml), [`netsukefile-test.yml`](https://github.com/leynos/netsuke/blob/f6769c4/.github/workflows/netsukefile-test.yml), and [`coverage-main.yml`](https://github.com/leynos/netsuke/blob/f6769c4/.github/workflows/coverage-main.yml). The stable/MSRV CI matrices are removed and `rust-version` is dropped from `Cargo.toml`, since Cargo cannot express a nightly requirement; [ADR-006](https://github.com/leynos/netsuke/blob/f6769c4/docs/adr-006-adopt-polonius-nightly-toolchain.md) records the policy decision and its release consequences.

The `nll-to-polonius` two-pass audit was run with the compiler as the oracle; every change was verified with and without the flag:

- **Polonius-dependent** — `NodePathRegistry::ensure_node_mut` in [`src/graph_view/mod.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/graph_view/mod.rs) replaces the three `entry(path.clone()).or_insert(...)` sites with a `&mut NodeKind`-returning accessor: one lookup on hits, a path clone only on insertion. It passes with `-Zpolonius=next` and is rejected by NLL with E0499 (tagged `POLONIUS(case-3)`).
- **Pass-both evolutions** (habit, no toolchain caveat) — `group_by` consumes its key instead of cloning ([`src/stdlib/collections.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/stdlib/collections.rs)); cycle detection snapshots borrowed keys ([`src/ir/cycle.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/ir/cycle.rs)); the `which` resolver borrows its search directories and copies them into the owned error only at the miss boundary ([`src/stdlib/which/env.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/stdlib/which/env.rs)).
- **Refusals** — the action hash stays owned as persistent IR identity (`POLONIUS-REFUSED(id-is-data)` in [`src/ir/from_manifest_support.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/ir/from_manifest_support.rs)), cache hits stay cloned out of the LRU mutex (`lock-boundary`), and the miss-dominant string-key registration keeps its `entry` form.

Clone counts fell from 158 to 151 in `src/` (graph_view 17→14); the clone-modify-writeback scan was empty before and after.

## Review walkthrough

- Start with [`docs/polonius.md`](https://github.com/leynos/netsuke/blob/f6769c4/docs/polonius.md) for the complete audit record: rewritten sites, pass-both evolutions, refusals, non-candidates, clone counts, and the stabilization checklist.
- Then review [`src/graph_view/mod.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/graph_view/mod.rs) for the Polonius-dependent registry and [`src/graph_view/tests.rs`](https://github.com/leynos/netsuke/blob/f6769c4/src/graph_view/tests.rs) for the new hit/miss accessor test.
- Review [ADR-006](https://github.com/leynos/netsuke/blob/f6769c4/docs/adr-006-adopt-polonius-nightly-toolchain.md) with the toolchain wiring (`rust-toolchain.toml`, `.cargo/config.toml`, `Makefile`, workflows).
- Note [`tests/kani_cfg_ui_tests.rs`](https://github.com/leynos/netsuke/blob/f6769c4/tests/kani_cfg_ui_tests.rs): trybuild discards workspace rustflags and rebuilt the crate under NLL, so the policy fixture is now compiled and run directly with the workspace `rustc`; its assertions are unchanged and the `trybuild` dev-dependency is removed.
- Finish with the anti-regression guidance in [`AGENTS.md`](https://github.com/leynos/netsuke/blob/f6769c4/AGENTS.md) and the [developers' guide](https://github.com/leynos/netsuke/blob/f6769c4/docs/developers-guide.md).

## Validation

- `make check-fmt`, `make lint` (rustdoc, Clippy, Whitaker), `make test`, `make markdownlint`, and `make nixie` all pass under the pinned nightly with `-Zpolonius=next`.
- `cargo check` without the flag fails only at the tagged `POLONIUS(case-3)` site with E0499, confirming the design genuinely depends on Polonius; each pass-both evolution was verified to compile under plain NLL.
- `coderabbit review --agent` ran after each milestone (toolchain adoption; API evolution and documentation) with zero findings on both passes.

## Notes

- Whitaker lints under its own pinned Dylint toolchain by design and accepts the Polonius flag; Kani reads the workspace `.cargo/config.toml`, so `cargo kani` borrow-checks with the same analysis.
- The changelog records pending changes under an "Unreleased" heading; these entries roll into the next release entry when it is cut.

## References

- Lody session: <https://lody.ai/leynos/sessions/5a7283cd-18c6-43de-9951-1b7436d2f852>

## Summary by Sourcery

Adopt a Polonius-based, borrow-centric ownership model and pin the project to a nightly Rust toolchain, updating graph view APIs, tooling, and documentation accordingly.

Enhancements:
- Introduce a NodePathRegistry for graph view node registration so callers work with borrow-returning accessors instead of cloning paths defensively.
- Refine borrowing patterns in cycle detection and stdlib utilities (group_by and which resolver) to snapshot and pass path data by reference where possible while documenting deliberate owned-value refusals.

Build:
- Pin the Rust toolchain to nightly-2026-06-25 in rust-toolchain.toml and enable -Zpolonius=next globally via .cargo/config.toml and Makefile POLONIUS_FLAGS.
- Remove the rust-version field from Cargo.toml so rust-toolchain.toml becomes the single source of truth for the compiler contract.

CI:
- Simplify CI and netsukefile workflows to run exclusively on the pinned nightly toolchain with Polonius enabled and adjust caches and coverage upload conditions accordingly.
- Update the coverage workflow to build and measure coverage on the same pinned nightly toolchain as the rest of CI.

Documentation:
- Add ADR-006 and a detailed polonius.md migration log describing the Polonius adoption, audit method, and stabilization plan.
- Extend AGENTS.md, the developers guide, netsuke-design, README, and contents to document the Polonius-based toolchain requirement and borrow-centric design guidelines.
- Introduce a CHANGELOG with an Unreleased section capturing the Polonius migration and related changes.

Tests:
- Replace the trybuild-based Kani cfg policy test with a direct compile-and-run harness that uses the workspace rustc and remove the trybuild dev-dependency.
- Add targeted tests for the new NodePathRegistry accessor semantics and update which resolver tests to use borrowed directory paths.

Chores:
- Add a project-level Cargo.lock and wire in a new .cargo/config.toml to centralize build-time Rust flags.