### PR TITLE
Give the workspace fallback switch an injectable env seam (#487)

### DIFF
--- a/docs/adr-008-environment-seam-taxonomy.md
+++ b/docs/adr-008-environment-seam-taxonomy.md
@@ -16,10 +16,9 @@ Accepted.
 that value as an argument rather than read the process directly. Several
 callers have satisfied that mandate with different shapes — a bare closure
 parameter, a mockable trait object, a shared `Arc`-wrapped reader — chosen
-independently as each site migrated off the disallowed calls under issues
-484, 488, and 493. Without a stated taxonomy, a future migration has no
-way to pick the right shape for a new boundary, and a reviewer lacks a
-yardstick for
+independently as each site migrated off the disallowed calls under issues 484,
+488, and 493. Without a stated taxonomy, a future migration has no way to pick
+the right shape for a new boundary, and a reviewer lacks a yardstick for
 whether a proposed seam is over- or under-engineered for its call-site count.
 
 Netsuke's design record (`docs/netsuke-design.md`) does not describe these
@@ -32,111 +31,106 @@ seams. This ADR fills that gap and gives `docs/developers-guide.md`'s
 Adopt three seam shapes, selected by how many call sites a boundary has and
 whether it is expected to grow:
 
-1. **Narrow closure seams**, for a single variable read by a single caller.
+- **Narrow closure seams**, for a single variable read by a single caller.
    The module owns a private function that takes an
    `FnOnce(&str) -> Result<String, env::VarError>` (or the equivalent
    `OsString`-typed form) instead of calling `std::env::var` itself. Examples:
-   `workspace_fallback_enabled_with` in
-   `src/stdlib/which/workspace_switch.rs` (the `NETSUKE_WHICH_WORKSPACE`
-   opt-out switch), and the `resolve_with` variants in `output_mode.rs` and
-   `output_prefs.rs` described earlier in the developer guide. A related but
-   distinct pattern injects a resolved *value* rather than a closure: the
-   `stdlib::path` home-directory resolver's `HomeDirectory` enum
-   (`Ambient`/`Missing`/`Explicit`) lets a caller supply the home directory
-   directly, so the process-reading `home_from_env` ladder in
+   `workspace_fallback_enabled_with` in `src/stdlib/which/workspace_switch.rs`
+   (the `NETSUKE_WHICH_WORKSPACE` opt-out switch), and the `resolve_with`
+   variants in `output_mode.rs` and `output_prefs.rs` described earlier in the
+   developer guide. A related but distinct pattern injects a resolved *value*
+   rather than a closure: the `stdlib::path` home-directory resolver's
+   `HomeDirectory` enum (`Ambient`/`Missing`/`Explicit`) lets a caller supply
+   the home directory directly, so the process-reading `home_from_env` ladder in
    `src/stdlib/path/path_utils.rs` remains a directly annotated composition
    root rather than gaining its own `_with` closure parameter.
-2. **The `mockable::Env` trait**, for a boundary mocked across many tests or
+- **The `mockable::Env` trait**, for a boundary mocked across many tests or
    expected to grow further inputs. `resolve_ninja_program_utf8_with` in
-   `src/runner/process/ninja_program.rs` takes `&impl Env`; production
-   supplies `mockable::DefaultEnv`, and tests supply `mockable::MockEnv` for
-   every resolution branch without mutating the process (#488).
-3. **`EnvReader` `Arc` closures**, for a boundary whose registration point
+   `src/runner/process/ninja_program.rs` takes `&impl Env`; production supplies
+   `mockable::DefaultEnv`, and tests supply `mockable::MockEnv` for every
+   resolution branch without mutating the process (#488).
+- **`EnvReader` `Arc` closures**, for a boundary whose registration point
    requires `Send + Sync`. The manifest `env()` Jinja helper
    (`src/manifest/env_reader.rs`) reads through an injected `EnvReader`, a
    shared `Fn(&str) -> Result<String, EnvReadError>` (a manifest-owned error
-   type distinguishing an absent variable from a non-UTF-8 one, so the
-   helper does not expose the process adapter's `VarError`); `minijinja`
-   requires registered functions to be `Send + Sync`, so the reader is
-   captured as an `Arc` by the registered closure rather than borrowed
-   (#484).
+   type distinguishing an absent variable from a non-UTF-8 one, so the helper
+   does not expose the process adapter's `VarError`); `minijinja` requires
+   registered functions to be `Send + Sync`, so the reader is captured as an
+   `Arc` by the registered closure rather than borrowed (#484).
 
-None of these shapes is a general-purpose environment service. Each is owned
-by the module that reads its variable, stays private to it, and covers one
+None of these shapes is a general-purpose environment service. Each is owned by
+the module that reads its variable, stays private to it, and covers one
 variable or one precedence ladder; see "Environment and template ports" in
-`docs/developers-guide.md` for the composition rules that apply to all
-three, and "Ownership and permitted call sites" under that guide's "Manifest
-`env()` reader" section for the `EnvReader` shape specifically.
+`docs/developers-guide.md` for the composition rules that apply to all three,
+and "Ownership and permitted call sites" under that guide's "Manifest `env()`
+reader" section for the `EnvReader` shape specifically.
 
 ### `EnvSnapshot` ownership
 
 `stdlib::which::env::EnvSnapshot::capture` is the resolver's single ambient
-boundary: it captures `PATH`, `PATHEXT`, and the raw
-`NETSUKE_WHICH_WORKSPACE` reading as *data*, in one place, rather than
-letting each downstream decision read the process independently. Absence and
-malformed-UTF-8 outcomes are stored, not resolved, at capture time.
+boundary: it captures `PATH`, `PATHEXT`, and the raw `NETSUKE_WHICH_WORKSPACE`
+reading as *data*, in one place, rather than letting each downstream decision
+read the process independently. Absence and malformed-UTF-8 outcomes are
+stored, not resolved, at capture time.
 
 Decisions are derived downstream from that captured data.
-`workspace_fallback_enabled()` classifies the stored
-`NETSUKE_WHICH_WORKSPACE` reading on demand, and `workspace_switch.rs`
-(`workspace_fallback_enabled_with`) is a leaf module: it is called by `env`
-and by `lookup::workspace`, and it does not call back into either, so there
-is no environment-to-lookup cycle.
+`workspace_fallback_enabled()` classifies the stored `NETSUKE_WHICH_WORKSPACE`
+reading on demand, and `workspace_switch.rs`
+(`workspace_fallback_enabled_with`) is a leaf module: it is called by `env` and
+by `lookup::workspace`, and it does not call back into either, so there is no
+environment-to-lookup cycle.
 
-The which-resolver cache fingerprint
-(`stdlib::which::cache::env_fingerprint`) hashes every input the snapshot
-captured — `raw_path`, `raw_pathext`, and the workspace switch's
-fingerprint-shaped projection — so two resolutions that differ only in one
-captured environment input cannot share a cache entry.
+The which-resolver cache fingerprint (`stdlib::which::cache::env_fingerprint`)
+hashes every input the snapshot captured — `raw_path`, `raw_pathext`, and the
+workspace switch's fingerprint-shaped projection — so two resolutions that
+differ only in one captured environment input cannot share a cache entry.
 
 ### Explicit child-environment composition
 
 Tests that need a controlled child-process environment configure the child
-explicitly; nothing sanctioned mutates the parent test process's environment
-to influence a spawned `netsuke` binary. `test_support::netsuke`'s
+explicitly; nothing sanctioned mutates the parent test process's environment to
+influence a spawned `netsuke` binary. `test_support::netsuke`'s
 `run_netsuke_in_with_env` calls `env_clear()` on the constructed
-`assert_cmd::Command`, forwards the host `PATH`, and then applies the
-caller's `extra_env` pairs through `Command::env`. The BDD helper
+`assert_cmd::Command`, forwards the host `PATH`, and then applies the caller's
+`extra_env` pairs through `Command::env`. The BDD helper
 `build_netsuke_command` follows the same pattern: it clears the inherited
 environment and forwards only `PATH` and the scenario's tracked
 `env_vars_forward` map, one `cmd.env(key, value)` call per entry. Since #493,
-nothing reads `NETSUKE_NINJA` (or any other override) from the parent
-process to populate a child; the value always travels explicitly through
-`extra_env` or `env_vars_forward`.
+nothing reads `NETSUKE_NINJA` (or any other override) from the parent process
+to populate a child; the value always travels explicitly through `extra_env` or
+`env_vars_forward`.
 
 Subprocess isolation constructed this way — explicit `Command::env` calls
-against a cleared child environment — is the only sanctioned route for
-getting an ambient-looking variable such as `NETSUKE_NINJA` or `PATH` to a
-spawned process under test. Mutating the test process's own environment to
-achieve the same effect is not an accepted alternative to any of the three
-seam shapes above.
+against a cleared child environment — is the only sanctioned route for getting
+an ambient-looking variable such as `NETSUKE_NINJA` or `PATH` to a spawned
+process under test. Mutating the test process's own environment to achieve the
+same effect is not an accepted alternative to any of the three seam shapes
+above.
 
 Composition does not stop at the child-process boundary: in-process callers
 that need a deterministic Ninja executable use `runner::run_with_ninja_program`
-to supply the already-resolved program path directly, bypassing
-`NETSUKE_NINJA` resolution entirely rather than setting the variable for a
-child to read.
+to supply the already-resolved program path directly, bypassing `NETSUKE_NINJA`
+resolution entirely rather than setting the variable for a child to read.
 
 ## Rationale
 
 - **Proportionate abstraction.** A trait object for a single-variable,
-  single-caller boundary would recreate the ambient coupling the seam exists
-  to remove, just one layer down; a bare closure is cheaper to read and to
-  test. `mockable::Env` earns its weight only once a boundary is exercised by
-  many tests or is expected to grow (#488).
+  single-caller boundary would recreate the ambient coupling the seam exists to
+  remove, just one layer down; a bare closure is cheaper to read and to test.
+  `mockable::Env` earns its weight only when a boundary is exercised by many
+  tests or is expected to grow (#488).
 - **`Send + Sync` is a real constraint, not a preference.** `EnvReader`'s
   `Arc` wrapping is not a stylistic choice; `minijinja`'s function-registration
-  API requires it, and a plain closure parameter cannot satisfy that bound
-  when the closure must be captured by a registered, potentially cloned
-  function (#484).
+  API requires it, and a plain closure parameter cannot satisfy that bound when
+  the closure must be captured by a registered, potentially cloned function
+  (#484).
 - **Data over decisions at the boundary.** Capturing `EnvSnapshot` once and
   deriving decisions downstream keeps the resolver testable without process
   mutation, and keeps `workspace_switch` a leaf module rather than a second
   place that reads the process.
 - **Cache correctness follows from capture completeness.** Hashing every
-  captured input, including the workspace switch, is what prevents a
-  resolution made with the fallback enabled from answering a lookup made with
-  it disabled.
+  captured input, including the workspace switch, is what prevents a resolution
+  made with the fallback enabled from answering a lookup made with it disabled.
 - **No back door around subprocess isolation.** Explicit `Command::env`
   composition is auditable per test and cannot race with parallel test
   execution the way a shared-process mutation could.
@@ -148,15 +142,15 @@ child to read.
   requirements, rather than inventing a fourth shape or reaching for the
   heaviest option by default.
 - `docs/developers-guide.md`'s "Environment and template ports", "Environment
-  lookup seams", and "Manifest `env()` reader" sections, and this ADR must
-  stay consistent; widen one only alongside the others when a boundary's
-  shape changes.
+  lookup seams", and "Manifest `env()` reader" sections, and this ADR must stay
+  consistent; widen one only alongside the others when a boundary's shape
+  changes.
 - Reviewers can reject a new `mockable::Env`-shaped boundary for a
-  single-variable, single-caller site, and a new closure-shaped boundary for
-  a site that clearly needs `Send + Sync` registration or broad mocking.
+  single-variable, single-caller site, and a new closure-shaped boundary for a
+  site that clearly needs `Send + Sync` registration or broad mocking.
 - Any future ambient input added to the which resolver's boundary (a new
-  environment variable, for example) must be folded into `EnvSnapshot` and
-  into `env_fingerprint`, not read independently downstream, to preserve the
+  environment variable, for example) must be folded into `EnvSnapshot` and into
+  `env_fingerprint`, not read independently downstream, to preserve the
   no-cycle and cache-correctness properties this ADR records.
 
 ## Alternatives considered
@@ -164,34 +158,36 @@ child to read.
 - **A single shared `Env` trait for every boundary.** Rejected: forcing
   `mockable::Env` (or an equivalent trait object) on single-variable,
   single-caller sites such as `workspace_fallback_enabled_with` would add
-  indirection with no matching test-surface benefit, and would blur the
-  "one variable or one precedence ladder" ownership rule this ADR reaffirms.
+  indirection with no matching test-surface benefit, and would blur the "one
+  variable or one precedence ladder" ownership rule this ADR reaffirms.
 - **Reading the parent process's environment for child-process tests.**
-  Rejected: mutating the test process to influence a spawned `netsuke`
-  binary reintroduces the shared-mutable-state races that injected readers
-  and child-process configuration exist to avoid, and it is exactly the
-  pattern #493 removed from the BDD and integration test helpers.
-  `.config/nextest.toml` runs no serialized environment group precisely
-  because no sanctioned test still mutates the harness environment;
-  `EnvLock` and `CwdGuard` remain only for the few tests that exercise
-  process working-directory behaviour.
+  Rejected: mutating the test process to influence a spawned `netsuke` binary
+  reintroduces the shared-mutable-state races that injected readers and
+  child-process configuration exist to avoid, and it is exactly the pattern
+  #493 removed from the BDD and integration test helpers.
+  `.config/nextest.toml` runs no serialized environment group precisely because
+  no sanctioned test still mutates the harness environment; `EnvLock` and
+  `CwdGuard` remain only for the few tests that exercise process
+  working-directory behaviour.
 
 ## Implementation references
 
-- Closure seam: [`src/stdlib/which/workspace_switch.rs`](../src/stdlib/which/workspace_switch.rs)
+- Closure seam:
+  [`src/stdlib/which/workspace_switch.rs`](../src/stdlib/which/workspace_switch.rs)
 - `EnvSnapshot`: [`src/stdlib/which/env.rs`](../src/stdlib/which/env.rs)
 - Cache fingerprint: [`src/stdlib/which/cache.rs`](../src/stdlib/which/cache.rs)
-- `mockable::Env` seam: [`src/runner/process/ninja_program.rs`](../src/runner/process/ninja_program.rs);
+- `mockable::Env` seam:
+  [`src/runner/process/ninja_program.rs`](../src/runner/process/ninja_program.rs);
   `runner::run_with_ninja_program` in
-  [`src/runner/mod.rs`](../src/runner/mod.rs) is the companion injected
-  seam that lets callers select the resolved Ninja executable directly,
-  without going through `NETSUKE_NINJA` resolution at all
+  [`src/runner/mod.rs`](../src/runner/mod.rs) is the companion injected seam
+  that lets callers select the resolved Ninja executable directly, without
+  going through `NETSUKE_NINJA` resolution at all
 - `EnvReader`: [`src/manifest/env_reader.rs`](../src/manifest/env_reader.rs)
   (manifest `env()` Jinja helper)
 - Child-environment composition:
   [`test_support/src/netsuke.rs`](../test_support/src/netsuke.rs)
-  (`run_netsuke_in_with_env`) and
-  `tests/bdd/steps/manifest_command_helpers.rs` (`build_netsuke_command`)
+  (`run_netsuke_in_with_env`) and `tests/bdd/steps/manifest_command_helpers.rs`
+  (`build_netsuke_command`)
 - Policy narrative: "Environment and template ports" and "Injected and
   child-process environments" in
   [`docs/developers-guide.md`](developers-guide.md)

--- a/docs/adr-008-environment-seam-taxonomy.md
+++ b/docs/adr-008-environment-seam-taxonomy.md
@@ -84,11 +84,12 @@ dependency. `workspace_switch.rs` holds only the variable name and that state,
 making it a leaf module: it is used by `env` and by `lookup::workspace`, and it
 calls back into neither, so there is no environment-to-lookup cycle.
 
-The which-resolver cache fingerprint (`stdlib::which::cache::env_fingerprint`)
-hashes every input the snapshot captured — `raw_path`, `raw_pathext`, and the
-`WorkspaceSwitch` state, which derives `Hash` precisely so it can be hashed
-directly — so two resolutions that differ only in one captured environment
-input cannot share a cache entry.
+The which-resolver `CacheKey` incorporates every input the snapshot captured,
+though not uniformly: `cwd` is stored directly as its own field, while
+`stdlib::which::cache::env_fingerprint` hashes `raw_path`, `raw_pathext`, and
+the `WorkspaceSwitch` state, which derives `Hash` precisely so it can be
+hashed directly. Either way, two resolutions that differ only in one captured
+environment input cannot share a cache entry.
 
 ### Explicit child-environment composition
 

--- a/docs/adr-008-environment-seam-taxonomy.md
+++ b/docs/adr-008-environment-seam-taxonomy.md
@@ -1,0 +1,197 @@
+# Architecture decision record (ADR): Environment seam taxonomy
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-08-06.
+
+## Context and problem statement
+
+`clippy.toml` disallows `std::env::var`, `var_os`, `set_var`, `remove_var`,
+`vars`, and `vars_os` across the workspace, per the testing mandate in
+`AGENTS.md`: behaviour that depends on an environment variable should accept
+that value as an argument rather than read the process directly. Several
+callers have satisfied that mandate with different shapes — a bare closure
+parameter, a mockable trait object, a shared `Arc`-wrapped reader — chosen
+independently as each site migrated off the disallowed calls under issues
+484, 488, and 493. Without a stated taxonomy, a future migration has no
+way to pick the right shape for a new boundary, and a reviewer lacks a
+yardstick for
+whether a proposed seam is over- or under-engineered for its call-site count.
+
+Netsuke's design record (`docs/netsuke-design.md`) does not describe these
+seams. This ADR fills that gap and gives `docs/developers-guide.md`'s
+"Environment and template ports", "Environment lookup seams", and "Manifest
+`env()` reader" sections a single decision record to point back to.
+
+## Decision
+
+Adopt three seam shapes, selected by how many call sites a boundary has and
+whether it is expected to grow:
+
+1. **Narrow closure seams**, for a single variable read by a single caller.
+   The module owns a private function that takes an
+   `FnOnce(&str) -> Result<String, env::VarError>` (or the equivalent
+   `OsString`-typed form) instead of calling `std::env::var` itself. Examples:
+   `workspace_fallback_enabled_with` in
+   `src/stdlib/which/workspace_switch.rs` (the `NETSUKE_WHICH_WORKSPACE`
+   opt-out switch), and the `resolve_with` variants in `output_mode.rs` and
+   `output_prefs.rs` described earlier in the developer guide. A related but
+   distinct pattern injects a resolved *value* rather than a closure: the
+   `stdlib::path` home-directory resolver's `HomeDirectory` enum
+   (`Ambient`/`Missing`/`Explicit`) lets a caller supply the home directory
+   directly, so the process-reading `home_from_env` ladder in
+   `src/stdlib/path/path_utils.rs` remains a directly annotated composition
+   root rather than gaining its own `_with` closure parameter.
+2. **The `mockable::Env` trait**, for a boundary mocked across many tests or
+   expected to grow further inputs. `resolve_ninja_program_utf8_with` in
+   `src/runner/process/ninja_program.rs` takes `&impl Env`; production
+   supplies `mockable::DefaultEnv`, and tests supply `mockable::MockEnv` for
+   every resolution branch without mutating the process (#488).
+3. **`EnvReader` `Arc` closures**, for a boundary whose registration point
+   requires `Send + Sync`. The manifest `env()` Jinja helper
+   (`src/manifest/env_reader.rs`) reads through an injected `EnvReader`, a
+   shared `Fn(&str) -> Result<String, EnvReadError>` (a manifest-owned error
+   type distinguishing an absent variable from a non-UTF-8 one, so the
+   helper does not expose the process adapter's `VarError`); `minijinja`
+   requires registered functions to be `Send + Sync`, so the reader is
+   captured as an `Arc` by the registered closure rather than borrowed
+   (#484).
+
+None of these shapes is a general-purpose environment service. Each is owned
+by the module that reads its variable, stays private to it, and covers one
+variable or one precedence ladder; see "Environment and template ports" in
+`docs/developers-guide.md` for the composition rules that apply to all
+three, and "Ownership and permitted call sites" under that guide's "Manifest
+`env()` reader" section for the `EnvReader` shape specifically.
+
+### `EnvSnapshot` ownership
+
+`stdlib::which::env::EnvSnapshot::capture` is the resolver's single ambient
+boundary: it captures `PATH`, `PATHEXT`, and the raw
+`NETSUKE_WHICH_WORKSPACE` reading as *data*, in one place, rather than
+letting each downstream decision read the process independently. Absence and
+malformed-UTF-8 outcomes are stored, not resolved, at capture time.
+
+Decisions are derived downstream from that captured data.
+`workspace_fallback_enabled()` classifies the stored
+`NETSUKE_WHICH_WORKSPACE` reading on demand, and `workspace_switch.rs`
+(`workspace_fallback_enabled_with`) is a leaf module: it is called by `env`
+and by `lookup::workspace`, and it does not call back into either, so there
+is no environment-to-lookup cycle.
+
+The which-resolver cache fingerprint
+(`stdlib::which::cache::env_fingerprint`) hashes every input the snapshot
+captured — `raw_path`, `raw_pathext`, and the workspace switch's
+fingerprint-shaped projection — so two resolutions that differ only in one
+captured environment input cannot share a cache entry.
+
+### Explicit child-environment composition
+
+Tests that need a controlled child-process environment configure the child
+explicitly; nothing sanctioned mutates the parent test process's environment
+to influence a spawned `netsuke` binary. `test_support::netsuke`'s
+`run_netsuke_in_with_env` calls `env_clear()` on the constructed
+`assert_cmd::Command`, forwards the host `PATH`, and then applies the
+caller's `extra_env` pairs through `Command::env`. The BDD helper
+`build_netsuke_command` follows the same pattern: it clears the inherited
+environment and forwards only `PATH` and the scenario's tracked
+`env_vars_forward` map, one `cmd.env(key, value)` call per entry. Since #493,
+nothing reads `NETSUKE_NINJA` (or any other override) from the parent
+process to populate a child; the value always travels explicitly through
+`extra_env` or `env_vars_forward`.
+
+Subprocess isolation constructed this way — explicit `Command::env` calls
+against a cleared child environment — is the only sanctioned route for
+getting an ambient-looking variable such as `NETSUKE_NINJA` or `PATH` to a
+spawned process under test. Mutating the test process's own environment to
+achieve the same effect is not an accepted alternative to any of the three
+seam shapes above.
+
+Composition does not stop at the child-process boundary: in-process callers
+that need a deterministic Ninja executable use `runner::run_with_ninja_program`
+to supply the already-resolved program path directly, bypassing
+`NETSUKE_NINJA` resolution entirely rather than setting the variable for a
+child to read.
+
+## Rationale
+
+- **Proportionate abstraction.** A trait object for a single-variable,
+  single-caller boundary would recreate the ambient coupling the seam exists
+  to remove, just one layer down; a bare closure is cheaper to read and to
+  test. `mockable::Env` earns its weight only once a boundary is exercised by
+  many tests or is expected to grow (#488).
+- **`Send + Sync` is a real constraint, not a preference.** `EnvReader`'s
+  `Arc` wrapping is not a stylistic choice; `minijinja`'s function-registration
+  API requires it, and a plain closure parameter cannot satisfy that bound
+  when the closure must be captured by a registered, potentially cloned
+  function (#484).
+- **Data over decisions at the boundary.** Capturing `EnvSnapshot` once and
+  deriving decisions downstream keeps the resolver testable without process
+  mutation, and keeps `workspace_switch` a leaf module rather than a second
+  place that reads the process.
+- **Cache correctness follows from capture completeness.** Hashing every
+  captured input, including the workspace switch, is what prevents a
+  resolution made with the fallback enabled from answering a lookup made with
+  it disabled.
+- **No back door around subprocess isolation.** Explicit `Command::env`
+  composition is auditable per test and cannot race with parallel test
+  execution the way a shared-process mutation could.
+
+## Consequences
+
+- A contributor introducing a new environment-dependent boundary chooses
+  among the three seam shapes by call-site count and `Send + Sync`
+  requirements, rather than inventing a fourth shape or reaching for the
+  heaviest option by default.
+- `docs/developers-guide.md`'s "Environment and template ports", "Environment
+  lookup seams", and "Manifest `env()` reader" sections, and this ADR must
+  stay consistent; widen one only alongside the others when a boundary's
+  shape changes.
+- Reviewers can reject a new `mockable::Env`-shaped boundary for a
+  single-variable, single-caller site, and a new closure-shaped boundary for
+  a site that clearly needs `Send + Sync` registration or broad mocking.
+- Any future ambient input added to the which resolver's boundary (a new
+  environment variable, for example) must be folded into `EnvSnapshot` and
+  into `env_fingerprint`, not read independently downstream, to preserve the
+  no-cycle and cache-correctness properties this ADR records.
+
+## Alternatives considered
+
+- **A single shared `Env` trait for every boundary.** Rejected: forcing
+  `mockable::Env` (or an equivalent trait object) on single-variable,
+  single-caller sites such as `workspace_fallback_enabled_with` would add
+  indirection with no matching test-surface benefit, and would blur the
+  "one variable or one precedence ladder" ownership rule this ADR reaffirms.
+- **Reading the parent process's environment for child-process tests.**
+  Rejected: mutating the test process to influence a spawned `netsuke`
+  binary reintroduces the shared-mutable-state races that injected readers
+  and child-process configuration exist to avoid, and it is exactly the
+  pattern #493 removed from the BDD and integration test helpers.
+  `.config/nextest.toml` runs no serialized environment group precisely
+  because no sanctioned test still mutates the harness environment;
+  `EnvLock` and `CwdGuard` remain only for the few tests that exercise
+  process working-directory behaviour.
+
+## Implementation references
+
+- Closure seam: [`src/stdlib/which/workspace_switch.rs`](../src/stdlib/which/workspace_switch.rs)
+- `EnvSnapshot`: [`src/stdlib/which/env.rs`](../src/stdlib/which/env.rs)
+- Cache fingerprint: [`src/stdlib/which/cache.rs`](../src/stdlib/which/cache.rs)
+- `mockable::Env` seam: [`src/runner/process/ninja_program.rs`](../src/runner/process/ninja_program.rs);
+  `runner::run_with_ninja_program` in
+  [`src/runner/mod.rs`](../src/runner/mod.rs) is the companion injected
+  seam that lets callers select the resolved Ninja executable directly,
+  without going through `NETSUKE_NINJA` resolution at all
+- `EnvReader`: [`src/manifest/env_reader.rs`](../src/manifest/env_reader.rs)
+  (manifest `env()` Jinja helper)
+- Child-environment composition:
+  [`test_support/src/netsuke.rs`](../test_support/src/netsuke.rs)
+  (`run_netsuke_in_with_env`) and
+  `tests/bdd/steps/manifest_command_helpers.rs` (`build_netsuke_command`)
+- Policy narrative: "Environment and template ports" and "Injected and
+  child-process environments" in
+  [`docs/developers-guide.md`](developers-guide.md)

--- a/docs/adr-008-environment-seam-taxonomy.md
+++ b/docs/adr-008-environment-seam-taxonomy.md
@@ -35,20 +35,23 @@ whether it is expected to grow:
    The module owns a private function that takes an
    `FnOnce(&str) -> Result<String, env::VarError>` (or the equivalent
    `OsString`-typed form) instead of calling `std::env::var` itself. Examples:
-   `workspace_fallback_enabled_with` in `src/stdlib/which/workspace_switch.rs`
-   (the `NETSUKE_WHICH_WORKSPACE` opt-out switch), and the `resolve_with`
-   variants in `output_mode.rs` and `output_prefs.rs` described earlier in the
-   developer guide. A related but distinct pattern injects a resolved *value*
-   rather than a closure: the `stdlib::path` home-directory resolver's
-   `HomeDirectory` enum (`Ambient`/`Missing`/`Explicit`) lets a caller supply
-   the home directory directly, so the process-reading `home_from_env` ladder in
-   `src/stdlib/path/path_utils.rs` remains a directly annotated composition
-   root rather than gaining its own `_with` closure parameter.
+   the `resolve_with` variants in `output_mode.rs` and `output_prefs.rs`
+   described earlier in the developer guide. A related but distinct pattern
+   injects a resolved *value* rather than a closure: the `stdlib::path`
+   home-directory resolver's `HomeDirectory` enum (`Ambient`/`Missing`/
+   `Explicit`) lets a caller supply the home directory directly, so the
+   process-reading `home_from_env` ladder in `src/stdlib/path/path_utils.rs`
+   remains a directly annotated composition root rather than gaining its own
+   `_with` closure parameter.
 - **The `mockable::Env` trait**, for a boundary mocked across many tests or
    expected to grow further inputs. `resolve_ninja_program_utf8_with` in
    `src/runner/process/ninja_program.rs` takes `&impl Env`; production supplies
    `mockable::DefaultEnv`, and tests supply `mockable::MockEnv` for every
    resolution branch without mutating the process (#488).
+   `stdlib::which::env::EnvSnapshot::capture_with_env` takes the same
+   `&impl Env` and reads `PATH`, `PATHEXT`, and `NETSUKE_WHICH_WORKSPACE`
+   through it, so one provider covers every ambient input the resolver has
+   (#487).
 - **`EnvReader` `Arc` closures**, for a boundary whose registration point
    requires `Send + Sync`. The manifest `env()` Jinja helper
    (`src/manifest/env_reader.rs`) reads through an injected `EnvReader`, a
@@ -68,22 +71,24 @@ reader" section for the `EnvReader` shape specifically.
 ### `EnvSnapshot` ownership
 
 `stdlib::which::env::EnvSnapshot::capture` is the resolver's single ambient
-boundary: it captures `PATH`, `PATHEXT`, and the raw `NETSUKE_WHICH_WORKSPACE`
-reading as *data*, in one place, rather than letting each downstream decision
+boundary: it captures `PATH`, `PATHEXT`, and the `NETSUKE_WHICH_WORKSPACE`
+switch as *data*, in one place, rather than letting each downstream decision
 read the process independently. Absence and malformed-UTF-8 outcomes are
 stored, not resolved, at capture time.
 
-Decisions are derived downstream from that captured data.
-`workspace_fallback_enabled()` classifies the stored `NETSUKE_WHICH_WORKSPACE`
-reading on demand, and `workspace_switch.rs`
-(`workspace_fallback_enabled_with`) is a leaf module: it is called by `env` and
-by `lookup::workspace`, and it does not call back into either, so there is no
-environment-to-lookup cycle.
+Capture is also the only place the platform's `std::env::VarError` is spoken.
+It translates the reading into the `WorkspaceSwitch` domain state (`Value`,
+`Absent`, `NotUnicode`) and emits the non-UTF-8 warning there, so the policy
+behind the boundary carries neither the platform error type nor a logging
+dependency. `workspace_switch.rs` holds only the variable name and that state,
+making it a leaf module: it is used by `env` and by `lookup::workspace`, and it
+calls back into neither, so there is no environment-to-lookup cycle.
 
 The which-resolver cache fingerprint (`stdlib::which::cache::env_fingerprint`)
 hashes every input the snapshot captured — `raw_path`, `raw_pathext`, and the
-workspace switch's fingerprint-shaped projection — so two resolutions that
-differ only in one captured environment input cannot share a cache entry.
+`WorkspaceSwitch` state, which derives `Hash` precisely so it can be hashed
+directly — so two resolutions that differ only in one captured environment
+input cannot share a cache entry.
 
 ### Explicit child-environment composition
 
@@ -157,7 +162,7 @@ resolution entirely rather than setting the variable for a child to read.
 
 - **A single shared `Env` trait for every boundary.** Rejected: forcing
   `mockable::Env` (or an equivalent trait object) on single-variable,
-  single-caller sites such as `workspace_fallback_enabled_with` would add
+  single-caller sites such as `output_mode.rs`'s `resolve_with` would add
   indirection with no matching test-surface benefit, and would blur the "one
   variable or one precedence ladder" ownership rule this ADR reaffirms.
 - **Reading the parent process's environment for child-process tests.**
@@ -172,7 +177,7 @@ resolution entirely rather than setting the variable for a child to read.
 
 ## Implementation references
 
-- Closure seam:
+- Workspace switch state:
   [`src/stdlib/which/workspace_switch.rs`](../src/stdlib/which/workspace_switch.rs)
 - `EnvSnapshot`: [`src/stdlib/which/env.rs`](../src/stdlib/which/env.rs)
 - Cache fingerprint: [`src/stdlib/which/cache.rs`](../src/stdlib/which/cache.rs)

--- a/docs/adr-008-environment-seam-taxonomy.md
+++ b/docs/adr-008-environment-seam-taxonomy.md
@@ -6,7 +6,7 @@ Accepted.
 
 ## Date
 
-2026-08-06.
+2026-08-06
 
 ## Context and problem statement
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -46,6 +46,10 @@ operator, user, and contributor references are easier to find.
 - [adr-007-publish-as-netsuke-build.md](adr-007-publish-as-netsuke-build.md):
   crates.io package rename decision record, and the package-versus-target
   naming rule it establishes.
+- [adr-008-environment-seam-taxonomy.md](adr-008-environment-seam-taxonomy.md):
+  Environment seam taxonomy decision record: three sanctioned shapes for
+  injecting environment-dependent input instead of reading the process
+  directly.
 
 ## User and operator guides
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -48,8 +48,7 @@ operator, user, and contributor references are easier to find.
   naming rule it establishes.
 - [adr-008-environment-seam-taxonomy.md](adr-008-environment-seam-taxonomy.md):
   Environment seam taxonomy decision record: three sanctioned shapes for
-  injecting environment-dependent input instead of reading the process
-  directly.
+  injecting environment-dependent input instead of reading the process directly.
 
 ## User and operator guides
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2268,14 +2268,20 @@ explicit root `--json` flag bypasses environment parsing.
 #### Workspace fallback switch seam
 
 `src/stdlib/which/workspace_switch.rs` is a leaf module holding the
-`NETSUKE_WHICH_WORKSPACE` name and the pure classifier
-`workspace_fallback_enabled_with`. The raw reading is captured by
-`EnvSnapshot::capture` through the injected `mockable::Env` provider and
-stored as snapshot data; the enable/disable decision is derived from that
-snapshot on demand. The cache fingerprint hashes the reading, so two
-resolutions differing only in this switch never share a cache entry. The
-non-UTF-8 diagnostic fires once at capture, where `warn_if_not_unicode` runs
-immediately after the raw read; the classifier itself emits nothing. See
+`NETSUKE_WHICH_WORKSPACE` name and the domain state `WorkspaceSwitch`
+(`Value`, `Absent`, `NotUnicode`) with its `enabled()` decision. The variable
+is read by `EnvSnapshot::capture` through the injected `mockable::Env`
+provider and stored as snapshot data; the enable/disable decision is derived
+from that snapshot on demand. The cache fingerprint hashes the state —
+`WorkspaceSwitch` derives `Hash` for exactly that purpose — so two resolutions
+differing only in this switch never share a cache entry.
+
+The adapter owns everything platform-specific. `env.rs` holds the
+`From<Result<String, std::env::VarError>>` conversion, the single point at
+which the platform error becomes a domain state, and emits the non-UTF-8
+warning once per capture immediately after the read. Only the variable's name
+is logged, never its value. The leaf module therefore names neither `VarError`
+nor `tracing`, and consulting the switch afterwards is silent. See
 [ADR-008](adr-008-environment-seam-taxonomy.md) for the seam taxonomy.
 
 #### Ninja program resolver seam

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1757,8 +1757,11 @@ boundary policy.
 
 ### Environment and template ports
 
-The seams described in this section follow one of three sanctioned shapes,
-chosen by call-site count and `Send + Sync` requirements; see
+The seams described in this section follow one of three sanctioned shapes —
+narrow closures, `mockable::Env`, or `EnvReader` — chosen by call-site count,
+expected growth, and `Send + Sync` registration requirements: use
+`mockable::Env` when a boundary is expected to acquire more inputs, even
+before its call-site count grows. See
 [ADR-008](adr-008-environment-seam-taxonomy.md) for the taxonomy.
 
 `manifest::EnvReader` owns environment lookup for the manifest `env()` helper.
@@ -2291,6 +2294,13 @@ takes `&impl mockable::Env`, with `mockable::DefaultEnv` as the production
 adapter supplied by the ambient `resolve_ninja_program_utf8` wrapper. The unit
 tests inject a `MockEnv` that pins the `NETSUKE_NINJA` key, so every override
 branch runs without process mutation.
+
+`resolve_ninja_program_with`, in the same module, takes the identical `&impl
+mockable::Env` seam and converts the UTF-8 result into a general platform
+`PathBuf`. It is compiled only under `#[cfg(test)]`: production reaches the
+platform-path form through `resolve_ninja_program`, which itself calls the
+UTF-8 resolver and converts its result, so no production path constructs a
+platform `PathBuf` independently of `resolve_ninja_program_utf8_with`.
 
 ### Configuration discovery module layout
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1757,6 +1757,10 @@ boundary policy.
 
 ### Environment and template ports
 
+The seams described in this section follow one of three sanctioned shapes,
+chosen by call-site count and `Send + Sync` requirements; see
+[ADR-008](adr-008-environment-seam-taxonomy.md) for the taxonomy.
+
 `manifest::EnvReader` owns environment lookup for the manifest `env()` helper.
 Production constructs the process-backed adapter at the manifest loading
 boundary; tests pass an `Arc`-backed reader directly. The port is only for

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -2265,6 +2265,27 @@ Selected file-load errors and malformed `NETSUKE_JSON` values are returned to
 the caller. Accepted environment values are `true`, `false`, `1`, and `0`. An
 explicit root `--json` flag bypasses environment parsing.
 
+#### Workspace fallback switch seam
+
+`src/stdlib/which/workspace_switch.rs` is a leaf module holding the
+`NETSUKE_WHICH_WORKSPACE` name and the pure classifier
+`workspace_fallback_enabled_with`. The raw reading is captured by
+`EnvSnapshot::capture` through the injected `mockable::Env` provider and
+stored as snapshot data; the enable/disable decision is derived from that
+snapshot on demand. The cache fingerprint hashes the reading, so two
+resolutions differing only in this switch never share a cache entry. The
+non-UTF-8 diagnostic fires once at capture, where `warn_if_not_unicode` runs
+immediately after the raw read; the classifier itself emits nothing. See
+[ADR-008](adr-008-environment-seam-taxonomy.md) for the seam taxonomy.
+
+#### Ninja program resolver seam
+
+`resolve_ninja_program_utf8_with` in `src/runner/process/ninja_program.rs`
+takes `&impl mockable::Env`, with `mockable::DefaultEnv` as the production
+adapter supplied by the ambient `resolve_ninja_program_utf8` wrapper. The unit
+tests inject a `MockEnv` that pins the `NETSUKE_NINJA` key, so every override
+branch runs without process mutation.
+
 ### Configuration discovery module layout
 
 `src/cli/discovery.rs` attaches several small `#[path = "..."]` modules that

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1569,9 +1569,9 @@ is not obvious from the name:
   present.
 - `try_is_file(path) -> io::Result<bool>` is the fallible counterpart to the
   boolean predicates: `Ok(true)` when the path is a regular file, `Ok(false)`
-  when it is absent (`NotFound` is folded into the boolean result), and
-  `Err` for any other metadata failure, so callers can distinguish absence
-  from inaccessibility. The binary locator in `test_support/src/netsuke.rs`
+  when it is absent (`NotFound` is folded into the boolean result), and `Err`
+  for any other metadata failure, so callers can distinguish absence from
+  inaccessibility. The binary locator in `test_support/src/netsuke.rs`
   (`netsuke_executable_from`, see
   [Locating the netsuke binary](#locating-the-netsuke-binary)) relies on it to
   surface unexpected filesystem errors while probing candidate paths.
@@ -2423,8 +2423,8 @@ any scenario that requires a hermetic child environment.
 
 #### Locating the netsuke binary
 
-Both `run_netsuke_in` and `run_netsuke_in_with_env` depend on a private
-locator, `netsuke_executable()`, to find the built `netsuke` binary.
+Both `run_netsuke_in` and `run_netsuke_in_with_env` depend on a private locator,
+`netsuke_executable()`, to find the built `netsuke` binary.
 `netsuke_executable()` converts `std::env::current_exe()` to a
 `camino::Utf8PathBuf` and delegates to `netsuke_executable_from`, which takes
 an injected `mockable::Env` — the same injectable-environment pattern used by
@@ -2442,8 +2442,8 @@ The locator checks candidate paths in order:
 3. `CARGO_TARGET_DIR/<triple>/<profile>/`, for `--target` builds where the
    profile directory nests under the target triple.
 
-Filesystem errors other than "not found" are surfaced rather than treated as
-a missing candidate, via the [`test_support::fs`](#test_supportfs) wrapper
+Filesystem errors other than "not found" are surfaced rather than treated as a
+missing candidate, via the [`test_support::fs`](#test_supportfs) wrapper
 `try_is_file`. When every candidate misses, the resulting error lists all
 attempted paths.
 

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -283,19 +283,19 @@ unredacted, that field changes on every version bump and would churn every
 diagnostic-JSON snapshot — this is exactly what happened on the v0.1.0-beta1
 bump.
 
-The shared `snapshot_settings()` helper in `src/diagnostic_json_tests.rs`
-adds an insta filter that rewrites the generator's version to `[version]`.
-The filter anchors on the preceding `"name": "netsuke"` line, so it redacts
-only the generator block's version; any other field named `version`
-elsewhere in a diagnostic document remains visible in snapshot diffs.
+The shared `snapshot_settings()` helper in `src/diagnostic_json_tests.rs` adds
+an insta filter that rewrites the generator's version to `[version]`. The
+filter anchors on the preceding `"name": "netsuke"` line, so it redacts only
+the generator block's version; any other field named `version` elsewhere in a
+diagnostic document remains visible in snapshot diffs.
 
 New diagnostic-JSON snapshot tests must bind through this shared
-`snapshot_settings()` helper rather than asserting raw output, so the
-redaction is applied consistently.
+`snapshot_settings()` helper rather than asserting raw output, so the redaction
+is applied consistently.
 
 `schema_version` and the generator name are deliberately excluded from this
-redaction: they are asserted structurally in dedicated tests, separate from
-the redacted version string.
+redaction: they are asserted structurally in dedicated tests, separate from the
+redacted version string.
 
 ## Running and Updating Snapshot Tests
 

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -283,19 +283,19 @@ unredacted, that field changes on every version bump and would churn every
 diagnostic-JSON snapshot — this is exactly what happened on the v0.1.0-beta1
 bump.
 
-The shared `snapshot_settings()` helper in `src/diagnostic_json_tests.rs` adds
-an insta filter that rewrites the generator's version to `[version]`. The
-filter anchors on the preceding `"name": "netsuke"` line, so it redacts only
-the generator block's version; any other field named `version` elsewhere in a
-diagnostic document remains visible in snapshot diffs.
+The shared `snapshot_settings()` helper in `src/diagnostic_json_tests.rs`
+adds an insta filter that rewrites the generator's version to `[version]`.
+The filter anchors on the preceding `"name": "netsuke"` line, so it redacts
+only the generator block's version; any other field named `version`
+elsewhere in a diagnostic document remains visible in snapshot diffs.
 
 New diagnostic-JSON snapshot tests must bind through this shared
-`snapshot_settings()` helper rather than asserting raw output, so the redaction
-is applied consistently.
+`snapshot_settings()` helper rather than asserting raw output, so the
+redaction is applied consistently.
 
 `schema_version` and the generator name are deliberately excluded from this
-redaction: they are asserted structurally in dedicated tests, separate from the
-redacted version string.
+redaction: they are asserted structurally in dedicated tests, separate from
+the redacted version string.
 
 ## Running and Updating Snapshot Tests
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -716,6 +716,7 @@ Common environment equivalents include:
 - `NETSUKE_LOCALE=en-US`
 - `NETSUKE_DEFAULT_TARGETS__0=hello.txt`
 - `NETSUKE_NINJA=/opt/ninja/bin/ninja`
+- `NETSUKE_WHICH_WORKSPACE=0`
 
 `NETSUKE_LOCALE` selects the interface language; see
 [Choose a language with `--locale`](#choose-a-language-with---locale) for how
@@ -724,6 +725,13 @@ it combines with the flag and the system default.
 `NETSUKE_NINJA` overrides the Ninja executable used by `build` and `clean`.
 Leave it unset to use `ninja` from `PATH`, or set another executable name or an
 absolute path. Empty and non-UTF-8 values fall back to the default.
+
+`NETSUKE_WHICH_WORKSPACE` switches off the `which()` workspace-tree fallback
+search that runs when a command is not found on `PATH`. Set it to `0`,
+`false`, or `off` (case-insensitively) to disable the fallback; any other
+value, or leaving it unset, keeps the fallback enabled. A non-Unicode value
+also disables the fallback and is treated as an explicit opt-out, emitting a
+warning.
 
 The CLI and configuration use the same policy values. `auto` follows terminal
 and environment detection. `always` or `never` makes colour, emoji, or progress

--- a/src/runner/process/mod.rs
+++ b/src/runner/process/mod.rs
@@ -31,7 +31,7 @@ pub use ninja_program::resolve_ninja_program;
 #[cfg(doctest)]
 pub use ninja_program::resolve_ninja_program_utf8;
 #[cfg(test)]
-use ninja_program::resolve_ninja_program_utf8_with;
+use ninja_program::{resolve_ninja_program_utf8_with, resolve_ninja_program_with};
 pub use paths::*;
 use streaming::{ForwardStats, forward_child_output, forward_child_output_with_ninja_status};
 

--- a/src/runner/process/ninja_program.rs
+++ b/src/runner/process/ninja_program.rs
@@ -3,23 +3,26 @@
 //! This module owns selection between `NETSUKE_NINJA` and the default program.
 //! Process construction consumes only its resolved paths; other adapters must
 //! not read or interpret the override independently.
+//!
+//! The environment reaches the resolver through [`mockable::Env`] (#488):
+//! production supplies [`mockable::DefaultEnv`], the crate's one explicit
+//! process-environment adapter for this boundary, and tests supply
+//! `mockable::MockEnv` so every branch runs without process mutation.
 
 use super::super::{NINJA_ENV, NINJA_PROGRAM};
 use camino::Utf8PathBuf;
-use std::{env, ffi::OsString, path::PathBuf};
+use mockable::Env;
+use std::path::PathBuf;
 use tracing::debug;
 
-/// Resolves Ninja with an injectable environment reader for testability.
+/// Resolves Ninja with an injectable environment for testability.
 ///
 /// This variant avoids mutating the process environment when testing
 /// resolution behaviour. It selects a non-empty UTF-8 `NETSUKE_NINJA`
 /// override, falls back to [`NINJA_PROGRAM`] when the override is unset,
 /// empty, or non-UTF-8, and emits resolution diagnostics at this boundary.
-pub(super) fn resolve_ninja_program_utf8_with<F>(mut read_env: F) -> Utf8PathBuf
-where
-    F: FnMut(&str) -> Option<OsString>,
-{
-    read_env(NINJA_ENV).map_or_else(
+pub(super) fn resolve_ninja_program_utf8_with(env: &impl Env) -> Utf8PathBuf {
+    env.os_string(NINJA_ENV).map_or_else(
         || {
             debug!(
                 ninja_program = NINJA_PROGRAM,
@@ -62,14 +65,19 @@ where
     )
 }
 
+/// Resolve Ninja as a general platform path with an injectable environment.
+///
+/// Compiled for tests only: production reaches the platform-path form through
+/// [`resolve_ninja_program`], which shares the UTF-8 resolution below.
+#[cfg(test)]
+pub(super) fn resolve_ninja_program_with(env: &impl Env) -> PathBuf {
+    resolve_ninja_program_utf8_with(env).into()
+}
+
 /// Resolve the configured Ninja executable as a UTF-8 path.
 #[must_use]
-#[expect(
-    clippy::disallowed_methods,
-    reason = "composition root: supplies the process environment to the ninja program resolver seam"
-)]
 pub fn resolve_ninja_program_utf8() -> Utf8PathBuf {
-    resolve_ninja_program_utf8_with(|key| env::var_os(key))
+    resolve_ninja_program_utf8_with(&mockable::DefaultEnv)
 }
 
 /// Resolve the configured Ninja executable as a general platform path.

--- a/src/runner/process/tests.rs
+++ b/src/runner/process/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 use camino::Utf8PathBuf;
 use mockable::MockEnv;
 use proptest::prelude::*;
+use rstest::{fixture, rstest};
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::path::PathBuf;
@@ -13,8 +14,10 @@ use std::path::PathBuf;
 ///
 /// The key expectation is part of the contract (#488): a resolver that reads
 /// any other variable, or reads more than once, fails these tests rather than
-/// silently consulting something else.
-fn ninja_env(value: Option<OsString>) -> MockEnv {
+/// silently consulting something else. Consumers override the answer with
+/// `#[with(...)]`; the `#[default(None)]` parameter models "variable unset".
+#[fixture]
+fn ninja_env(#[default(None)] value: Option<OsString>) -> MockEnv {
     let mut env = MockEnv::new();
     env.expect_os_string()
         .times(1)
@@ -23,42 +26,58 @@ fn ninja_env(value: Option<OsString>) -> MockEnv {
     env
 }
 
-#[test]
-fn resolve_ninja_program_utf8_prefers_env_override() {
-    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::from("/opt/ninja"))));
+#[rstest]
+fn resolve_ninja_program_utf8_prefers_env_override(
+    #[with(Some(OsString::from("/opt/ninja")))] ninja_env: MockEnv,
+) {
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env);
     assert_eq!(resolved, Utf8PathBuf::from("/opt/ninja"));
 }
 
-#[test]
-fn resolve_ninja_program_utf8_defaults_without_override() {
-    let resolved = resolve_ninja_program_utf8_with(&ninja_env(None));
+#[rstest]
+fn resolve_ninja_program_utf8_defaults_without_override(ninja_env: MockEnv) {
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env);
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
 }
 
-#[test]
-fn resolve_ninja_program_utf8_defaults_for_empty_override() {
-    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::new())));
+#[rstest]
+fn resolve_ninja_program_utf8_defaults_for_empty_override(
+    #[with(Some(OsString::new()))] ninja_env: MockEnv,
+) {
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env);
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
 }
 
 #[cfg(unix)]
-#[test]
-fn resolve_ninja_program_utf8_ignores_invalid_utf8_override() {
-    use std::os::unix::ffi::OsStringExt;
-
-    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::from_vec(vec![
-        0xff, b'n', b'i', b'n', b'j', b'a',
-    ]))));
+#[rstest]
+fn resolve_ninja_program_utf8_ignores_invalid_utf8_override(
+    #[with(Some(invalid_utf8_override()))] ninja_env: MockEnv,
+) {
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env);
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
 }
 
+/// A non-UTF-8 override value; the leading `0xff` byte is never valid UTF-8.
+#[cfg(unix)]
+fn invalid_utf8_override() -> OsString {
+    use std::os::unix::ffi::OsStringExt;
+
+    OsString::from_vec(vec![0xff, b'n', b'i', b'n', b'j', b'a'])
+}
+
 /// The platform-path variant shares the UTF-8 resolution and conversion.
-#[test]
-fn resolve_ninja_program_with_converts_the_resolved_path() {
-    let resolved = resolve_ninja_program_with(&ninja_env(Some(OsString::from("/opt/ninja"))));
+#[rstest]
+fn resolve_ninja_program_with_converts_the_resolved_path(
+    #[with(Some(OsString::from("/opt/ninja")))] ninja_env: MockEnv,
+) {
+    let resolved = resolve_ninja_program_with(&ninja_env);
     assert_eq!(resolved, std::path::PathBuf::from("/opt/ninja"));
 }
 
+// `proptest!` owns the generated function signature, so rstest cannot inject
+// the fixture here. Calling the fixture function directly keeps the one-read,
+// exact-key contract identical to the injected cases without weakening the
+// property's input coverage.
 proptest! {
     #[test]
     fn resolve_ninja_program_utf8_matches_utf8_env_invariant(
@@ -108,6 +127,8 @@ fn finalize_streaming_joins_stderr_thread_when_wait_fails() {
     );
 }
 
+// As above, the fixture is called directly because `proptest!` generates the
+// function signature and leaves no parameter for rstest to inject.
 #[cfg(unix)]
 proptest! {
     #[test]

--- a/src/runner/process/tests.rs
+++ b/src/runner/process/tests.rs
@@ -1,28 +1,43 @@
 //! Unit and property tests for Ninja process helpers.
 
-use super::super::NINJA_PROGRAM;
+use super::super::{NINJA_ENV, NINJA_PROGRAM};
 use super::*;
 use camino::Utf8PathBuf;
+use mockable::MockEnv;
 use proptest::prelude::*;
 use std::ffi::OsString;
 #[cfg(unix)]
 use std::path::PathBuf;
 
+/// A `MockEnv` answering exactly one `os_string` read of `NETSUKE_NINJA`.
+///
+/// The key expectation is part of the contract (#488): a resolver that reads
+/// any other variable, or reads more than once, fails these tests rather than
+/// silently consulting something else.
+fn ninja_env(value: Option<OsString>) -> MockEnv {
+    let mut env = MockEnv::new();
+    env.expect_os_string()
+        .times(1)
+        .withf(|key| key == NINJA_ENV)
+        .return_const(value);
+    env
+}
+
 #[test]
 fn resolve_ninja_program_utf8_prefers_env_override() {
-    let resolved = resolve_ninja_program_utf8_with(|_| Some(OsString::from("/opt/ninja")));
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::from("/opt/ninja"))));
     assert_eq!(resolved, Utf8PathBuf::from("/opt/ninja"));
 }
 
 #[test]
 fn resolve_ninja_program_utf8_defaults_without_override() {
-    let resolved = resolve_ninja_program_utf8_with(|_| None);
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env(None));
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
 }
 
 #[test]
 fn resolve_ninja_program_utf8_defaults_for_empty_override() {
-    let resolved = resolve_ninja_program_utf8_with(|_| Some(OsString::new()));
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::new())));
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
 }
 
@@ -31,10 +46,17 @@ fn resolve_ninja_program_utf8_defaults_for_empty_override() {
 fn resolve_ninja_program_utf8_ignores_invalid_utf8_override() {
     use std::os::unix::ffi::OsStringExt;
 
-    let resolved = resolve_ninja_program_utf8_with(|_| {
-        Some(OsString::from_vec(vec![0xff, b'n', b'i', b'n', b'j', b'a']))
-    });
+    let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(OsString::from_vec(vec![
+        0xff, b'n', b'i', b'n', b'j', b'a',
+    ]))));
     assert_eq!(resolved, Utf8PathBuf::from(NINJA_PROGRAM));
+}
+
+/// The platform-path variant shares the UTF-8 resolution and conversion.
+#[test]
+fn resolve_ninja_program_with_converts_the_resolved_path() {
+    let resolved = resolve_ninja_program_with(&ninja_env(Some(OsString::from("/opt/ninja"))));
+    assert_eq!(resolved, std::path::PathBuf::from("/opt/ninja"));
 }
 
 proptest! {
@@ -48,7 +70,7 @@ proptest! {
             _ => Utf8PathBuf::from(NINJA_PROGRAM),
         };
 
-        let resolved = resolve_ninja_program_utf8_with(|_| env_value.clone());
+        let resolved = resolve_ninja_program_utf8_with(&ninja_env(env_value));
 
         prop_assert_eq!(resolved, expected);
     }
@@ -102,7 +124,7 @@ proptest! {
                 .unwrap_or_else(|_| Utf8PathBuf::from(NINJA_PROGRAM))
         };
 
-        let resolved = resolve_ninja_program_utf8_with(|_| Some(env_value.clone()));
+        let resolved = resolve_ninja_program_utf8_with(&ninja_env(Some(env_value)));
 
         prop_assert_eq!(resolved, expected);
     }

--- a/src/stdlib/which/cache.rs
+++ b/src/stdlib/which/cache.rs
@@ -197,7 +197,7 @@ fn env_fingerprint(env: &EnvSnapshot) -> u64 {
     // The workspace switch is an environment input like PATH: a fallback hit
     // cached while the switch was on must not answer a resolution made with
     // it off, and vice versa.
-    env.workspace_switch_fingerprint().hash(&mut hasher);
+    env.workspace_switch().hash(&mut hasher);
     hasher.finish()
 }
 
@@ -206,6 +206,7 @@ mod tests {
     //! Unit tests for the which resolver cache: key derivation, capacity
     //! bounds, and skip-list handling during resolution.
     use super::*;
+    use crate::stdlib::which::workspace_switch::WorkspaceSwitch;
     use anyhow::{Result, anyhow, ensure};
     use camino::Utf8PathBuf;
     use rstest::rstest;
@@ -277,7 +278,7 @@ mod tests {
     /// A fallback hit cached while `NETSUKE_WHICH_WORKSPACE` left the search
     /// enabled would otherwise answer a resolution made with it disabled —
     /// cross-toggle cache poisoning. The snapshots here differ only in the
-    /// captured raw switch value, so key inequality proves the fingerprint
+    /// captured switch state, so key inequality proves the fingerprint
     /// covers it.
     #[test]
     fn cache_key_differs_when_workspace_switch_differs() -> Result<()> {
@@ -288,10 +289,8 @@ mod tests {
         let options = WhichOptions::default();
         let skips = WorkspaceSkipList::default();
 
-        let enabled = base
-            .clone()
-            .with_workspace_switch(Err(std::env::VarError::NotPresent));
-        let disabled = base.with_workspace_switch(Ok(String::from("0")));
+        let enabled = base.clone().with_workspace_switch(WorkspaceSwitch::Absent);
+        let disabled = base.with_workspace_switch(WorkspaceSwitch::Value(String::from("0")));
         ensure!(
             enabled.workspace_fallback_enabled() && !disabled.workspace_fallback_enabled(),
             "the fixtures should sit on opposite sides of the switch"

--- a/src/stdlib/which/cache.rs
+++ b/src/stdlib/which/cache.rs
@@ -194,6 +194,10 @@ fn env_fingerprint(env: &EnvSnapshot) -> u64 {
     let mut hasher = DefaultHasher::new();
     env.raw_path.hash(&mut hasher);
     env.raw_pathext.hash(&mut hasher);
+    // The workspace switch is an environment input like PATH: a fallback hit
+    // cached while the switch was on must not answer a resolution made with
+    // it off, and vice versa.
+    env.workspace_switch_fingerprint().hash(&mut hasher);
     hasher.finish()
 }
 
@@ -265,6 +269,40 @@ mod tests {
         );
 
         ensure!(key_a != key_b, "skip lists must influence cache key");
+        Ok(())
+    }
+
+    /// Differing workspace-switch readings must not share a cache entry.
+    ///
+    /// A fallback hit cached while `NETSUKE_WHICH_WORKSPACE` left the search
+    /// enabled would otherwise answer a resolution made with it disabled —
+    /// cross-toggle cache poisoning. The snapshots here differ only in the
+    /// captured raw switch value, so key inequality proves the fingerprint
+    /// covers it.
+    #[test]
+    fn cache_key_differs_when_workspace_switch_differs() -> Result<()> {
+        let temp = TempDir::new()?;
+        let cwd = Utf8PathBuf::from_path_buf(temp.path().to_path_buf())
+            .map_err(|path| anyhow!("temp path should be utf8: {path:?}"))?;
+        let base = EnvSnapshot::capture(Some(cwd.as_path()), Some(std::ffi::OsStr::new("")))?;
+        let options = WhichOptions::default();
+        let skips = WorkspaceSkipList::default();
+
+        let enabled = base
+            .clone()
+            .with_workspace_switch(Err(std::env::VarError::NotPresent));
+        let disabled = base.with_workspace_switch(Ok(String::from("0")));
+        ensure!(
+            enabled.workspace_fallback_enabled() && !disabled.workspace_fallback_enabled(),
+            "the fixtures should sit on opposite sides of the switch"
+        );
+
+        let key_enabled = CacheKey::new("tool", &enabled, &options, &skips);
+        let key_disabled = CacheKey::new("tool", &disabled, &options, &skips);
+        ensure!(
+            key_enabled != key_disabled,
+            "the workspace switch must influence the cache key"
+        );
         Ok(())
     }
 

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -64,6 +64,7 @@ impl EnvSnapshot {
     ) -> Result<Self, ResolveError> {
         let (cwd, raw_path, entries) = capture_common(cwd_override, path_override, env)?;
         let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
+        super::workspace_switch::warn_if_not_unicode(&raw_workspace_switch);
         Ok(Self {
             cwd,
             raw_path,
@@ -86,6 +87,7 @@ impl EnvSnapshot {
             .or_else(|| env.os_string("PATHEXT"));
         let pathext = parse_pathext(raw_pathext.as_deref());
         let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
+        super::workspace_switch::warn_if_not_unicode(&raw_workspace_switch);
         Ok(Self {
             cwd,
             raw_path,
@@ -132,9 +134,9 @@ impl EnvSnapshot {
 
     /// Whether the workspace fallback is enabled for this snapshot.
     ///
-    /// Classified on demand from the captured raw value; the non-UTF-8
-    /// warning therefore fires when a search consults the switch, which is
-    /// where the diagnostic is actionable.
+    /// Classified on demand from the captured raw value by the pure
+    /// classifier; the non-UTF-8 warning has already fired once at capture,
+    /// so repeated consultations of the switch stay silent.
     pub(super) fn workspace_fallback_enabled(&self) -> bool {
         super::workspace_switch::workspace_fallback_enabled_with(|_| {
             self.raw_workspace_switch.clone()
@@ -269,7 +271,15 @@ mod tests {
     //! Unit tests for injected executable-search environment capture.
 
     use super::*;
+    use crate::test_tracing_capture::with_test_subscriber;
     use mockable::MockEnv;
+    use tracing::level_filters::LevelFilter;
+
+    /// The exact warning capture emits for a non-UTF-8 switch value. Asserted
+    /// verbatim: without it the test passes even when the message is replaced
+    /// wholesale, which is precisely what happened before.
+    const NOT_UNICODE_WARNING: &str =
+        "workspace fallback disabled because env var is not valid UTF-8";
 
     #[test]
     fn capture_uses_the_injected_path_provider() {
@@ -297,6 +307,55 @@ mod tests {
             [Utf8Path::new("/configured/bin")]
         );
     }
+
+    /// A non-UTF-8 switch value must warn exactly once, at capture.
+    ///
+    /// The classifier is pure, so the diagnostic lives at the boundary where
+    /// the ambient reading is taken; consulting the switch afterwards adds
+    /// nothing. Silently switching workspace search off would leave a user
+    /// whose variable is mis-encoded with commands mysteriously unresolved
+    /// and no indication why.
+    #[test]
+    fn capture_warns_once_for_a_non_utf8_workspace_switch() {
+        let mut env = MockEnv::new();
+        env.expect_os_string()
+            .withf(|key| key == "PATH")
+            .once()
+            .return_once(|_| Some(OsString::from("/configured/bin")));
+        env.expect_raw()
+            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
+            .once()
+            .return_const(Err(std::env::VarError::NotUnicode(OsString::from(
+                "ignored",
+            ))));
+
+        let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
+            let snapshot =
+                EnvSnapshot::capture_with_env(Some(Utf8Path::new("/workspace")), None, &env)
+                    .expect("a non-UTF-8 switch value should not fail capture");
+            (snapshot.workspace_fallback_enabled(), captured.snapshot())
+        });
+
+        assert!(!enabled, "a non-UTF-8 value must disable the fallback");
+        // The subscriber admits WARN and above, so the level is asserted by
+        // the filter; requiring exactly one event proves the warning fires at
+        // capture and is not repeated when the switch is consulted.
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one warning, got {events:?}"
+        );
+        assert!(
+            events.iter().any(|event| {
+                event.contains(super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
+                    && event.contains(NOT_UNICODE_WARNING)
+            }),
+            "expected a warning naming {} and carrying {:?}, got {:?}",
+            super::super::workspace_switch::WORKSPACE_FALLBACK_ENV,
+            NOT_UNICODE_WARNING,
+            events
+        );
+    }
 }
 
 #[cfg(all(test, windows))]
@@ -317,6 +376,12 @@ mod windows_tests {
             .withf(|key| key == "PATHEXT")
             .once()
             .return_once(|_| Some(OsString::from(".EXE;exe; CMD ;.cmd")));
+        // Capture also reads the workspace switch through the same provider;
+        // pinning the key keeps that read observable rather than wildcarded.
+        env.expect_raw()
+            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
+            .once()
+            .return_const(Err(std::env::VarError::NotPresent));
 
         let snapshot =
             EnvSnapshot::capture_with_env(Some(Utf8Path::new("C:/workspace")), None, &env)

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -19,6 +19,13 @@ pub(super) struct EnvSnapshot {
     entries: Vec<PathEntry>,
     #[cfg(windows)]
     pathext: Vec<String>,
+    /// The raw `NETSUKE_WHICH_WORKSPACE` reading taken at capture.
+    ///
+    /// Stored as data rather than a decision so the cache fingerprint can
+    /// hash it — two resolutions differing only in this switch must not
+    /// share a cache entry — and so `env` depends only on the leaf
+    /// `workspace_switch` module rather than calling into `lookup`.
+    raw_workspace_switch: Result<String, std::env::VarError>,
 }
 
 impl EnvSnapshot {
@@ -56,11 +63,13 @@ impl EnvSnapshot {
         env: &impl Env,
     ) -> Result<Self, ResolveError> {
         let (cwd, raw_path, entries) = capture_common(cwd_override, path_override, env)?;
+        let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
         Ok(Self {
             cwd,
             raw_path,
             raw_pathext: None,
             entries,
+            raw_workspace_switch,
         })
     }
 
@@ -76,12 +85,14 @@ impl EnvSnapshot {
             .map(OsString::from)
             .or_else(|| env.os_string("PATHEXT"));
         let pathext = parse_pathext(raw_pathext.as_deref());
+        let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
         Ok(Self {
             cwd,
             raw_path,
             raw_pathext,
             entries,
             pathext,
+            raw_workspace_switch,
         })
     }
 
@@ -117,6 +128,36 @@ impl EnvSnapshot {
     #[cfg(windows)]
     pub(super) fn pathext(&self) -> &[String] {
         &self.pathext
+    }
+
+    /// Whether the workspace fallback is enabled for this snapshot.
+    ///
+    /// Classified on demand from the captured raw value; the non-UTF-8
+    /// warning therefore fires when a search consults the switch, which is
+    /// where the diagnostic is actionable.
+    pub(super) fn workspace_fallback_enabled(&self) -> bool {
+        super::workspace_switch::workspace_fallback_enabled_with(|_| {
+            self.raw_workspace_switch.clone()
+        })
+    }
+
+    /// Replace the captured switch reading, for cache-key tests.
+    #[cfg(test)]
+    pub(super) fn with_workspace_switch(mut self, raw: Result<String, std::env::VarError>) -> Self {
+        self.raw_workspace_switch = raw;
+        self
+    }
+
+    /// The switch reading in the shape the cache fingerprint hashes.
+    ///
+    /// `VarError` is not `Hash`, so the three states are flattened to a
+    /// discriminant plus the value when present.
+    pub(super) const fn workspace_switch_fingerprint(&self) -> (u8, Option<&str>) {
+        match &self.raw_workspace_switch {
+            Ok(value) => (0, Some(value.as_str())),
+            Err(std::env::VarError::NotPresent) => (1, None),
+            Err(std::env::VarError::NotUnicode(_)) => (2, None),
+        }
     }
 }
 
@@ -240,6 +281,12 @@ mod tests {
             .withf(|key| key == "PATH")
             .once()
             .return_once(move |_| Some(configured));
+        // Capture also reads the workspace switch through the same provider;
+        // pinning the key keeps that read observable rather than wildcarded.
+        env.expect_raw()
+            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
+            .once()
+            .return_const(Err(std::env::VarError::NotPresent));
 
         let snapshot = EnvSnapshot::capture_with_env(Some(cwd), None, &env)
             .expect("injected PATH should produce an environment snapshot");

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -9,7 +9,45 @@ use mockable::{DefaultEnv, Env};
 
 use crate::localization::{self, keys};
 
-use super::{options::CwdMode, resolve_error::ResolveError};
+use super::{
+    options::CwdMode,
+    resolve_error::ResolveError,
+    workspace_switch::{WORKSPACE_FALLBACK_ENV, WorkspaceSwitch},
+};
+
+/// Translate a platform reading of the switch into its domain state.
+///
+/// The conversion lives here, in the adapter that performs the read, so
+/// `workspace_switch` never names `std::env::VarError`. It is the single
+/// place the platform error crosses into the resolver's own vocabulary.
+impl From<Result<String, std::env::VarError>> for WorkspaceSwitch {
+    fn from(raw: Result<String, std::env::VarError>) -> Self {
+        match raw {
+            Ok(value) => Self::Value(value),
+            Err(std::env::VarError::NotPresent) => Self::Absent,
+            Err(std::env::VarError::NotUnicode(_)) => Self::NotUnicode,
+        }
+    }
+}
+
+/// Read and translate the workspace switch, warning about a mis-encoded value.
+///
+/// Both capture variants funnel through here so the diagnostic fires exactly
+/// once per capture, at the boundary where the ambient read happens, rather
+/// than on every consultation of the switch. Silently switching workspace
+/// search off would leave a user whose variable is mis-encoded with commands
+/// mysteriously unresolved and no indication why. Only the variable's name is
+/// logged; its value never is.
+fn capture_workspace_switch(env: &impl Env) -> WorkspaceSwitch {
+    let switch = WorkspaceSwitch::from(env.raw(WORKSPACE_FALLBACK_ENV));
+    if matches!(switch, WorkspaceSwitch::NotUnicode) {
+        tracing::warn!(
+            env = WORKSPACE_FALLBACK_ENV,
+            "workspace fallback disabled because env var is not valid UTF-8",
+        );
+    }
+    switch
+}
 
 #[derive(Clone, Debug)]
 pub(super) struct EnvSnapshot {
@@ -19,13 +57,13 @@ pub(super) struct EnvSnapshot {
     entries: Vec<PathEntry>,
     #[cfg(windows)]
     pathext: Vec<String>,
-    /// The raw `NETSUKE_WHICH_WORKSPACE` reading taken at capture.
+    /// The `NETSUKE_WHICH_WORKSPACE` state captured for this snapshot.
     ///
     /// Stored as data rather than a decision so the cache fingerprint can
     /// hash it — two resolutions differing only in this switch must not
     /// share a cache entry — and so `env` depends only on the leaf
     /// `workspace_switch` module rather than calling into `lookup`.
-    raw_workspace_switch: Result<String, std::env::VarError>,
+    workspace_switch: WorkspaceSwitch,
 }
 
 impl EnvSnapshot {
@@ -63,14 +101,13 @@ impl EnvSnapshot {
         env: &impl Env,
     ) -> Result<Self, ResolveError> {
         let (cwd, raw_path, entries) = capture_common(cwd_override, path_override, env)?;
-        let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
-        super::workspace_switch::warn_if_not_unicode(&raw_workspace_switch);
+        let workspace_switch = capture_workspace_switch(env);
         Ok(Self {
             cwd,
             raw_path,
             raw_pathext: None,
             entries,
-            raw_workspace_switch,
+            workspace_switch,
         })
     }
 
@@ -86,15 +123,14 @@ impl EnvSnapshot {
             .map(OsString::from)
             .or_else(|| env.os_string("PATHEXT"));
         let pathext = parse_pathext(raw_pathext.as_deref());
-        let raw_workspace_switch = env.raw(super::workspace_switch::WORKSPACE_FALLBACK_ENV);
-        super::workspace_switch::warn_if_not_unicode(&raw_workspace_switch);
+        let workspace_switch = capture_workspace_switch(env);
         Ok(Self {
             cwd,
             raw_path,
             raw_pathext,
             entries,
             pathext,
-            raw_workspace_switch,
+            workspace_switch,
         })
     }
 
@@ -134,32 +170,23 @@ impl EnvSnapshot {
 
     /// Whether the workspace fallback is enabled for this snapshot.
     ///
-    /// Classified on demand from the captured raw value by the pure
-    /// classifier; the non-UTF-8 warning has already fired once at capture,
-    /// so repeated consultations of the switch stay silent.
+    /// Decided on demand from the captured state; the non-UTF-8 warning has
+    /// already fired once at capture, so repeated consultations of the switch
+    /// stay silent.
     pub(super) fn workspace_fallback_enabled(&self) -> bool {
-        super::workspace_switch::workspace_fallback_enabled_with(|_| {
-            self.raw_workspace_switch.clone()
-        })
+        self.workspace_switch.enabled()
     }
 
-    /// Replace the captured switch reading, for cache-key tests.
+    /// Replace the captured switch state, for cache-key tests.
     #[cfg(test)]
-    pub(super) fn with_workspace_switch(mut self, raw: Result<String, std::env::VarError>) -> Self {
-        self.raw_workspace_switch = raw;
+    pub(super) fn with_workspace_switch(mut self, switch: WorkspaceSwitch) -> Self {
+        self.workspace_switch = switch;
         self
     }
 
-    /// The switch reading in the shape the cache fingerprint hashes.
-    ///
-    /// `VarError` is not `Hash`, so the three states are flattened to a
-    /// discriminant plus the value when present.
-    pub(super) const fn workspace_switch_fingerprint(&self) -> (u8, Option<&str>) {
-        match &self.raw_workspace_switch {
-            Ok(value) => (0, Some(value.as_str())),
-            Err(std::env::VarError::NotPresent) => (1, None),
-            Err(std::env::VarError::NotUnicode(_)) => (2, None),
-        }
+    /// The captured switch state, as the cache fingerprint hashes it.
+    pub(super) const fn workspace_switch(&self) -> &WorkspaceSwitch {
+        &self.workspace_switch
     }
 }
 
@@ -267,126 +294,9 @@ pub(super) fn candidate_paths(
 }
 
 #[cfg(all(test, not(windows)))]
-mod tests {
-    //! Unit tests for injected executable-search environment capture.
-
-    use super::*;
-    use crate::test_tracing_capture::with_test_subscriber;
-    use mockable::MockEnv;
-    use tracing::level_filters::LevelFilter;
-
-    /// The exact warning capture emits for a non-UTF-8 switch value. Asserted
-    /// verbatim: without it the test passes even when the message is replaced
-    /// wholesale, which is precisely what happened before.
-    const NOT_UNICODE_WARNING: &str =
-        "workspace fallback disabled because env var is not valid UTF-8";
-
-    #[test]
-    fn capture_uses_the_injected_path_provider() {
-        let cwd = Utf8Path::new("/workspace");
-        let configured = OsString::from("/configured/bin");
-        let expected = configured.clone();
-        let mut env = MockEnv::new();
-        env.expect_os_string()
-            .withf(|key| key == "PATH")
-            .once()
-            .return_once(move |_| Some(configured));
-        // Capture also reads the workspace switch through the same provider;
-        // pinning the key keeps that read observable rather than wildcarded.
-        env.expect_raw()
-            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
-            .once()
-            .return_const(Err(std::env::VarError::NotPresent));
-
-        let snapshot = EnvSnapshot::capture_with_env(Some(cwd), None, &env)
-            .expect("injected PATH should produce an environment snapshot");
-
-        assert_eq!(snapshot.raw_path, Some(expected));
-        assert_eq!(
-            snapshot.resolved_dirs(CwdMode::Never),
-            [Utf8Path::new("/configured/bin")]
-        );
-    }
-
-    /// A non-UTF-8 switch value must warn exactly once, at capture.
-    ///
-    /// The classifier is pure, so the diagnostic lives at the boundary where
-    /// the ambient reading is taken; consulting the switch afterwards adds
-    /// nothing. Silently switching workspace search off would leave a user
-    /// whose variable is mis-encoded with commands mysteriously unresolved
-    /// and no indication why.
-    #[test]
-    fn capture_warns_once_for_a_non_utf8_workspace_switch() {
-        let mut env = MockEnv::new();
-        env.expect_os_string()
-            .withf(|key| key == "PATH")
-            .once()
-            .return_once(|_| Some(OsString::from("/configured/bin")));
-        env.expect_raw()
-            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
-            .once()
-            .return_const(Err(std::env::VarError::NotUnicode(OsString::from(
-                "ignored",
-            ))));
-
-        let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
-            let snapshot =
-                EnvSnapshot::capture_with_env(Some(Utf8Path::new("/workspace")), None, &env)
-                    .expect("a non-UTF-8 switch value should not fail capture");
-            (snapshot.workspace_fallback_enabled(), captured.snapshot())
-        });
-
-        assert!(!enabled, "a non-UTF-8 value must disable the fallback");
-        // The subscriber admits WARN and above, so the level is asserted by
-        // the filter; requiring exactly one event proves the warning fires at
-        // capture and is not repeated when the switch is consulted.
-        assert_eq!(
-            events.len(),
-            1,
-            "expected exactly one warning, got {events:?}"
-        );
-        assert!(
-            events.iter().any(|event| {
-                event.contains(super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
-                    && event.contains(NOT_UNICODE_WARNING)
-            }),
-            "expected a warning naming {} and carrying {:?}, got {:?}",
-            super::super::workspace_switch::WORKSPACE_FALLBACK_ENV,
-            NOT_UNICODE_WARNING,
-            events
-        );
-    }
-}
+#[path = "env_tests.rs"]
+mod tests;
 
 #[cfg(all(test, windows))]
-mod windows_tests {
-    //! Windows-specific injected `PATH` and `PATHEXT` capture tests.
-
-    use super::*;
-    use mockable::MockEnv;
-
-    #[test]
-    fn capture_uses_injected_and_normalized_pathext() {
-        let mut env = MockEnv::new();
-        env.expect_os_string()
-            .withf(|key| key == "PATH")
-            .once()
-            .return_once(|_| Some(OsString::from(r"C:\configured\bin")));
-        env.expect_os_string()
-            .withf(|key| key == "PATHEXT")
-            .once()
-            .return_once(|_| Some(OsString::from(".EXE;exe; CMD ;.cmd")));
-        // Capture also reads the workspace switch through the same provider;
-        // pinning the key keeps that read observable rather than wildcarded.
-        env.expect_raw()
-            .withf(|key| key == super::super::workspace_switch::WORKSPACE_FALLBACK_ENV)
-            .once()
-            .return_const(Err(std::env::VarError::NotPresent));
-
-        let snapshot =
-            EnvSnapshot::capture_with_env(Some(Utf8Path::new("C:/workspace")), None, &env)
-                .expect("injected PATH and PATHEXT should produce an environment snapshot");
-
-        assert_eq!(snapshot.pathext(), [".exe", ".cmd"]);
-    }
-}
+#[path = "env_windows_tests.rs"]
+mod windows_tests;

--- a/src/stdlib/which/env_tests.rs
+++ b/src/stdlib/which/env_tests.rs
@@ -1,0 +1,84 @@
+//! Unit tests for injected executable-search environment capture.
+
+use super::*;
+use crate::test_tracing_capture::with_test_subscriber;
+use mockable::MockEnv;
+use tracing::level_filters::LevelFilter;
+
+/// The exact warning capture emits for a non-UTF-8 switch value. Asserted
+/// verbatim: without it the test passes even when the message is replaced
+/// wholesale, which is precisely what happened before.
+const NOT_UNICODE_WARNING: &str = "workspace fallback disabled because env var is not valid UTF-8";
+
+#[test]
+fn capture_uses_the_injected_path_provider() {
+    let cwd = Utf8Path::new("/workspace");
+    let configured = OsString::from("/configured/bin");
+    let expected = configured.clone();
+    let mut env = MockEnv::new();
+    env.expect_os_string()
+        .withf(|key| key == "PATH")
+        .once()
+        .return_once(move |_| Some(configured));
+    // Capture also reads the workspace switch through the same provider;
+    // pinning the key keeps that read observable rather than wildcarded.
+    env.expect_raw()
+        .withf(|key| key == WORKSPACE_FALLBACK_ENV)
+        .once()
+        .return_const(Err(std::env::VarError::NotPresent));
+
+    let snapshot = EnvSnapshot::capture_with_env(Some(cwd), None, &env)
+        .expect("injected PATH should produce an environment snapshot");
+
+    assert_eq!(snapshot.raw_path, Some(expected));
+    assert_eq!(
+        snapshot.resolved_dirs(CwdMode::Never),
+        [Utf8Path::new("/configured/bin")]
+    );
+}
+
+/// A non-UTF-8 switch value must warn exactly once, at capture.
+///
+/// The classifier is pure, so the diagnostic lives at the boundary where
+/// the ambient reading is taken; consulting the switch afterwards adds
+/// nothing. Silently switching workspace search off would leave a user
+/// whose variable is mis-encoded with commands mysteriously unresolved
+/// and no indication why.
+#[test]
+fn capture_warns_once_for_a_non_utf8_workspace_switch() {
+    let mut env = MockEnv::new();
+    env.expect_os_string()
+        .withf(|key| key == "PATH")
+        .once()
+        .return_once(|_| Some(OsString::from("/configured/bin")));
+    env.expect_raw()
+        .withf(|key| key == WORKSPACE_FALLBACK_ENV)
+        .once()
+        .return_const(Err(std::env::VarError::NotUnicode(OsString::from(
+            "ignored",
+        ))));
+
+    let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
+        let snapshot = EnvSnapshot::capture_with_env(Some(Utf8Path::new("/workspace")), None, &env)
+            .expect("a non-UTF-8 switch value should not fail capture");
+        (snapshot.workspace_fallback_enabled(), captured.snapshot())
+    });
+
+    assert!(!enabled, "a non-UTF-8 value must disable the fallback");
+    // The subscriber admits WARN and above, so the level is asserted by
+    // the filter; requiring exactly one event proves the warning fires at
+    // capture and is not repeated when the switch is consulted.
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one warning, got {events:?}"
+    );
+    let expectation =
+        format!("a warning naming {WORKSPACE_FALLBACK_ENV} carrying {NOT_UNICODE_WARNING:?}");
+    assert!(
+        events.iter().any(|event| {
+            event.contains(WORKSPACE_FALLBACK_ENV) && event.contains(NOT_UNICODE_WARNING)
+        }),
+        "expected {expectation}, got {events:?}"
+    );
+}

--- a/src/stdlib/which/env_windows_tests.rs
+++ b/src/stdlib/which/env_windows_tests.rs
@@ -1,0 +1,28 @@
+//! Windows-specific injected `PATH` and `PATHEXT` capture tests.
+
+use super::*;
+use mockable::MockEnv;
+
+#[test]
+fn capture_uses_injected_and_normalized_pathext() {
+    let mut env = MockEnv::new();
+    env.expect_os_string()
+        .withf(|key| key == "PATH")
+        .once()
+        .return_once(|_| Some(OsString::from(r"C:\configured\bin")));
+    env.expect_os_string()
+        .withf(|key| key == "PATHEXT")
+        .once()
+        .return_once(|_| Some(OsString::from(".EXE;exe; CMD ;.cmd")));
+    // Capture also reads the workspace switch through the same provider;
+    // pinning the key keeps that read observable rather than wildcarded.
+    env.expect_raw()
+        .withf(|key| key == WORKSPACE_FALLBACK_ENV)
+        .once()
+        .return_const(Err(std::env::VarError::NotPresent));
+
+    let snapshot = EnvSnapshot::capture_with_env(Some(Utf8Path::new("C:/workspace")), None, &env)
+        .expect("injected PATH and PATHEXT should produce an environment snapshot");
+
+    assert_eq!(snapshot.pathext(), [".exe", ".cmd"]);
+}

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -304,6 +304,7 @@ fn resolve_direct_appends_pathext(workspace: Result<TempWorkspace>) -> Result<()
         raw_pathext: Some(".bat".into()),
         entries: vec![],
         pathext: vec![".bat".into()],
+        raw_workspace_switch: Err(std::env::VarError::NotPresent),
     };
 
     let matches = resolve_direct(".\\tools\\gradlew", &snapshot, &WhichOptions::default())?;

--- a/src/stdlib/which/lookup/tests.rs
+++ b/src/stdlib/which/lookup/tests.rs
@@ -286,6 +286,7 @@ fn direct_path_not_executable_raises_direct_not_found(
 #[cfg(windows)]
 #[rstest]
 fn resolve_direct_appends_pathext(workspace: Result<TempWorkspace>) -> Result<()> {
+    use crate::stdlib::which::workspace_switch::WorkspaceSwitch;
     use test_support::exec::make_executable;
 
     let env = workspace?;
@@ -304,7 +305,7 @@ fn resolve_direct_appends_pathext(workspace: Result<TempWorkspace>) -> Result<()
         raw_pathext: Some(".bat".into()),
         entries: vec![],
         pathext: vec![".bat".into()],
-        raw_workspace_switch: Err(std::env::VarError::NotPresent),
+        workspace_switch: WorkspaceSwitch::Absent,
     };
 
     let matches = resolve_direct(".\\tools\\gradlew", &snapshot, &WhichOptions::default())?;

--- a/src/stdlib/which/lookup/workspace/fallback_tests.rs
+++ b/src/stdlib/which/lookup/workspace/fallback_tests.rs
@@ -7,13 +7,8 @@
 //! AGENTS.md testing mandate in-process mutation is not available regardless.
 
 use super::{WORKSPACE_FALLBACK_ENV, workspace_fallback_enabled_with};
-use rstest::rstest;
-
-/// The exact warning `workspace_fallback_enabled_with` emits for a non-UTF-8
-/// value. Asserted verbatim: without it the test passes even when the message
-/// is replaced wholesale, which is precisely what happened before.
-const NOT_UNICODE_WARNING: &str = "workspace fallback disabled because env var is not valid UTF-8";
 use crate::test_tracing_capture::with_test_subscriber;
+use rstest::rstest;
 use std::env::VarError;
 use std::ffi::OsString;
 use tracing::level_filters::LevelFilter;
@@ -77,14 +72,14 @@ fn the_documented_variable_name_is_consulted() {
     assert_eq!(observed.as_deref(), Some(WORKSPACE_FALLBACK_ENV));
 }
 
-/// The non-UTF-8 branch must warn, not merely disable the fallback.
+/// The classifier is pure: classification must emit no events.
 ///
-/// Silently switching workspace search off would leave a user whose `PATHEXT`-
-/// style variable is mis-encoded with commands mysteriously unresolved and no
-/// indication why. The boolean assertion alone would not notice the warning
-/// being deleted.
+/// The non-UTF-8 diagnostic fires once at the capture boundary —
+/// `EnvSnapshot::capture_with_env` calls `warn_if_not_unicode` after the raw
+/// read; see the capture-level test in `env.rs` — so the classifier itself
+/// must stay silent however often the switch is consulted.
 #[test]
-fn non_utf8_value_warns_before_disabling() {
+fn non_utf8_classification_is_silent() {
     let err = VarError::NotUnicode(OsString::from("ignored"));
     let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
         let enabled = workspace_fallback_enabled_with(|_| Err(err));
@@ -92,25 +87,9 @@ fn non_utf8_value_warns_before_disabling() {
     });
 
     assert!(!enabled, "a non-UTF-8 value must disable the fallback");
-    // The subscriber admits WARN and above, so the level is asserted by the
-    // filter rather than by a string prefix; requiring exactly one event keeps
-    // that as strict as the previous `starts_with("WARN")` check.
-    assert_eq!(
-        events.len(),
-        1,
-        "expected exactly one warning, got {events:?}"
-    );
     assert!(
-        events.iter().any(|event| {
-            event.contains(WORKSPACE_FALLBACK_ENV) && event.contains(NOT_UNICODE_WARNING)
-        }),
-        concat!(
-            "expected a warning naming {} and carrying {:?}, ",
-            "got {:?}"
-        ),
-        WORKSPACE_FALLBACK_ENV,
-        NOT_UNICODE_WARNING,
-        events
+        events.is_empty(),
+        "the pure classifier must emit no events, got {events:?}"
     );
 }
 

--- a/src/stdlib/which/lookup/workspace/fallback_tests.rs
+++ b/src/stdlib/which/lookup/workspace/fallback_tests.rs
@@ -1,0 +1,220 @@
+//! Tests for the workspace fallback environment switch.
+//!
+//! These drive `workspace_fallback_enabled_with` directly rather than setting
+//! `NETSUKE_WHICH_WORKSPACE`, so they mutate nothing and run concurrently. The
+//! non-UTF-8 branch is reachable only this way: fabricating such a value in the
+//! live environment needs platform-specific `OsString` surgery, and under the
+//! AGENTS.md testing mandate in-process mutation is not available regardless.
+
+use super::{WORKSPACE_FALLBACK_ENV, workspace_fallback_enabled_with};
+use rstest::rstest;
+
+/// The exact warning `workspace_fallback_enabled_with` emits for a non-UTF-8
+/// value. Asserted verbatim: without it the test passes even when the message
+/// is replaced wholesale, which is precisely what happened before.
+const NOT_UNICODE_WARNING: &str = "workspace fallback disabled because env var is not valid UTF-8";
+use crate::test_tracing_capture::with_test_subscriber;
+use std::env::VarError;
+use std::ffi::OsString;
+use tracing::level_filters::LevelFilter;
+
+/// Values that switch the fallback off, in each accepted spelling and case.
+#[rstest]
+#[case("0")]
+#[case("false")]
+#[case("off")]
+#[case("FALSE")]
+#[case("Off")]
+#[case("OFF")]
+fn disabling_values_switch_the_fallback_off(#[case] value: &str) {
+    assert!(
+        !workspace_fallback_enabled_with(|_| Ok(value.to_owned())),
+        "{value:?} should disable the workspace fallback"
+    );
+}
+
+/// Anything else leaves the fallback on, including values that merely contain
+/// a disabling word.
+#[rstest]
+#[case("1")]
+#[case("true")]
+#[case("on")]
+#[case("")]
+#[case("offbeat")]
+#[case("no")]
+fn other_values_leave_the_fallback_on(#[case] value: &str) {
+    assert!(
+        workspace_fallback_enabled_with(|_| Ok(value.to_owned())),
+        "{value:?} should leave the workspace fallback enabled"
+    );
+}
+
+#[test]
+fn absent_variable_leaves_the_fallback_on() {
+    assert!(
+        workspace_fallback_enabled_with(|_| Err(VarError::NotPresent)),
+        "the fallback is opt-out, so an unset variable must leave it enabled"
+    );
+}
+
+#[test]
+fn non_utf8_value_switches_the_fallback_off() {
+    let err = VarError::NotUnicode(OsString::from("ignored"));
+    assert!(
+        !workspace_fallback_enabled_with(|_| Err(err)),
+        "a non-UTF-8 value must disable the fallback rather than be treated as absent"
+    );
+}
+
+/// The seam must consult the documented variable, not some other name.
+#[test]
+fn the_documented_variable_name_is_consulted() {
+    let mut observed = None;
+    let _ = workspace_fallback_enabled_with(|key| {
+        observed = Some(key.to_owned());
+        Err(VarError::NotPresent)
+    });
+    assert_eq!(observed.as_deref(), Some(WORKSPACE_FALLBACK_ENV));
+}
+
+/// The non-UTF-8 branch must warn, not merely disable the fallback.
+///
+/// Silently switching workspace search off would leave a user whose `PATHEXT`-
+/// style variable is mis-encoded with commands mysteriously unresolved and no
+/// indication why. The boolean assertion alone would not notice the warning
+/// being deleted.
+#[test]
+fn non_utf8_value_warns_before_disabling() {
+    let err = VarError::NotUnicode(OsString::from("ignored"));
+    let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
+        let enabled = workspace_fallback_enabled_with(|_| Err(err));
+        (enabled, captured.snapshot())
+    });
+
+    assert!(!enabled, "a non-UTF-8 value must disable the fallback");
+    // The subscriber admits WARN and above, so the level is asserted by the
+    // filter rather than by a string prefix; requiring exactly one event keeps
+    // that as strict as the previous `starts_with("WARN")` check.
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one warning, got {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.contains(WORKSPACE_FALLBACK_ENV) && event.contains(NOT_UNICODE_WARNING)
+        }),
+        concat!(
+            "expected a warning naming {} and carrying {:?}, ",
+            "got {:?}"
+        ),
+        WORKSPACE_FALLBACK_ENV,
+        NOT_UNICODE_WARNING,
+        events
+    );
+}
+
+mod properties {
+    //! Property coverage for the fallback switch.
+    //!
+    //! The fixed cases name the three disabling spellings; these state the
+    //! classification rule over arbitrary values, using an independent model
+    //! rather than re-deriving the implementation's own `matches!`.
+
+    use super::{WORKSPACE_FALLBACK_ENV, workspace_fallback_enabled_with};
+    use proptest::prelude::*;
+    use std::env::VarError;
+
+    /// The rule, written independently: exactly three values disable it, and
+    /// case is ignored. Deliberately a set lookup rather than the same
+    /// `matches!` the implementation uses, so a change to one does not
+    /// silently change the other.
+    fn model_says_enabled(value: &str) -> bool {
+        const DISABLING: [&str; 3] = ["0", "false", "off"];
+        !DISABLING.contains(&value.to_ascii_lowercase().as_str())
+    }
+
+    /// Every case permutation of one disabling word.
+    ///
+    /// Per-character case flags rather than a fixed spelling list: a
+    /// hardcoded handful of variants cannot catch a normalizer that
+    /// special-cases exactly those spellings, whereas this reaches all
+    /// 2^5 + 2^3 + 1 permutations of `false`, `off`, and `0`.
+    fn case_variant() -> impl Strategy<Value = String> {
+        prop_oneof![
+            1 => Just(String::from("0")),
+            4 => mixed_case("false"),
+            3 => mixed_case("off"),
+        ]
+    }
+
+    /// `word` with each character independently upper- or lowercased.
+    fn mixed_case(word: &'static str) -> impl Strategy<Value = String> {
+        proptest::collection::vec(any::<bool>(), word.len()).prop_map(move |uppers| {
+            word.chars()
+                .zip(uppers)
+                .map(|(ch, upper)| if upper { ch.to_ascii_uppercase() } else { ch })
+                .collect()
+        })
+    }
+
+    proptest! {
+        /// Classification matches the model for any value, however spelled.
+        #[test]
+        fn classification_matches_the_model(value in "\\PC{0,12}") {
+            let expected = model_says_enabled(&value);
+            let diagnostic = format!("value {value:?}");
+            let enabled = workspace_fallback_enabled_with(move |_| Ok(value));
+            prop_assert_eq!(enabled, expected, "{}", diagnostic);
+        }
+
+        /// Every case variant of a disabling word disables the fallback.
+        ///
+        /// Generated separately because a uniform string generator produces
+        /// `"off"` about never, so the interesting half of the rule would go
+        /// untested by the property above alone.
+        #[test]
+        fn case_variants_disable(value in case_variant()) {
+            let diagnostic = format!("{value:?} should disable the fallback");
+            prop_assert!(
+                !workspace_fallback_enabled_with(move |_| Ok(value)),
+                "{}", diagnostic
+            );
+        }
+
+        /// Anything outside the disabling set enables it.
+        #[test]
+        fn other_values_enable(value in "\\PC{0,12}".prop_filter(
+            "must not be a disabling spelling",
+            |v: &String| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        )) {
+            prop_assert!(workspace_fallback_enabled_with(move |_| Ok(value)));
+        }
+
+        /// The variable name asked for is always the documented one.
+        #[test]
+        fn the_queried_key_is_stable(value in "\\PC{0,8}") {
+            let mut seen = None;
+            let seen_slot = &mut seen;
+            let _ = workspace_fallback_enabled_with(move |key| {
+                *seen_slot = Some(key.to_owned());
+                Ok(value)
+            });
+            prop_assert_eq!(seen.as_deref(), Some(WORKSPACE_FALLBACK_ENV));
+        }
+    }
+
+    /// An absent variable enables the fallback; a non-UTF-8 one disables it.
+    ///
+    /// Fixed rather than generated: both are single states, and `VarError`
+    /// has no other inhabitants to explore.
+    #[test]
+    fn error_variants_are_classified() {
+        assert!(workspace_fallback_enabled_with(|_| Err(
+            VarError::NotPresent
+        )));
+        assert!(!workspace_fallback_enabled_with(|_| Err(
+            VarError::NotUnicode(std::ffi::OsString::from("x"))
+        )));
+    }
+}

--- a/src/stdlib/which/lookup/workspace/fallback_tests.rs
+++ b/src/stdlib/which/lookup/workspace/fallback_tests.rs
@@ -1,12 +1,16 @@
 //! Tests for the workspace fallback environment switch.
 //!
-//! These drive `workspace_fallback_enabled_with` directly rather than setting
+//! These construct [`WorkspaceSwitch`] states directly rather than setting
 //! `NETSUKE_WHICH_WORKSPACE`, so they mutate nothing and run concurrently. The
 //! non-UTF-8 branch is reachable only this way: fabricating such a value in the
 //! live environment needs platform-specific `OsString` surgery, and under the
 //! AGENTS.md testing mandate in-process mutation is not available regardless.
+//!
+//! The translation from a platform reading is exercised here too, even though
+//! the `From` implementation lives with the adapter in `env`, because the
+//! mapping is what pins these three states to the environment they model.
 
-use super::{WORKSPACE_FALLBACK_ENV, workspace_fallback_enabled_with};
+use super::{WORKSPACE_FALLBACK_ENV, WorkspaceSwitch};
 use crate::test_tracing_capture::with_test_subscriber;
 use rstest::rstest;
 use std::env::VarError;
@@ -23,7 +27,7 @@ use tracing::level_filters::LevelFilter;
 #[case("OFF")]
 fn disabling_values_switch_the_fallback_off(#[case] value: &str) {
     assert!(
-        !workspace_fallback_enabled_with(|_| Ok(value.to_owned())),
+        !WorkspaceSwitch::Value(value.to_owned()).enabled(),
         "{value:?} should disable the workspace fallback"
     );
 }
@@ -39,7 +43,7 @@ fn disabling_values_switch_the_fallback_off(#[case] value: &str) {
 #[case("no")]
 fn other_values_leave_the_fallback_on(#[case] value: &str) {
     assert!(
-        workspace_fallback_enabled_with(|_| Ok(value.to_owned())),
+        WorkspaceSwitch::Value(value.to_owned()).enabled(),
         "{value:?} should leave the workspace fallback enabled"
     );
 }
@@ -47,49 +51,60 @@ fn other_values_leave_the_fallback_on(#[case] value: &str) {
 #[test]
 fn absent_variable_leaves_the_fallback_on() {
     assert!(
-        workspace_fallback_enabled_with(|_| Err(VarError::NotPresent)),
+        WorkspaceSwitch::Absent.enabled(),
         "the fallback is opt-out, so an unset variable must leave it enabled"
     );
 }
 
 #[test]
 fn non_utf8_value_switches_the_fallback_off() {
-    let err = VarError::NotUnicode(OsString::from("ignored"));
     assert!(
-        !workspace_fallback_enabled_with(|_| Err(err)),
+        !WorkspaceSwitch::NotUnicode.enabled(),
         "a non-UTF-8 value must disable the fallback rather than be treated as absent"
     );
 }
 
-/// The seam must consult the documented variable, not some other name.
-#[test]
-fn the_documented_variable_name_is_consulted() {
-    let mut observed = None;
-    let _ = workspace_fallback_enabled_with(|key| {
-        observed = Some(key.to_owned());
-        Err(VarError::NotPresent)
-    });
-    assert_eq!(observed.as_deref(), Some(WORKSPACE_FALLBACK_ENV));
+/// The adapter maps each platform reading onto the state that models it.
+#[rstest]
+#[case(Ok(String::from("off")), WorkspaceSwitch::Value(String::from("off")))]
+#[case(Err(VarError::NotPresent), WorkspaceSwitch::Absent)]
+#[case(
+    Err(VarError::NotUnicode(OsString::from("ignored"))),
+    WorkspaceSwitch::NotUnicode
+)]
+fn readings_translate_to_switch_states(
+    #[case] raw: Result<String, VarError>,
+    #[case] expected: WorkspaceSwitch,
+) {
+    assert_eq!(WorkspaceSwitch::from(raw), expected);
 }
 
-/// The classifier is pure: classification must emit no events.
+/// The seam must name the documented variable, not some other one.
+///
+/// That the capture boundary actually asks for this key is pinned separately
+/// by the `MockEnv` expectations in the `env` capture tests.
+#[test]
+fn the_documented_variable_name_is_used() {
+    assert_eq!(WORKSPACE_FALLBACK_ENV, "NETSUKE_WHICH_WORKSPACE");
+}
+
+/// The decision is pure: consulting the switch must emit no events.
 ///
 /// The non-UTF-8 diagnostic fires once at the capture boundary —
-/// `EnvSnapshot::capture_with_env` calls `warn_if_not_unicode` after the raw
-/// read; see the capture-level test in `env.rs` — so the classifier itself
-/// must stay silent however often the switch is consulted.
+/// `EnvSnapshot::capture_with_env` warns immediately after the raw read; see
+/// the capture-level test in `env.rs` — so the state itself must stay silent
+/// however often it is consulted.
 #[test]
 fn non_utf8_classification_is_silent() {
-    let err = VarError::NotUnicode(OsString::from("ignored"));
     let (enabled, events) = with_test_subscriber(LevelFilter::WARN, |captured| {
-        let enabled = workspace_fallback_enabled_with(|_| Err(err));
+        let enabled = WorkspaceSwitch::NotUnicode.enabled();
         (enabled, captured.snapshot())
     });
 
     assert!(!enabled, "a non-UTF-8 value must disable the fallback");
     assert!(
         events.is_empty(),
-        "the pure classifier must emit no events, got {events:?}"
+        "consulting the switch must emit no events, got {events:?}"
     );
 }
 
@@ -100,9 +115,8 @@ mod properties {
     //! classification rule over arbitrary values, using an independent model
     //! rather than re-deriving the implementation's own `matches!`.
 
-    use super::{WORKSPACE_FALLBACK_ENV, workspace_fallback_enabled_with};
+    use super::WorkspaceSwitch;
     use proptest::prelude::*;
-    use std::env::VarError;
 
     /// The rule, written independently: exactly three values disable it, and
     /// case is ignored. Deliberately a set lookup rather than the same
@@ -143,7 +157,7 @@ mod properties {
         fn classification_matches_the_model(value in "\\PC{0,12}") {
             let expected = model_says_enabled(&value);
             let diagnostic = format!("value {value:?}");
-            let enabled = workspace_fallback_enabled_with(move |_| Ok(value));
+            let enabled = WorkspaceSwitch::Value(value).enabled();
             prop_assert_eq!(enabled, expected, "{}", diagnostic);
         }
 
@@ -155,10 +169,7 @@ mod properties {
         #[test]
         fn case_variants_disable(value in case_variant()) {
             let diagnostic = format!("{value:?} should disable the fallback");
-            prop_assert!(
-                !workspace_fallback_enabled_with(move |_| Ok(value)),
-                "{}", diagnostic
-            );
+            prop_assert!(!WorkspaceSwitch::Value(value).enabled(), "{}", diagnostic);
         }
 
         /// Anything outside the disabling set enables it.
@@ -167,33 +178,17 @@ mod properties {
             "must not be a disabling spelling",
             |v: &String| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "off"),
         )) {
-            prop_assert!(workspace_fallback_enabled_with(move |_| Ok(value)));
-        }
-
-        /// The variable name asked for is always the documented one.
-        #[test]
-        fn the_queried_key_is_stable(value in "\\PC{0,8}") {
-            let mut seen = None;
-            let seen_slot = &mut seen;
-            let _ = workspace_fallback_enabled_with(move |key| {
-                *seen_slot = Some(key.to_owned());
-                Ok(value)
-            });
-            prop_assert_eq!(seen.as_deref(), Some(WORKSPACE_FALLBACK_ENV));
+            prop_assert!(WorkspaceSwitch::Value(value).enabled());
         }
     }
 
     /// An absent variable enables the fallback; a non-UTF-8 one disables it.
     ///
-    /// Fixed rather than generated: both are single states, and `VarError`
-    /// has no other inhabitants to explore.
+    /// Fixed rather than generated: both are single states with no payload to
+    /// explore.
     #[test]
-    fn error_variants_are_classified() {
-        assert!(workspace_fallback_enabled_with(|_| Err(
-            VarError::NotPresent
-        )));
-        assert!(!workspace_fallback_enabled_with(|_| Err(
-            VarError::NotUnicode(std::ffi::OsString::from("x"))
-        )));
+    fn error_states_are_classified() {
+        assert!(WorkspaceSwitch::Absent.enabled());
+        assert!(!WorkspaceSwitch::NotUnicode.enabled());
     }
 }

--- a/src/stdlib/which/lookup/workspace/mod.rs
+++ b/src/stdlib/which/lookup/workspace/mod.rs
@@ -1,9 +1,6 @@
 //! Workspace fallback search helpers for the `which` resolver.
 
-use std::{
-    env,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
 use camino::Utf8PathBuf;
 use indexmap::IndexSet;
@@ -23,8 +20,6 @@ use windows::search_workspace as platform_search_workspace;
 pub(super) const WORKSPACE_MAX_DEPTH: usize = 6;
 pub(crate) const WORKSPACE_SKIP_DIRS: &[&str] =
     &[".git", "target", "node_modules", "dist", "build"];
-
-const WORKSPACE_FALLBACK_ENV: &str = "NETSUKE_WHICH_WORKSPACE";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WorkspaceSkipList {
@@ -81,9 +76,9 @@ pub(super) fn search_workspace(
     collect_all: bool,
     skip_dirs: &WorkspaceSkipList,
 ) -> Result<Vec<Utf8PathBuf>, ResolveError> {
-    if !workspace_fallback_enabled() {
+    if !env.workspace_fallback_enabled() {
         tracing::debug!(
-            env = WORKSPACE_FALLBACK_ENV,
+            env = crate::stdlib::which::workspace_switch::WORKSPACE_FALLBACK_ENV,
             "workspace which fallback disabled via env override",
         );
         return Ok(Vec::new());
@@ -104,27 +99,6 @@ pub(super) fn should_visit_entry(entry: &walkdir::DirEntry, skip_dirs: &Workspac
     }
     let name = entry.file_name().to_string_lossy();
     !skip_dirs.contains(&name)
-}
-
-#[expect(
-    clippy::disallowed_methods,
-    reason = "composition root: supplies the process environment to the workspace fallback seam"
-)]
-fn workspace_fallback_enabled() -> bool {
-    match env::var(WORKSPACE_FALLBACK_ENV) {
-        Ok(value) => {
-            let normalised = value.to_ascii_lowercase();
-            !matches!(normalised.as_str(), "0" | "false" | "off")
-        }
-        Err(env::VarError::NotPresent) => true,
-        Err(env::VarError::NotUnicode(_)) => {
-            tracing::warn!(
-                env = WORKSPACE_FALLBACK_ENV,
-                "workspace fallback disabled because env var is not valid UTF-8",
-            );
-            false
-        }
-    }
 }
 
 /// Convert a walkdir item to an entry, propagating traversal errors as

--- a/src/stdlib/which/mod.rs
+++ b/src/stdlib/which/mod.rs
@@ -18,6 +18,7 @@ mod env;
 mod lookup;
 mod options;
 mod resolve_error;
+mod workspace_switch;
 pub(crate) use lookup::{WORKSPACE_SKIP_DIRS, WorkspaceSkipList};
 
 pub(crate) use cache::WhichResolver;

--- a/src/stdlib/which/workspace_switch.rs
+++ b/src/stdlib/which/workspace_switch.rs
@@ -1,0 +1,56 @@
+//! The `NETSUKE_WHICH_WORKSPACE` opt-out switch for the workspace fallback.
+//!
+//! A leaf module by design: `env::EnvSnapshot::capture` reads the variable at
+//! the resolver's ambient boundary and stores the raw result as snapshot
+//! data, and `lookup::workspace` classifies that data when deciding whether
+//! to search. Placing the name and the pure classifier here keeps both
+//! consumers pointing downward — the earlier arrangement had `env` calling
+//! back into `lookup::workspace`, a module cycle.
+
+use std::env;
+
+/// The variable a user sets to switch the workspace fallback off.
+pub(super) const WORKSPACE_FALLBACK_ENV: &str = "NETSUKE_WHICH_WORKSPACE";
+
+/// Decide whether the workspace fallback is enabled, reading through `read_env`.
+///
+/// This is the pure decision function; it owns no composition root. The
+/// process-backed value is captured by `EnvSnapshot::capture` alongside the
+/// resolver's other ambient reads, and the decision is derived from the
+/// snapshot. Keeping the seam pure means the three outcomes — an explicit
+/// value, an absent variable, and a non-UTF-8 value — can each be exercised
+/// without mutating the process environment. The non-UTF-8 branch is
+/// otherwise unreachable from a test, because constructing such a value
+/// requires platform-specific `OsString` surgery on the live environment.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // A disabling value switches the fallback off, case-insensitively.
+/// assert!(!workspace_fallback_enabled_with(|_| Ok("OFF".to_owned())));
+/// // The switch is opt-out, so an unset variable leaves it enabled.
+/// assert!(workspace_fallback_enabled_with(|_| Err(env::VarError::NotPresent)));
+/// ```
+pub(super) fn workspace_fallback_enabled_with<F>(read_env: F) -> bool
+where
+    F: FnOnce(&str) -> Result<String, env::VarError>,
+{
+    match read_env(WORKSPACE_FALLBACK_ENV) {
+        Ok(value) => {
+            let normalised = value.to_ascii_lowercase();
+            !matches!(normalised.as_str(), "0" | "false" | "off")
+        }
+        Err(env::VarError::NotPresent) => true,
+        Err(env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                env = WORKSPACE_FALLBACK_ENV,
+                "workspace fallback disabled because env var is not valid UTF-8",
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "lookup/workspace/fallback_tests.rs"]
+mod fallback_tests;

--- a/src/stdlib/which/workspace_switch.rs
+++ b/src/stdlib/which/workspace_switch.rs
@@ -14,14 +14,16 @@ pub(super) const WORKSPACE_FALLBACK_ENV: &str = "NETSUKE_WHICH_WORKSPACE";
 
 /// Decide whether the workspace fallback is enabled, reading through `read_env`.
 ///
-/// This is the pure decision function; it owns no composition root. The
-/// process-backed value is captured by `EnvSnapshot::capture` alongside the
-/// resolver's other ambient reads, and the decision is derived from the
-/// snapshot. Keeping the seam pure means the three outcomes — an explicit
-/// value, an absent variable, and a non-UTF-8 value — can each be exercised
-/// without mutating the process environment. The non-UTF-8 branch is
-/// otherwise unreachable from a test, because constructing such a value
-/// requires platform-specific `OsString` surgery on the live environment.
+/// This is the pure decision function; it owns no composition root and emits
+/// no diagnostics. The process-backed value is captured by
+/// `EnvSnapshot::capture` alongside the resolver's other ambient reads, and
+/// the decision is derived from the snapshot; the non-UTF-8 warning fires
+/// once at capture via [`warn_if_not_unicode`]. Keeping the seam pure means
+/// the three outcomes — an explicit value, an absent variable, and a
+/// non-UTF-8 value — can each be exercised without mutating the process
+/// environment. The non-UTF-8 branch is otherwise unreachable from a test,
+/// because constructing such a value requires platform-specific `OsString`
+/// surgery on the live environment.
 ///
 /// # Examples
 ///
@@ -41,13 +43,23 @@ where
             !matches!(normalised.as_str(), "0" | "false" | "off")
         }
         Err(env::VarError::NotPresent) => true,
-        Err(env::VarError::NotUnicode(_)) => {
-            tracing::warn!(
-                env = WORKSPACE_FALLBACK_ENV,
-                "workspace fallback disabled because env var is not valid UTF-8",
-            );
-            false
-        }
+        Err(env::VarError::NotUnicode(_)) => false,
+    }
+}
+
+/// Warn when a captured switch reading is not valid UTF-8.
+///
+/// Called by `EnvSnapshot::capture_impl` immediately after the raw reading is
+/// taken, so the diagnostic fires exactly once per capture rather than on
+/// every classification. Silently switching workspace search off would leave
+/// a user whose variable is mis-encoded with commands mysteriously unresolved
+/// and no indication why.
+pub(super) fn warn_if_not_unicode(raw: &Result<String, env::VarError>) {
+    if matches!(raw, Err(env::VarError::NotUnicode(_))) {
+        tracing::warn!(
+            env = WORKSPACE_FALLBACK_ENV,
+            "workspace fallback disabled because env var is not valid UTF-8",
+        );
     }
 }
 

--- a/src/stdlib/which/workspace_switch.rs
+++ b/src/stdlib/which/workspace_switch.rs
@@ -1,65 +1,64 @@
 //! The `NETSUKE_WHICH_WORKSPACE` opt-out switch for the workspace fallback.
 //!
 //! A leaf module by design: `env::EnvSnapshot::capture` reads the variable at
-//! the resolver's ambient boundary and stores the raw result as snapshot
-//! data, and `lookup::workspace` classifies that data when deciding whether
-//! to search. Placing the name and the pure classifier here keeps both
-//! consumers pointing downward — the earlier arrangement had `env` calling
-//! back into `lookup::workspace`, a module cycle.
-
-use std::env;
+//! the resolver's ambient boundary, translates the reading into
+//! [`WorkspaceSwitch`], and stores that as snapshot data; `lookup::workspace`
+//! asks the stored state whether to search. Placing the name and the domain
+//! state here keeps both consumers pointing downward — the earlier
+//! arrangement had `env` calling back into `lookup::workspace`, a module
+//! cycle.
+//!
+//! The state is deliberately infrastructure-free: it names no
+//! `std::env::VarError` and emits no diagnostics. Translating the platform
+//! reading and warning about a mis-encoded value both belong to the adapter
+//! that performs the read, so `env` owns the `From` conversion and the
+//! non-UTF-8 warning.
 
 /// The variable a user sets to switch the workspace fallback off.
 pub(super) const WORKSPACE_FALLBACK_ENV: &str = "NETSUKE_WHICH_WORKSPACE";
 
-/// Decide whether the workspace fallback is enabled, reading through `read_env`.
+/// The workspace switch as captured, in domain terms.
 ///
-/// This is the pure decision function; it owns no composition root and emits
-/// no diagnostics. The process-backed value is captured by
-/// `EnvSnapshot::capture` alongside the resolver's other ambient reads, and
-/// the decision is derived from the snapshot; the non-UTF-8 warning fires
-/// once at capture via [`warn_if_not_unicode`]. Keeping the seam pure means
-/// the three outcomes — an explicit value, an absent variable, and a
-/// non-UTF-8 value — can each be exercised without mutating the process
-/// environment. The non-UTF-8 branch is otherwise unreachable from a test,
-/// because constructing such a value requires platform-specific `OsString`
-/// surgery on the live environment.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// // A disabling value switches the fallback off, case-insensitively.
-/// assert!(!workspace_fallback_enabled_with(|_| Ok("OFF".to_owned())));
-/// // The switch is opt-out, so an unset variable leaves it enabled.
-/// assert!(workspace_fallback_enabled_with(|_| Err(env::VarError::NotPresent)));
-/// ```
-pub(super) fn workspace_fallback_enabled_with<F>(read_env: F) -> bool
-where
-    F: FnOnce(&str) -> Result<String, env::VarError>,
-{
-    match read_env(WORKSPACE_FALLBACK_ENV) {
-        Ok(value) => {
-            let normalised = value.to_ascii_lowercase();
-            !matches!(normalised.as_str(), "0" | "false" | "off")
-        }
-        Err(env::VarError::NotPresent) => true,
-        Err(env::VarError::NotUnicode(_)) => false,
-    }
+/// Three states rather than a bare `bool` because the cache fingerprint must
+/// distinguish them — two resolutions differing only in this switch must not
+/// share a cache entry — and because the adapter reports the non-UTF-8 case
+/// to the user. `Hash` is derived, so the fingerprint hashes the state
+/// directly instead of flattening a non-`Hash` platform error.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum WorkspaceSwitch {
+    /// The variable was set to this value.
+    Value(String),
+    /// The variable was not set at all.
+    Absent,
+    /// The variable was set to a value that is not valid UTF-8.
+    NotUnicode,
 }
 
-/// Warn when a captured switch reading is not valid UTF-8.
-///
-/// Called by `EnvSnapshot::capture_impl` immediately after the raw reading is
-/// taken, so the diagnostic fires exactly once per capture rather than on
-/// every classification. Silently switching workspace search off would leave
-/// a user whose variable is mis-encoded with commands mysteriously unresolved
-/// and no indication why.
-pub(super) fn warn_if_not_unicode(raw: &Result<String, env::VarError>) {
-    if matches!(raw, Err(env::VarError::NotUnicode(_))) {
-        tracing::warn!(
-            env = WORKSPACE_FALLBACK_ENV,
-            "workspace fallback disabled because env var is not valid UTF-8",
-        );
+impl WorkspaceSwitch {
+    /// Whether this state leaves the workspace fallback enabled.
+    ///
+    /// The switch is opt-out: an absent variable leaves the search on. A
+    /// mis-encoded value switches it off rather than being treated as absent,
+    /// because the user plainly meant to set something and guessing at the
+    /// intent would be worse than declining to search.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // A disabling value switches the fallback off, case-insensitively.
+    /// assert!(!WorkspaceSwitch::Value("OFF".to_owned()).enabled());
+    /// // The switch is opt-out, so an unset variable leaves it enabled.
+    /// assert!(WorkspaceSwitch::Absent.enabled());
+    /// ```
+    pub(super) fn enabled(&self) -> bool {
+        match self {
+            Self::Value(value) => {
+                let normalised = value.to_ascii_lowercase();
+                !matches!(normalised.as_str(), "0" | "false" | "off")
+            }
+            Self::Absent => true,
+            Self::NotUnicode => false,
+        }
     }
 }
 

--- a/tests/features_unix/clean.feature
+++ b/tests/features_unix/clean.feature
@@ -28,3 +28,10 @@ Feature: Clean subcommand execution
     And the CLI uses the temporary directory
     When the clean process is run
     Then the command should succeed
+
+  Scenario: Clean respects combined directory and file flags
+    Given a fake ninja executable that expects the clean tool
+    And the CLI is parsed with "-C work --file custom.yml clean"
+    And the CLI uses the temporary directory
+    When the clean process is run
+    Then the command should succeed

--- a/tests/stdlib_workspace_switch_tests.rs
+++ b/tests/stdlib_workspace_switch_tests.rs
@@ -1,0 +1,70 @@
+//! Behavioural coverage for `NETSUKE_WHICH_WORKSPACE` at the process boundary.
+//!
+//! The classification rule is covered exhaustively at its pure seam
+//! (`src/stdlib/which/workspace_switch.rs`); these cases prove the switch
+//! observed by a real `netsuke` process changes `command_available`'s
+//! answer. The variable reaches the child through `Command::env`, never by
+//! mutating this process (#493), which is why the boundary test is a
+//! subprocess test.
+
+use anyhow::{Context, Result, ensure};
+use test_support::fs as test_fs;
+use test_support::netsuke::run_netsuke_in_with_env;
+
+const SWITCH: &str = "NETSUKE_WHICH_WORKSPACE";
+
+/// A manifest whose generated output encodes `command_available`'s verdict.
+const MANIFEST: &str = concat!(
+    "netsuke_version: \"1.0.0\"\n",
+    "targets:\n",
+    "  - name: \"probe-{{ command_available('netsuke_workspace_probe') }}.txt\"\n",
+    "    command: \"true\"\n",
+);
+
+/// Build a workspace whose only copy of the probe lives inside the tree.
+///
+/// The probe is deliberately absent from the child's `PATH`, so a `true`
+/// verdict can come only from the workspace fallback.
+fn probe_workspace() -> Result<tempfile::TempDir> {
+    let temp = tempfile::tempdir().context("create workspace")?;
+    test_fs::write(temp.path().join("Netsukefile"), MANIFEST).context("write manifest")?;
+    let tools = temp.path().join("tools");
+    test_fs::create_dir_all(&tools).context("create tools dir")?;
+    let probe = tools.join("netsuke_workspace_probe");
+    test_fs::write(&probe, "#!/bin/sh\nexit 0\n").context("write probe")?;
+    test_fs::set_mode(&probe, 0o755).context("chmod probe")?;
+    Ok(temp)
+}
+
+/// Generate the Ninja file with `switch` applied and report the verdict.
+fn probe_verdict(temp: &tempfile::TempDir, switch: Option<&str>) -> Result<String> {
+    // The workspace fallback engages only when the child's PATH is empty or
+    // absent, so the probe cannot be masked by host tooling; an empty PATH
+    // override is therefore part of the boundary being tested.
+    let mut env: Vec<(&str, &str)> = vec![("PATH", "")];
+    if let Some(value) = switch {
+        env.push((SWITCH, value));
+    }
+    let run = run_netsuke_in_with_env(temp.path(), &["generate", "--output", "out.ninja"], &env)?;
+    ensure!(run.success, "generate should succeed: {}", run.stderr);
+    test_fs::read_to_string(temp.path().join("out.ninja")).context("read generated ninja")
+}
+
+#[cfg(unix)]
+#[test]
+fn the_switch_gates_the_workspace_fallback_end_to_end() -> Result<()> {
+    let temp = probe_workspace()?;
+
+    let enabled = probe_verdict(&temp, None)?;
+    ensure!(
+        enabled.contains("probe-true.txt"),
+        "with the switch unset the workspace fallback should find the probe:\n{enabled}"
+    );
+
+    let disabled = probe_verdict(&temp, Some("0"))?;
+    ensure!(
+        disabled.contains("probe-false.txt"),
+        "with the switch set to 0 the fallback must not run:\n{disabled}"
+    );
+    Ok(())
+}

--- a/tests/stdlib_workspace_switch_tests.rs
+++ b/tests/stdlib_workspace_switch_tests.rs
@@ -6,6 +6,11 @@
 //! answer. The variable reaches the child through `Command::env`, never by
 //! mutating this process (#493), which is why the boundary test is a
 //! subprocess test.
+//!
+//! Unix-gated at the crate level: the probe is a shell script, so on other
+//! hosts every helper here would be dead code under -D warnings.
+
+#![cfg(unix)]
 
 use anyhow::{Context, Result, ensure};
 use test_support::fs as test_fs;
@@ -50,7 +55,6 @@ fn probe_verdict(temp: &tempfile::TempDir, switch: Option<&str>) -> Result<Strin
     test_fs::read_to_string(temp.path().join("out.ninja")).context("read generated ninja")
 }
 
-#[cfg(unix)]
 #[test]
 fn the_switch_gates_the_workspace_fallback_end_to_end() -> Result<()> {
     let temp = probe_workspace()?;


### PR DESCRIPTION
## Summary

`workspace_fallback_enabled` read `NETSUKE_WHICH_WORKSPACE` directly from the process:

```rust
fn workspace_fallback_enabled() -> bool {
    match env::var(WORKSPACE_FALLBACK_ENV) { ... }
}
```

Its three outcomes could only be reached by mutating global state, which the [AGENTS.md testing mandate](https://github.com/leynos/netsuke/blob/main/AGENTS.md) no longer permits. One branch was unreachable in practice regardless — fabricating a non-UTF-8 value in the live environment requires platform-specific `OsString` surgery — so the `NotUnicode` path and its `warn!` had no coverage at all.

## Approach

Split the decision into `workspace_fallback_enabled_with`, taking a `read_env` closure.

This deliberately mirrors the seam already established in `src/runner/process/ninja_program.rs` rather than introducing a `mockable::Env` trait object. The mandate permits "a narrow closure seam of the same shape ... where a trait object would be disproportionate", and this is a single-variable lookup with one caller: a trait object would add a dependency and an indirection for no gain. It is the same reasoning that closed #488.

## Coverage

Fifteen cases, none of which mutate anything — no `#[serial]`, no lock:

- each disabling value (`0`, `false`, `off`) in lower, title, and upper case
- values that leave it on, including `""`, `"no"`, and `"offbeat"` — the last pins that matching is exact rather than substring
- the absent variable, confirming the switch is opt-out
- the non-UTF-8 branch, now reachable for the first time
- that the documented variable name is the one consulted

## Verification

All gates pass: `check-fmt`, `lint`, `typecheck`, `test` (1203 nextest, 44 doctests), `markdownlint`, `nixie`. CodeScene delta: no issues.

Closes #487.
Refs #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an injectable environment-reading seam for the workspace fallback switch and add comprehensive tests to cover all configuration outcomes without mutating global process state.

Bug Fixes:
- Make the workspace fallback switch behavior testable without mutating process environment variables.

Enhancements:
- Introduce an injectable environment reader seam for the workspace fallback switch via `workspace_fallback_enabled_with`.

Tests:
- Add focused tests that cover all workspace fallback switch outcomes, including case-insensitive disabling values, opt-out behavior, non-UTF-8 values, and use of the documented env var name.