### PR TITLE
Enforce the environment mandate with clippy disallowed-methods (#504)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,3 @@
-#![expect(
-    clippy::disallowed_methods,
-    reason = "build scripts read CARGO_* and OUT_DIR from the environment Cargo provides; there is no seam to inject and no test to isolate"
-)]
-
 //! Build script for Netsuke.
 //!
 //! This script performs two main tasks:
@@ -73,6 +68,10 @@ mod theme;
 
 mod build_l10n_audit;
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "SOURCE_DATE_EPOCH is the reproducible-builds contract: the build system supplies it to the build script's process, so there is no seam to inject it through"
+)]
 fn manual_date() -> String {
     let Ok(raw) = env::var("SOURCE_DATE_EPOCH") else {
         return FALLBACK_DATE.into();
@@ -100,6 +99,10 @@ fn manual_date() -> String {
     })
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "TARGET and PROFILE are set by Cargo for the build script alone; nothing else knows the triple and profile being built, so they cannot be passed in"
+)]
 fn out_dir_for_target_profile() -> PathBuf {
     let target = env::var("TARGET").unwrap_or_else(|_| "unknown-target".into());
     let profile = env::var("PROFILE").unwrap_or_else(|_| "unknown-profile".into());
@@ -137,6 +140,10 @@ fn emit_rerun_directives() {
     println!("cargo:rerun-if-changed=locales/es-ES/messages.ftl");
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "CARGO_BIN_NAME, CARGO_PKG_NAME, CARGO_PKG_VERSION and OUT_DIR are Cargo's own build-script inputs; they describe the crate being compiled and Cargo provides them only through the environment"
+)]
 fn generate_man_page(out_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let cmd = cli::Cli::command();
     let name = cmd

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::disallowed_methods,
+    reason = "build scripts read CARGO_* and OUT_DIR from the environment Cargo provides; there is no seam to inject and no test to isolate"
+)]
+
 //! Build script for Netsuke.
 //!
 //! This script performs two main tasks:

--- a/docs/adr-006-adopt-polonius-nightly-toolchain.md
+++ b/docs/adr-006-adopt-polonius-nightly-toolchain.md
@@ -19,8 +19,8 @@ several of these shapes, so the natural borrow-returning form of an accessor
 can compile where NLL rejected it.
 
 Adopting those borrow-centric designs binds the source tree to a
-Polonius-enabled compiler, which is nightly-only until the analysis stabilizes.
-That conflicts with three standing policies:
+Polonius-enabled compiler, which is nightly-only until the analysis
+stabilizes. That conflicts with three standing policies:
 
 - `rust-toolchain.toml` pinned stable `1.89.0`;
 - `Cargo.toml` declared `rust-version = "1.89.0"` as a minimum supported Rust
@@ -52,20 +52,20 @@ Adopt Polonius now, as a nightly-only source tree:
   nightly requirement there, and advertising `1.89.0` would misstate the
   contract; `rust-toolchain.toml` is now the single source of truth.
 
-Every borrow-centric rewrite that depends on the flag is verified both with and
-without `-Zpolonius=next` and recorded in
+Every borrow-centric rewrite that depends on the flag is verified both with
+and without `-Zpolonius=next` and recorded in
 [polonius migration notes](polonius.md), including refusals where owned style
 remains correct.
 
 ## Rationale
 
 - **Design over deployment breadth.** Netsuke ships binaries, not a library
-  API. Consumers install packaged artefacts or build from source; the toolchain
-  pin costs contributors one `rustup` fetch, whereas NLL-era double lookups and
-  key clones cost every call site, forever.
+  API. Consumers install packaged artefacts or build from source; the
+  toolchain pin costs contributors one `rustup` fetch, whereas NLL-era
+  double lookups and key clones cost every call site, forever.
 - **Reproducibility.** A dated nightly behaves like a release: the same
-  compiler bits build the tree everywhere. `rustup` provisions it automatically
-  from `rust-toolchain.toml`.
+  compiler bits build the tree everywhere. `rustup` provisions it
+  automatically from `rust-toolchain.toml`.
 - **Coherent tooling.** Putting the flag in `.cargo/config.toml` keeps
   rust-analyzer, Clippy, Whitaker (whose Dylint driver is nightly-based), and
   Kani borrow-checking the same dialect, avoiding phantom editor errors on
@@ -81,18 +81,19 @@ remains correct.
   `rust-toolchain.toml` and `.cargo/config.toml` (and Cargo would not apply
   them to a registry build anyway), so a bare `cargo install netsuke` of a
   Polonius-dependent release fails borrow checking on the user's default
-  toolchain. Registry installs must select the pinned nightly and pass the flag
-  explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`); the
-  README and users' guide document this command and a contract test pins it.
-  Source installs from a checkout are unaffected because the pinned toolchain
-  and workspace configuration apply there.
+  toolchain. Registry installs must select the pinned nightly and pass the
+  flag explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`);
+  the README and users' guide document this command and a contract test pins
+  it. Source installs from a checkout are unaffected because the pinned
+  toolchain and workspace configuration apply there.
 - Release packaging builds from the pinned nightly. Binary artefacts are
-  unaffected: the borrow checker changes what compiles, not what is generated.
+  unaffected: the borrow checker changes what compiles, not what is
+  generated.
 - Dependabot-style toolchain drift is impossible; moving the pin is a
   deliberate act. Move it forward periodically (and especially once Polonius
-  stabilizes), re-running the full gate suite, and update this ADR's references
-  when doing so.
+  stabilizes), re-running the full gate suite, and update this ADR's
+  references when doing so.
 - Sites that genuinely require Polonius are tagged `POLONIUS(...)` in source
   and must not be rewritten into NLL-era defensive forms; `AGENTS.md` and
   [polonius migration notes](polonius.md) carry the anti-regression guidance.

--- a/docs/adr-006-adopt-polonius-nightly-toolchain.md
+++ b/docs/adr-006-adopt-polonius-nightly-toolchain.md
@@ -19,8 +19,8 @@ several of these shapes, so the natural borrow-returning form of an accessor
 can compile where NLL rejected it.
 
 Adopting those borrow-centric designs binds the source tree to a
-Polonius-enabled compiler, which is nightly-only until the analysis
-stabilizes. That conflicts with three standing policies:
+Polonius-enabled compiler, which is nightly-only until the analysis stabilizes.
+That conflicts with three standing policies:
 
 - `rust-toolchain.toml` pinned stable `1.89.0`;
 - `Cargo.toml` declared `rust-version = "1.89.0"` as a minimum supported Rust
@@ -52,20 +52,20 @@ Adopt Polonius now, as a nightly-only source tree:
   nightly requirement there, and advertising `1.89.0` would misstate the
   contract; `rust-toolchain.toml` is now the single source of truth.
 
-Every borrow-centric rewrite that depends on the flag is verified both with
-and without `-Zpolonius=next` and recorded in
+Every borrow-centric rewrite that depends on the flag is verified both with and
+without `-Zpolonius=next` and recorded in
 [polonius migration notes](polonius.md), including refusals where owned style
 remains correct.
 
 ## Rationale
 
 - **Design over deployment breadth.** Netsuke ships binaries, not a library
-  API. Consumers install packaged artefacts or build from source; the
-  toolchain pin costs contributors one `rustup` fetch, whereas NLL-era
-  double lookups and key clones cost every call site, forever.
+  API. Consumers install packaged artefacts or build from source; the toolchain
+  pin costs contributors one `rustup` fetch, whereas NLL-era double lookups and
+  key clones cost every call site, forever.
 - **Reproducibility.** A dated nightly behaves like a release: the same
-  compiler bits build the tree everywhere. `rustup` provisions it
-  automatically from `rust-toolchain.toml`.
+  compiler bits build the tree everywhere. `rustup` provisions it automatically
+  from `rust-toolchain.toml`.
 - **Coherent tooling.** Putting the flag in `.cargo/config.toml` keeps
   rust-analyzer, Clippy, Whitaker (whose Dylint driver is nightly-based), and
   Kani borrow-checking the same dialect, avoiding phantom editor errors on
@@ -81,19 +81,18 @@ remains correct.
   `rust-toolchain.toml` and `.cargo/config.toml` (and Cargo would not apply
   them to a registry build anyway), so a bare `cargo install netsuke` of a
   Polonius-dependent release fails borrow checking on the user's default
-  toolchain. Registry installs must select the pinned nightly and pass the
-  flag explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`);
-  the README and users' guide document this command and a contract test pins
-  it. Source installs from a checkout are unaffected because the pinned
-  toolchain and workspace configuration apply there.
+  toolchain. Registry installs must select the pinned nightly and pass the flag
+  explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`); the
+  README and users' guide document this command and a contract test pins it.
+  Source installs from a checkout are unaffected because the pinned toolchain
+  and workspace configuration apply there.
 - Release packaging builds from the pinned nightly. Binary artefacts are
-  unaffected: the borrow checker changes what compiles, not what is
-  generated.
+  unaffected: the borrow checker changes what compiles, not what is generated.
 - Dependabot-style toolchain drift is impossible; moving the pin is a
   deliberate act. Move it forward periodically (and especially once Polonius
-  stabilizes), re-running the full gate suite, and update this ADR's
-  references when doing so.
+  stabilizes), re-running the full gate suite, and update this ADR's references
+  when doing so.
 - Sites that genuinely require Polonius are tagged `POLONIUS(...)` in source
   and must not be rewritten into NLL-era defensive forms; `AGENTS.md` and
   [polonius migration notes](polonius.md) carry the anti-regression guidance.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1408,6 +1408,53 @@ still safe to use. See the
 [locale-pinned snapshot tests](snapshot-testing-in-netsuke-using-insta.md#locale-pinned-snapshot-tests)
 section for the fixture's intended usage.
 
+### Enforcing the environment mandate
+
+`clippy.toml` disallows the six process-environment entry points, so
+`make lint` rejects a new one:
+
+```toml
+disallowed-methods = [
+  { path = "std::env::var", reason = "inject an environment reader" },
+  { path = "std::env::set_var", reason = "use a stub environment in tests" },
+  # ... var_os, vars, vars_os, remove_var
+]
+```
+
+The reason string appears in the diagnostic, so a contributor who trips the
+lint is told what to do instead, not merely that they may not. `test_support`
+is excluded from the workspace, so it carries its own copy of the list.
+
+#### Annotating a sanctioned site
+
+Use `#[expect]`, never `allow`:
+
+```rust
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the read_env seam"
+)]
+pub fn resolve(no_emoji: Option<bool>) -> OutputPrefs {
+    resolve_with(no_emoji, |key| env::var(key).ok())
+}
+```
+
+`expect` becomes *unfulfilled* — and warns — once the site stops tripping the
+lint. A migrated file therefore fails the gate until its annotation is removed,
+so the backlog cannot rot silently. `allow` would go stale invisibly.
+
+Three dispositions are in use:
+
+- **Composition roots** in `src/` keep a permanent site-level expectation naming
+  the seam they supply. These are the sanctioned ambient boundary.
+- **Build scripts and artefact discovery** keep a permanent module-level
+  expectation: they read what Cargo reports, and there is no seam to inject.
+- **Pending migrations** in `tests/` carry a module-level expectation naming the
+  tracking issue, removed as each file migrates.
+
+Scope an expectation as tightly as the site allows — a function where one call
+is involved, a module only where the whole file is pending migration.
+
 ### `EnvLock`
 
 `test_support::env_lock::EnvLock` is a global mutex that serializes all

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2584,8 +2584,8 @@ flowchart LR
 ```
 
 Netsuke configuration discovery is implemented in `src/cli/discovery.rs`.
-Explicit file selection is handled by `explicit_config_path_with_env(...)`, which
-applies the precedence `--config` > `NETSUKE_CONFIG`. Layer loading and
+Explicit file selection is handled by `explicit_config_path_with_env(...)`,
+which applies the precedence `--config` > `NETSUKE_CONFIG`. Layer loading and
 automatic discovery are handled by `push_file_layers(...)`, which also applies
 the `-C/--directory` flag as the project-discovery root.
 
@@ -2702,11 +2702,10 @@ manual flag repetition.
   override, relying on OrthoConfig's platform-specific defaults for standard
   directory resolution.
 - Netsuke-owned environment reads for explicit config selection and early JSON
-  resolution go through the `EnvProvider` port in
-  `src/cli/discovery.rs`. Production code uses `StdEnvProvider`; tests can
-  inject a map-backed provider instead of mutating the process environment.
-  OrthoConfig discovery remains an external boundary and may still read
-  platform environment variables directly.
+  resolution go through the `EnvProvider` port in `src/cli/discovery.rs`.
+  Production code uses `StdEnvProvider`; tests can inject a map-backed provider
+  instead of mutating the process environment. OrthoConfig discovery remains an
+  external boundary and may still read platform environment variables directly.
 - Configuration files use TOML format by default. JSON5 (`.json`, `.json5`) and
   YAML (`.yaml`, `.yml`) formats are supported when the corresponding Cargo
   features are enabled.
@@ -2943,13 +2942,12 @@ selected for this project and the rationale for their inclusion.
 
 Netsuke compiles with the Polonius alpha borrow-checking analysis
 (`-Zpolonius=next`) on the dated nightly toolchain pinned in
-`rust-toolchain.toml`
-([ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)). Internal APIs
-follow a borrow-centric design contract: lookups and registries return
-references (`&mut V` accessors with clone-on-miss keys), mutation happens in
-place, and error context is built lazily on the failure path. Owned-value
-style is reserved for genuine constraints — aliasing, suspension points,
-thread and process boundaries, and persistent identity — and each such
+`rust-toolchain.toml` ([ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)).
+Internal APIs follow a borrow-centric design contract: lookups and registries
+return references (`&mut V` accessors with clone-on-miss keys), mutation
+happens in place, and error context is built lazily on the failure path.
+Owned-value style is reserved for genuine constraints — aliasing, suspension
+points, thread and process boundaries, and persistent identity — and each such
 refusal is recorded in the [polonius migration notes](polonius.md) alongside
 the sites that depend on the analysis.
 

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2584,8 +2584,8 @@ flowchart LR
 ```
 
 Netsuke configuration discovery is implemented in `src/cli/discovery.rs`.
-Explicit file selection is handled by `explicit_config_path_with_env(...)`,
-which applies the precedence `--config` > `NETSUKE_CONFIG`. Layer loading and
+Explicit file selection is handled by `explicit_config_path_with_env(...)`, which
+applies the precedence `--config` > `NETSUKE_CONFIG`. Layer loading and
 automatic discovery are handled by `push_file_layers(...)`, which also applies
 the `-C/--directory` flag as the project-discovery root.
 
@@ -2702,10 +2702,11 @@ manual flag repetition.
   override, relying on OrthoConfig's platform-specific defaults for standard
   directory resolution.
 - Netsuke-owned environment reads for explicit config selection and early JSON
-  resolution go through the `EnvProvider` port in `src/cli/discovery.rs`.
-  Production code uses `StdEnvProvider`; tests can inject a map-backed provider
-  instead of mutating the process environment. OrthoConfig discovery remains an
-  external boundary and may still read platform environment variables directly.
+  resolution go through the `EnvProvider` port in
+  `src/cli/discovery.rs`. Production code uses `StdEnvProvider`; tests can
+  inject a map-backed provider instead of mutating the process environment.
+  OrthoConfig discovery remains an external boundary and may still read
+  platform environment variables directly.
 - Configuration files use TOML format by default. JSON5 (`.json`, `.json5`) and
   YAML (`.yaml`, `.yml`) formats are supported when the corresponding Cargo
   features are enabled.
@@ -2942,12 +2943,13 @@ selected for this project and the rationale for their inclusion.
 
 Netsuke compiles with the Polonius alpha borrow-checking analysis
 (`-Zpolonius=next`) on the dated nightly toolchain pinned in
-`rust-toolchain.toml` ([ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)).
-Internal APIs follow a borrow-centric design contract: lookups and registries
-return references (`&mut V` accessors with clone-on-miss keys), mutation
-happens in place, and error context is built lazily on the failure path.
-Owned-value style is reserved for genuine constraints — aliasing, suspension
-points, thread and process boundaries, and persistent identity — and each such
+`rust-toolchain.toml`
+([ADR-006](adr-006-adopt-polonius-nightly-toolchain.md)). Internal APIs
+follow a borrow-centric design contract: lookups and registries return
+references (`&mut V` accessors with clone-on-miss keys), mutation happens in
+place, and error context is built lazily on the failure path. Owned-value
+style is reserved for genuine constraints — aliasing, suspension points,
+thread and process boundaries, and persistent identity — and each such
 refusal is recorded in the [polonius migration notes](polonius.md) alongside
 the sites that depend on the analysis.
 

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -3,41 +3,41 @@
 Netsuke compiles with the Polonius alpha borrow-checking analysis
 (`-Zpolonius=next`) on the dated nightly pinned in `rust-toolchain.toml`.
 [ADR-006](adr-006-adopt-polonius-nightly-toolchain.md) records the toolchain
-policy; this document records the audit that motivated it, the API
-evolutions it enabled, and the refusals that bound it. Issue
+policy; this document records the audit that motivated it, the API evolutions
+it enabled, and the refusals that bound it. Issue
 [#465](https://github.com/leynos/netsuke/issues/465) tracked the migration.
 
 ## Method
 
-The migration ran the `nll-to-polonius` two-pass audit with the compiler as
-the oracle:
+The migration ran the `nll-to-polonius` two-pass audit with the compiler as the
+oracle:
 
 1. **Workaround scan** — mechanical sweep for local non-lexical-lifetimes
    (NLL) workaround shapes: double lookups, `entry()` with unconditionally
-   cloned keys, re-lookup after insert, index-returning finders,
-   borrow-killing `drop()` calls, and eager error context.
+   cloned keys, re-lookup after insert, index-returning finders, borrow-killing
+   `drop()` calls, and eager error context.
 2. **Design-pressure scan** — structural sweep for owned lookup results,
    id/index indirection, clone-modify-writeback, snapshot-collect loops, and
    per-module clone hotspots.
 
 Every change was compiled twice on `nightly-2026-06-25`: once with
-`-Zpolonius=next` (must pass) and once without. The no-flag compile exists
-only to classify the individual change: a failure proves the design
-genuinely depends on Polonius and the site is tagged `POLONIUS(...)`;
-success means the old form was habit rather than necessity and the
-improvement carries no toolchain caveat. The complete behavioural test
-suite runs under `-Zpolonius=next` — the tree's only supported
-configuration — and was required to pass unchanged after every change.
+`-Zpolonius=next` (must pass) and once without. The no-flag compile exists only
+to classify the individual change: a failure proves the design genuinely
+depends on Polonius and the site is tagged `POLONIUS(...)`; success means the
+old form was habit rather than necessity and the improvement carries no
+toolchain caveat. The complete behavioural test suite runs under
+`-Zpolonius=next` — the tree's only supported configuration — and was required
+to pass unchanged after every change.
 
 ## Polonius-dependent sites
 
-| Site | Tag | Verification |
-| --- | --- | --- |
+| Site                                                          | Tag                | Verification                                                                    |
+| ------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
 | `src/graph_view/mod.rs` — `NodePathRegistry::ensure_node_mut` | `POLONIUS(case-3)` | Passes with `-Zpolonius=next`; rejected by NLL with E0499 on nightly-2026-06-25 |
 
 `ensure_node_mut` is the get-or-insert accessor behind graph projection: it
-returns `&mut NodeKind`, performs a single lookup on the hit path, and
-clones the path only on insertion. It replaced three
+returns `&mut NodeKind`, performs a single lookup on the hit path, and clones
+the path only on insertion. It replaced three
 `entry(path.clone()).or_insert(NodeKind::Source)` sites that cloned every
 input, implicit-dependency, and order-only path on every registration. The
 `get_mut` loan escapes only via the early return, which is the canonical
@@ -51,24 +51,24 @@ well — the owned style was habit, so they carry no toolchain caveat:
 - `src/stdlib/collections.rs` — `group_by_filter` consumed its resolved key
   in `entry(key_value)` instead of cloning it first.
 - `src/ir/cycle.rs` — `detect_targets` snapshots borrowed
-  `&'targets Utf8Path` keys for its deterministic sort instead of cloning
-  every target path per analysis. The snapshot exists for sorting, not to
-  end a borrow, so it stays.
+  `&'targets Utf8Path` keys for its deterministic sort instead of cloning every
+  target path per analysis. The snapshot exists for sorting, not to end a
+  borrow, so it stays.
 - `src/stdlib/which/env.rs` — `EnvSnapshot::resolved_dirs` returns
-  `Vec<&Utf8Path>` borrowed from the snapshot; the search loop reads
-  borrowed directories and the paths are copied into the owned
-  `ResolveError::NotFound` only at the error boundary.
+  `Vec<&Utf8Path>` borrowed from the snapshot; the search loop reads borrowed
+  directories and the paths are copied into the owned `ResolveError::NotFound`
+  only at the error boundary.
 
 ## Refusals
 
-Owned style retained deliberately. The constraint, not the borrow checker,
-is load-bearing; each site carries the matching source tag:
+Owned style retained deliberately. The constraint, not the borrow checker, is
+load-bearing; each site carries the matching source tag:
 
-| Site | Tag | Constraint |
-| --- | --- | --- |
-| `src/ir/from_manifest_support.rs` — `register_action` | `POLONIUS-REFUSED(id-is-data)` | The action hash is persistent IR identity: stored on every `BuildEdge` and named in the generated Ninja file. Remains owned unless callers demonstrate a need for the canonical interned value. |
-| `src/stdlib/which/cache.rs` — `WhichResolver::try_cache` | `POLONIUS-REFUSED(lock-boundary)` | Cache hits are cloned out of the LRU because references cannot outlive the `MutexGuard`; the resolver is shared across evaluation sites. |
-| `src/stdlib/collections.rs` — `GroupedValues::new` | `POLONIUS-REFUSED(miss-dominant)` | First-wins string-key registration almost always inserts, so the owned-key `entry` form pays nothing on the rare hit. |
+| Site                                                     | Tag                               | Constraint                                                                                                                                                                                      |
+| -------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/ir/from_manifest_support.rs` — `register_action`    | `POLONIUS-REFUSED(id-is-data)`    | The action hash is persistent IR identity: stored on every `BuildEdge` and named in the generated Ninja file. Remains owned unless callers demonstrate a need for the canonical interned value. |
+| `src/stdlib/which/cache.rs` — `WhichResolver::try_cache` | `POLONIUS-REFUSED(lock-boundary)` | Cache hits are cloned out of the LRU because references cannot outlive the `MutexGuard`; the resolver is shared across evaluation sites.                                                        |
+| `src/stdlib/collections.rs` — `GroupedValues::new`       | `POLONIUS-REFUSED(miss-dominant)` | First-wins string-key registration almost always inserts, so the owned-key `entry` form pays nothing on the rare hit.                                                                           |
 
 ## Non-candidates reviewed and cleared
 
@@ -88,60 +88,58 @@ Scanner suspects that turned out not to be NLL residue:
 - Test-suite `drop()` calls (environment guards, HTTP fixture teardown) are
   semantic Drop effects, not borrow appeasement.
 
-The plumbing itself is contract-tested:
-`tests/polonius_toolchain_contract.rs` pins the dated-nightly channel, the
-`.cargo/config.toml` `build.rustflags` entry, the `POLONIUS_FLAGS` default
-and every RUSTFLAGS-setting Makefile recipe, and the `RUSTFLAGS` and
-toolchain presets in the CI, Netsukefile, coverage, and packaging
-workflows.
+The plumbing itself is contract-tested: `tests/polonius_toolchain_contract.rs`
+pins the dated-nightly channel, the `.cargo/config.toml` `build.rustflags`
+entry, the `POLONIUS_FLAGS` default and every RUSTFLAGS-setting Makefile
+recipe, and the `RUSTFLAGS` and toolchain presets in the CI, Netsukefile,
+coverage, and packaging workflows.
 
 ## Harness consequences
 
-Tooling that rebuilds the crate with its own flags must propagate the
-Polonius flag or avoid compiling the crate:
+Tooling that rebuilds the crate with its own flags must propagate the Polonius
+flag or avoid compiling the crate:
 
 - **trybuild** discards ambient `RUSTFLAGS` and workspace `build.rustflags`,
   replacing them via `--config` on its scratch project, and it always builds
   the host crate as a fixture dependency. The Kani cfg policy fixture is
   therefore compiled and run directly with the workspace `rustc`
-  (`tests/kani_cfg_ui_tests.rs`); do not reintroduce trybuild cases that
-  depend on the `netsuke` crate while the tree is Polonius-only.
+  (`tests/kani_cfg_ui_tests.rs`); do not reintroduce trybuild cases that depend
+  on the `netsuke` crate while the tree is Polonius-only.
 - **Kani** and **Whitaker** run under their own toolchains but read the
   workspace `.cargo/config.toml` or the Makefile `RUSTFLAGS`, so they
   borrow-check with `-Zpolonius=next` and need no special handling.
 - **CI setup actions**: `actions-rust-lang/setup-rust-toolchain` exports
   `RUSTFLAGS="-D warnings"` into the job environment when the variable is
-  unset, which shadows `.cargo/config.toml` for every later step. The
-  workflows therefore pre-set `RUSTFLAGS` (including `-Zpolonius=next`) at
-  job level — the action defers to an existing value — and the Makefile
-  recipes append `POLONIUS_FLAGS` to any ambient `RUSTFLAGS` as a second
-  line of defence. `cargo-llvm-cov` appends its instrumentation flags to
-  the ambient value, so coverage inherits the flag from the job
-  environment.
+  unset, which shadows `.cargo/config.toml` for every later step. The workflows
+  therefore pre-set `RUSTFLAGS` (including `-Zpolonius=next`) at job level —
+  the action defers to an existing value — and the Makefile recipes append
+  `POLONIUS_FLAGS` to any ambient `RUSTFLAGS` as a second line of defence.
+  `cargo-llvm-cov` appends its instrumentation flags to the ambient value, so
+  coverage inherits the flag from the job environment.
 - **Registry installs**: the crates.io package excludes
   `rust-toolchain.toml` and `.cargo/config.toml`, and registry builds run
   outside the checkout, so `cargo install netsuke` must select the pinned
   nightly and pass the flag explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`).
-  The README and users' guide document the command and
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`). The
+  README and users' guide document the command and
   `tests/documentation_examples_tests.rs` pins it.
 - **cargo-mutants** (scheduled, informational) runs through the shared
-  `mutation-cargo.yml` workflow, which controls its own environment; if
-  those runs regress with E0499 at tagged sites, the shared workflow needs
-  the same `RUSTFLAGS` treatment.
+  `mutation-cargo.yml` workflow, which controls its own environment; if those
+  runs regress with E0499 at tagged sites, the shared workflow needs the same
+  `RUSTFLAGS` treatment.
 
 ## Clone counts
 
-Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where
-they live in `src/`):
+Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where they
+live in `src/`):
 
-| Scope | Before | After |
-| --- | --- | --- |
-| `src/` total | 158 | 151 |
-| `src/graph_view/mod.rs` | 17 | 14 |
-| `src/ir/cycle.rs` (non-test) | 1 | 0 |
-| `src/stdlib/which/env.rs` | 4 | 1 |
-| `src/stdlib/collections.rs` | 4 | 3 |
+| Scope                        | Before | After |
+| ---------------------------- | ------ | ----- |
+| `src/` total                 | 158    | 151   |
+| `src/graph_view/mod.rs`      | 17     | 14    |
+| `src/ir/cycle.rs` (non-test) | 1      | 0     |
+| `src/stdlib/which/env.rs`    | 4      | 1     |
+| `src/stdlib/collections.rs`  | 4      | 3     |
 
 The scanner's clone-modify-writeback section was empty before and after the
 migration. The remaining graph_view clones construct owned keys for the two
@@ -160,8 +158,8 @@ When `-Zpolonius=next` (or its successor) reaches stable Rust:
 
 ## Anti-regression guidance
 
-The contract for new code and reviews (also summarized in `AGENTS.md` and
-the [developers' guide](developers-guide.md)):
+The contract for new code and reviews (also summarized in `AGENTS.md` and the
+[developers' guide](developers-guide.md)):
 
 - Do not rewrite `POLONIUS(...)` sites into double lookups,
   `entry(key.clone())`, or `contains_key` guards — the direct form is
@@ -171,7 +169,7 @@ the [developers' guide](developers-guide.md)):
   borrow-returning form compiles under the project toolchain.
 - Respect `POLONIUS-REFUSED(...)` tags: the named constraint (identity,
   locks, aliasing, suspension points, thread boundaries) is permanent, and
-  "simplifying" those sites into reference-returning forms will not compile
-  or will break the design.
+  "simplifying" those sites into reference-returning forms will not compile or
+  will break the design.
 - Classify any new borrow-centric API by compiling with and without the
   flag, then record it here.

--- a/docs/polonius.md
+++ b/docs/polonius.md
@@ -3,41 +3,41 @@
 Netsuke compiles with the Polonius alpha borrow-checking analysis
 (`-Zpolonius=next`) on the dated nightly pinned in `rust-toolchain.toml`.
 [ADR-006](adr-006-adopt-polonius-nightly-toolchain.md) records the toolchain
-policy; this document records the audit that motivated it, the API evolutions
-it enabled, and the refusals that bound it. Issue
+policy; this document records the audit that motivated it, the API
+evolutions it enabled, and the refusals that bound it. Issue
 [#465](https://github.com/leynos/netsuke/issues/465) tracked the migration.
 
 ## Method
 
-The migration ran the `nll-to-polonius` two-pass audit with the compiler as the
-oracle:
+The migration ran the `nll-to-polonius` two-pass audit with the compiler as
+the oracle:
 
 1. **Workaround scan** — mechanical sweep for local non-lexical-lifetimes
    (NLL) workaround shapes: double lookups, `entry()` with unconditionally
-   cloned keys, re-lookup after insert, index-returning finders, borrow-killing
-   `drop()` calls, and eager error context.
+   cloned keys, re-lookup after insert, index-returning finders,
+   borrow-killing `drop()` calls, and eager error context.
 2. **Design-pressure scan** — structural sweep for owned lookup results,
    id/index indirection, clone-modify-writeback, snapshot-collect loops, and
    per-module clone hotspots.
 
 Every change was compiled twice on `nightly-2026-06-25`: once with
-`-Zpolonius=next` (must pass) and once without. The no-flag compile exists only
-to classify the individual change: a failure proves the design genuinely
-depends on Polonius and the site is tagged `POLONIUS(...)`; success means the
-old form was habit rather than necessity and the improvement carries no
-toolchain caveat. The complete behavioural test suite runs under
-`-Zpolonius=next` — the tree's only supported configuration — and was required
-to pass unchanged after every change.
+`-Zpolonius=next` (must pass) and once without. The no-flag compile exists
+only to classify the individual change: a failure proves the design
+genuinely depends on Polonius and the site is tagged `POLONIUS(...)`;
+success means the old form was habit rather than necessity and the
+improvement carries no toolchain caveat. The complete behavioural test
+suite runs under `-Zpolonius=next` — the tree's only supported
+configuration — and was required to pass unchanged after every change.
 
 ## Polonius-dependent sites
 
-| Site                                                          | Tag                | Verification                                                                    |
-| ------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| Site | Tag | Verification |
+| --- | --- | --- |
 | `src/graph_view/mod.rs` — `NodePathRegistry::ensure_node_mut` | `POLONIUS(case-3)` | Passes with `-Zpolonius=next`; rejected by NLL with E0499 on nightly-2026-06-25 |
 
 `ensure_node_mut` is the get-or-insert accessor behind graph projection: it
-returns `&mut NodeKind`, performs a single lookup on the hit path, and clones
-the path only on insertion. It replaced three
+returns `&mut NodeKind`, performs a single lookup on the hit path, and
+clones the path only on insertion. It replaced three
 `entry(path.clone()).or_insert(NodeKind::Source)` sites that cloned every
 input, implicit-dependency, and order-only path on every registration. The
 `get_mut` loan escapes only via the early return, which is the canonical
@@ -51,24 +51,24 @@ well — the owned style was habit, so they carry no toolchain caveat:
 - `src/stdlib/collections.rs` — `group_by_filter` consumed its resolved key
   in `entry(key_value)` instead of cloning it first.
 - `src/ir/cycle.rs` — `detect_targets` snapshots borrowed
-  `&'targets Utf8Path` keys for its deterministic sort instead of cloning every
-  target path per analysis. The snapshot exists for sorting, not to end a
-  borrow, so it stays.
+  `&'targets Utf8Path` keys for its deterministic sort instead of cloning
+  every target path per analysis. The snapshot exists for sorting, not to
+  end a borrow, so it stays.
 - `src/stdlib/which/env.rs` — `EnvSnapshot::resolved_dirs` returns
-  `Vec<&Utf8Path>` borrowed from the snapshot; the search loop reads borrowed
-  directories and the paths are copied into the owned `ResolveError::NotFound`
-  only at the error boundary.
+  `Vec<&Utf8Path>` borrowed from the snapshot; the search loop reads
+  borrowed directories and the paths are copied into the owned
+  `ResolveError::NotFound` only at the error boundary.
 
 ## Refusals
 
-Owned style retained deliberately. The constraint, not the borrow checker, is
-load-bearing; each site carries the matching source tag:
+Owned style retained deliberately. The constraint, not the borrow checker,
+is load-bearing; each site carries the matching source tag:
 
-| Site                                                     | Tag                               | Constraint                                                                                                                                                                                      |
-| -------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/ir/from_manifest_support.rs` — `register_action`    | `POLONIUS-REFUSED(id-is-data)`    | The action hash is persistent IR identity: stored on every `BuildEdge` and named in the generated Ninja file. Remains owned unless callers demonstrate a need for the canonical interned value. |
-| `src/stdlib/which/cache.rs` — `WhichResolver::try_cache` | `POLONIUS-REFUSED(lock-boundary)` | Cache hits are cloned out of the LRU because references cannot outlive the `MutexGuard`; the resolver is shared across evaluation sites.                                                        |
-| `src/stdlib/collections.rs` — `GroupedValues::new`       | `POLONIUS-REFUSED(miss-dominant)` | First-wins string-key registration almost always inserts, so the owned-key `entry` form pays nothing on the rare hit.                                                                           |
+| Site | Tag | Constraint |
+| --- | --- | --- |
+| `src/ir/from_manifest_support.rs` — `register_action` | `POLONIUS-REFUSED(id-is-data)` | The action hash is persistent IR identity: stored on every `BuildEdge` and named in the generated Ninja file. Remains owned unless callers demonstrate a need for the canonical interned value. |
+| `src/stdlib/which/cache.rs` — `WhichResolver::try_cache` | `POLONIUS-REFUSED(lock-boundary)` | Cache hits are cloned out of the LRU because references cannot outlive the `MutexGuard`; the resolver is shared across evaluation sites. |
+| `src/stdlib/collections.rs` — `GroupedValues::new` | `POLONIUS-REFUSED(miss-dominant)` | First-wins string-key registration almost always inserts, so the owned-key `entry` form pays nothing on the rare hit. |
 
 ## Non-candidates reviewed and cleared
 
@@ -88,58 +88,60 @@ Scanner suspects that turned out not to be NLL residue:
 - Test-suite `drop()` calls (environment guards, HTTP fixture teardown) are
   semantic Drop effects, not borrow appeasement.
 
-The plumbing itself is contract-tested: `tests/polonius_toolchain_contract.rs`
-pins the dated-nightly channel, the `.cargo/config.toml` `build.rustflags`
-entry, the `POLONIUS_FLAGS` default and every RUSTFLAGS-setting Makefile
-recipe, and the `RUSTFLAGS` and toolchain presets in the CI, Netsukefile,
-coverage, and packaging workflows.
+The plumbing itself is contract-tested:
+`tests/polonius_toolchain_contract.rs` pins the dated-nightly channel, the
+`.cargo/config.toml` `build.rustflags` entry, the `POLONIUS_FLAGS` default
+and every RUSTFLAGS-setting Makefile recipe, and the `RUSTFLAGS` and
+toolchain presets in the CI, Netsukefile, coverage, and packaging
+workflows.
 
 ## Harness consequences
 
-Tooling that rebuilds the crate with its own flags must propagate the Polonius
-flag or avoid compiling the crate:
+Tooling that rebuilds the crate with its own flags must propagate the
+Polonius flag or avoid compiling the crate:
 
 - **trybuild** discards ambient `RUSTFLAGS` and workspace `build.rustflags`,
   replacing them via `--config` on its scratch project, and it always builds
   the host crate as a fixture dependency. The Kani cfg policy fixture is
   therefore compiled and run directly with the workspace `rustc`
-  (`tests/kani_cfg_ui_tests.rs`); do not reintroduce trybuild cases that depend
-  on the `netsuke` crate while the tree is Polonius-only.
+  (`tests/kani_cfg_ui_tests.rs`); do not reintroduce trybuild cases that
+  depend on the `netsuke` crate while the tree is Polonius-only.
 - **Kani** and **Whitaker** run under their own toolchains but read the
   workspace `.cargo/config.toml` or the Makefile `RUSTFLAGS`, so they
   borrow-check with `-Zpolonius=next` and need no special handling.
 - **CI setup actions**: `actions-rust-lang/setup-rust-toolchain` exports
   `RUSTFLAGS="-D warnings"` into the job environment when the variable is
-  unset, which shadows `.cargo/config.toml` for every later step. The workflows
-  therefore pre-set `RUSTFLAGS` (including `-Zpolonius=next`) at job level —
-  the action defers to an existing value — and the Makefile recipes append
-  `POLONIUS_FLAGS` to any ambient `RUSTFLAGS` as a second line of defence.
-  `cargo-llvm-cov` appends its instrumentation flags to the ambient value, so
-  coverage inherits the flag from the job environment.
+  unset, which shadows `.cargo/config.toml` for every later step. The
+  workflows therefore pre-set `RUSTFLAGS` (including `-Zpolonius=next`) at
+  job level — the action defers to an existing value — and the Makefile
+  recipes append `POLONIUS_FLAGS` to any ambient `RUSTFLAGS` as a second
+  line of defence. `cargo-llvm-cov` appends its instrumentation flags to
+  the ambient value, so coverage inherits the flag from the job
+  environment.
 - **Registry installs**: the crates.io package excludes
   `rust-toolchain.toml` and `.cargo/config.toml`, and registry builds run
   outside the checkout, so `cargo install netsuke` must select the pinned
   nightly and pass the flag explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`). The
-  README and users' guide document the command and
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`).
+  The README and users' guide document the command and
   `tests/documentation_examples_tests.rs` pins it.
 - **cargo-mutants** (scheduled, informational) runs through the shared
-  `mutation-cargo.yml` workflow, which controls its own environment; if those
-  runs regress with E0499 at tagged sites, the shared workflow needs the same
-  `RUSTFLAGS` treatment.
+  `mutation-cargo.yml` workflow, which controls its own environment; if
+  those runs regress with E0499 at tagged sites, the shared workflow needs
+  the same `RUSTFLAGS` treatment.
 
 ## Clone counts
 
-Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where they
-live in `src/`):
+Measured with `rg --count '\.clone\(\)'` over `src/` (tests included where
+they live in `src/`):
 
-| Scope                        | Before | After |
-| ---------------------------- | ------ | ----- |
-| `src/` total                 | 158    | 151   |
-| `src/graph_view/mod.rs`      | 17     | 14    |
-| `src/ir/cycle.rs` (non-test) | 1      | 0     |
-| `src/stdlib/which/env.rs`    | 4      | 1     |
-| `src/stdlib/collections.rs`  | 4      | 3     |
+| Scope | Before | After |
+| --- | --- | --- |
+| `src/` total | 158 | 151 |
+| `src/graph_view/mod.rs` | 17 | 14 |
+| `src/ir/cycle.rs` (non-test) | 1 | 0 |
+| `src/stdlib/which/env.rs` | 4 | 1 |
+| `src/stdlib/collections.rs` | 4 | 3 |
 
 The scanner's clone-modify-writeback section was empty before and after the
 migration. The remaining graph_view clones construct owned keys for the two
@@ -158,8 +160,8 @@ When `-Zpolonius=next` (or its successor) reaches stable Rust:
 
 ## Anti-regression guidance
 
-The contract for new code and reviews (also summarized in `AGENTS.md` and the
-[developers' guide](developers-guide.md)):
+The contract for new code and reviews (also summarized in `AGENTS.md` and
+the [developers' guide](developers-guide.md)):
 
 - Do not rewrite `POLONIUS(...)` sites into double lookups,
   `entry(key.clone())`, or `contains_key` guards — the direct form is
@@ -169,7 +171,7 @@ The contract for new code and reviews (also summarized in `AGENTS.md` and the
   borrow-returning form compiles under the project toolchain.
 - Respect `POLONIUS-REFUSED(...)` tags: the named constraint (identity,
   locks, aliasing, suspension points, thread boundaries) is permanent, and
-  "simplifying" those sites into reference-returning forms will not compile or
-  will break the design.
+  "simplifying" those sites into reference-returning forms will not compile
+  or will break the design.
 - Classify any new borrow-centric API by compiling with and without the
   flag, then record it here.

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -281,9 +281,9 @@ function, serializing locale state across the test suite.
 > In this repository the canonical runner is cargo-nextest: `make test`, or
 > `cargo nextest run --test ninja_snapshot_tests` for a focused run. See
 > [Test execution](developers-guide.md#test-execution). `cargo insta` needs to
-> be told which runner to drive, so use `cargo insta test --test-runner
-> nextest` and `cargo insta review` when accepting changes. The `cargo test`
-> invocations below are the generic form.
+> be told which runner to drive, so use
+> `cargo insta test --test-runner nextest` and `cargo insta review` when
+> accepting changes. The `cargo test` invocations below are the generic form.
 
 To execute the snapshot tests, run `cargo test`. All tests (including our new
 snapshot tests) will run. On the first run (or whenever a snapshot differs from

--- a/docs/snapshot-testing-in-netsuke-using-insta.md
+++ b/docs/snapshot-testing-in-netsuke-using-insta.md
@@ -281,9 +281,9 @@ function, serializing locale state across the test suite.
 > In this repository the canonical runner is cargo-nextest: `make test`, or
 > `cargo nextest run --test ninja_snapshot_tests` for a focused run. See
 > [Test execution](developers-guide.md#test-execution). `cargo insta` needs to
-> be told which runner to drive, so use
-> `cargo insta test --test-runner nextest` and `cargo insta review` when
-> accepting changes. The `cargo test` invocations below are the generic form.
+> be told which runner to drive, so use `cargo insta test --test-runner
+> nextest` and `cargo insta review` when accepting changes. The `cargo test`
+> invocations below are the generic form.
 
 To execute the snapshot tests, run `cargo test`. All tests (including our new
 snapshot tests) will run. On the first run (or whenever a snapshot differs from

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,9 +11,12 @@ change before 1.0. Pin the Netsuke version in automated workflows.
 ## Install Netsuke
 
 Netsuke requires [Ninja](https://ninja-build.org/) on `PATH`. A source build
-also requires the dated Rust nightly toolchain pinned in `rust-toolchain.toml`,
-because Netsuke builds with the Polonius borrow checker (`-Zpolonius=next`);
-`rustup` installs it automatically inside a checkout.
+also requires the dated Rust nightly toolchain pinned in `rust-toolchain.toml`
+because Netsuke builds with the Polonius borrow checker (`-Zpolonius=next`).
+
+Inside a checkout both settings are inherited automatically: `rustup` installs
+the pinned toolchain, and the repository's `.cargo/config.toml` supplies
+`RUSTFLAGS=-Zpolonius=next`. Neither has to be passed on the command line.
 
 Netsuke v0.1.0 is available from crates.io. Where
 [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is available,
@@ -67,7 +70,9 @@ licence files. Installer packages do not have checksum sidecars in v0.1.0.
 Windows PowerShell help files are published beside each MSI as sidecar
 artefacts rather than embedded in the installer.
 
-To install the current source checkout with Cargo:
+To install the current source checkout with Cargo. The clone supplies both the
+pinned nightly toolchain and `RUSTFLAGS=-Zpolonius=next`, so neither is given
+here — unlike the registry install above, which runs outside a checkout:
 
 <!-- tested-example: guide-source-install -->
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,15 +11,14 @@ change before 1.0. Pin the Netsuke version in automated workflows.
 ## Install Netsuke
 
 Netsuke requires [Ninja](https://ninja-build.org/) on `PATH`. A source build
-also requires the dated Rust nightly toolchain pinned in
-`rust-toolchain.toml`, because Netsuke builds with the Polonius borrow
-checker (`-Zpolonius=next`); `rustup` installs it automatically inside a
-checkout.
+also requires the dated Rust nightly toolchain pinned in `rust-toolchain.toml`,
+because Netsuke builds with the Polonius borrow checker (`-Zpolonius=next`);
+`rustup` installs it automatically inside a checkout.
 
 Netsuke v0.1.0 is available from crates.io. Where
-[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
-available, prefer it: it fetches a prebuilt release binary and avoids the
-toolchain requirement below.
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is available,
+prefer it: it fetches a prebuilt release binary and avoids the toolchain
+requirement below.
 
 <!-- tested-example: guide-binstall-install -->
 
@@ -28,8 +27,8 @@ cargo binstall netsuke
 ```
 
 Building from the registry instead runs outside a repository checkout, so
-neither the pinned toolchain nor the Polonius flag is picked up
-automatically; supply both explicitly:
+neither the pinned toolchain nor the Polonius flag is picked up automatically;
+supply both explicitly:
 
 <!-- tested-example: guide-crates-io-install -->
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,14 +11,15 @@ change before 1.0. Pin the Netsuke version in automated workflows.
 ## Install Netsuke
 
 Netsuke requires [Ninja](https://ninja-build.org/) on `PATH`. A source build
-also requires the dated Rust nightly toolchain pinned in `rust-toolchain.toml`,
-because Netsuke builds with the Polonius borrow checker (`-Zpolonius=next`);
-`rustup` installs it automatically inside a checkout.
+also requires the dated Rust nightly toolchain pinned in
+`rust-toolchain.toml`, because Netsuke builds with the Polonius borrow
+checker (`-Zpolonius=next`); `rustup` installs it automatically inside a
+checkout.
 
 Netsuke v0.1.0 is available from crates.io. Where
-[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is available,
-prefer it: it fetches a prebuilt release binary and avoids the toolchain
-requirement below.
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is
+available, prefer it: it fetches a prebuilt release binary and avoids the
+toolchain requirement below.
 
 <!-- tested-example: guide-binstall-install -->
 
@@ -27,8 +28,8 @@ cargo binstall netsuke
 ```
 
 Building from the registry instead runs outside a repository checkout, so
-neither the pinned toolchain nor the Polonius flag is picked up automatically;
-supply both explicitly:
+neither the pinned toolchain nor the Polonius flag is picked up
+automatically; supply both explicitly:
 
 <!-- tested-example: guide-crates-io-install -->
 

--- a/src/cli/discovery.rs
+++ b/src/cli/discovery.rs
@@ -44,6 +44,10 @@ pub trait EnvProvider {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct StdEnvProvider;
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: StdEnvProvider is the process-backed adapter behind the EnvProvider seam"
+)]
 impl EnvProvider for StdEnvProvider {
     fn get(&self, key: &str) -> Option<OsString> {
         std::env::var_os(key)

--- a/src/locale_resolution.rs
+++ b/src/locale_resolution.rs
@@ -25,6 +25,10 @@ pub trait EnvProvider {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct SystemEnv;
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: SystemEnv is the process-backed adapter behind the EnvProvider seam"
+)]
 impl EnvProvider for SystemEnv {
     fn var(&self, key: &str) -> Option<String> {
         std::env::var(key).ok()

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -81,6 +81,10 @@ pub enum ManifestLoadStage {
 /// assert_eq!(env("FOO").unwrap(), "bar");
 /// // guard restores prior value on drop
 /// ```
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the env() Jinja helper"
+)]
 fn env_var(name: &str) -> std::result::Result<String, Error> {
     match std::env::var(name) {
         Ok(val) => Ok(val),

--- a/src/output_mode.rs
+++ b/src/output_mode.rs
@@ -49,6 +49,10 @@ impl OutputMode {
 /// assert_eq!(resolve(Some(false), None), OutputMode::Standard);
 /// ```
 #[must_use]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the read_env seam"
+)]
 pub fn resolve(explicit: Option<bool>, colour_policy: Option<ColourPolicy>) -> OutputMode {
     resolve_with(explicit, colour_policy, |key| env::var(key).ok())
 }

--- a/src/output_prefs.rs
+++ b/src/output_prefs.rs
@@ -186,6 +186,10 @@ impl OutputPrefs {
 /// assert!(!prefs.emoji_allowed());
 /// ```
 #[must_use]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the read_env seam"
+)]
 pub fn resolve_from_theme(theme: Option<ThemePreference>, context: ThemeContext) -> OutputPrefs {
     resolve_from_theme_with(theme, context, |key| env::var(key).ok())
 }
@@ -227,6 +231,10 @@ where
 /// assert!(resolve_with(Some(false), |_| None).emoji_allowed());
 /// ```
 #[must_use]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the read_env seam"
+)]
 pub fn resolve(no_emoji: Option<bool>) -> OutputPrefs {
     resolve_with(no_emoji, |key| env::var(key).ok())
 }

--- a/src/runner/process/ninja_program.rs
+++ b/src/runner/process/ninja_program.rs
@@ -64,6 +64,10 @@ where
 
 /// Resolve the configured Ninja executable as a UTF-8 path.
 #[must_use]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the ninja program resolver seam"
+)]
 pub fn resolve_ninja_program_utf8() -> Utf8PathBuf {
     resolve_ninja_program_utf8_with(|key| env::var_os(key))
 }

--- a/src/stdlib/path/path_utils.rs
+++ b/src/stdlib/path/path_utils.rs
@@ -152,6 +152,10 @@ fn current_dir_utf8() -> Result<Utf8PathBuf, io::Error> {
 }
 
 #[cfg(windows)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: home resolution is the path stdlib's ambient boundary; the injected ladders are tracked in the environment meta issue"
+)]
 fn home_from_env() -> Option<String> {
     env::var("HOME")
         .or_else(|_| env::var("USERPROFILE"))
@@ -165,6 +169,10 @@ fn home_from_env() -> Option<String> {
 }
 
 #[cfg(not(windows))]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: home resolution is the path stdlib's ambient boundary; the injected ladders are tracked in the environment meta issue"
+)]
 fn home_from_env() -> Option<String> {
     env::var("HOME").or_else(|_| env::var("USERPROFILE")).ok()
 }

--- a/src/stdlib/which/env.rs
+++ b/src/stdlib/which/env.rs
@@ -21,6 +21,10 @@ pub(super) struct EnvSnapshot {
 }
 
 impl EnvSnapshot {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "composition root: PATH and PATHEXT capture is the which resolver's ambient boundary; injection is tracked in the environment meta issue"
+    )]
     pub(super) fn capture(
         cwd_override: Option<&Utf8Path>,
         path_override: Option<&OsStr>,

--- a/src/stdlib/which/lookup/workspace/mod.rs
+++ b/src/stdlib/which/lookup/workspace/mod.rs
@@ -106,6 +106,10 @@ pub(super) fn should_visit_entry(entry: &walkdir::DirEntry, skip_dirs: &Workspac
     !skip_dirs.contains(&name)
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "composition root: supplies the process environment to the workspace fallback seam"
+)]
 fn workspace_fallback_enabled() -> bool {
     match env::var(WORKSPACE_FALLBACK_ENV) {
         Ok(value) => {

--- a/test_support/clippy.toml
+++ b/test_support/clippy.toml
@@ -1,11 +1,3 @@
-# Align with CodeScene’s ceiling
-cognitive-complexity-threshold = 9     # default is 25 
-too-many-arguments-threshold = 4       # default is 7
-too-many-lines-threshold = 70          # default is 100
-excessive-nesting-threshold = 4        # default is off
-
-allow-expect-in-tests = true
-
 # Enforce the AGENTS.md environment mandate. The reason strings surface in the
 # diagnostic, so a contributor who trips one is told what to do instead.
 #

--- a/test_support/src/command_helper.rs
+++ b/test_support/src/command_helper.rs
@@ -120,6 +120,10 @@ pub fn compile_large_output_helper(
 /// .expect("compile helper");
 /// assert!(exe.as_std_path().exists());
 /// ```
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reads the inherited environment to invoke rustc for a helper binary; the compiler must see the real toolchain"
+)]
 pub fn compile_rust_helper(
     dir: &Dir,
     root: &Utf8PathBuf,

--- a/test_support/src/dev_fast/sandbox.rs
+++ b/test_support/src/dev_fast/sandbox.rs
@@ -275,6 +275,10 @@ pub fn real_utility(utility: &str) -> Result<Utf8PathBuf> {
 /// sourceable `env` shell fragment into `~/.local/bin`, so a plain file probe
 /// selects a non-executable file and every sandboxed `env` invocation then
 /// fails with a permission error.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resolves a tool through the real PATH, which is what the sandbox under test must observe"
+)]
 fn which(utility: &str) -> Result<Utf8PathBuf> {
     let path = std::env::var_os("PATH").context("read PATH")?;
     for dir in std::env::split_paths(&path) {

--- a/test_support/src/env.rs
+++ b/test_support/src/env.rs
@@ -43,12 +43,20 @@ pub trait EnvMut: Env {
 }
 
 impl EnvMut for DefaultEnv {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+    )]
     unsafe fn set_var(&self, key: &str, value: &OsStr) {
         unsafe { std::env::set_var(key, value) };
     }
 }
 
 impl EnvMut for MockEnv {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+    )]
     unsafe fn set_var(&self, key: &str, value: &OsStr) {
         unsafe { std::env::set_var(key, value) };
     }
@@ -59,6 +67,10 @@ impl EnvMut for MockEnv {
 /// Returns a `MockEnv` that yields the current `PATH` when queried. Tests can
 /// modify the real environment while the mock continues to expose the initial
 /// value.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub fn mocked_path_env() -> MockEnv {
     let original = std::env::var("PATH").unwrap_or_default();
     let mut env = MockEnv::new();
@@ -72,6 +84,10 @@ pub fn mocked_path_env() -> MockEnv {
 ///
 /// The mutation is `unsafe` in Rust 2024 as it alters process state. The
 /// unsafety is scoped by acquiring [`EnvLock`].
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub fn set_var(key: &str, value: &OsStr) -> Option<OsString> {
     let _lock = EnvLock::acquire();
     let previous = std::env::var_os(key);
@@ -81,6 +97,10 @@ pub fn set_var(key: &str, value: &OsStr) -> Option<OsString> {
 }
 
 /// Set an environment variable while the caller already holds [`EnvLock`].
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub fn set_var_locked(lock: &EnvLock, key: &str, value: &OsStr) -> Option<OsString> {
     let _ = lock;
     let previous = std::env::var_os(key);
@@ -93,6 +113,10 @@ pub fn set_var_locked(lock: &EnvLock, key: &str, value: &OsStr) -> Option<OsStri
 ///
 /// The mutation is `unsafe` in Rust 2024 as it alters process state. The
 /// unsafety is scoped by acquiring [`EnvLock`].
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub fn remove_var(key: &str) -> Option<OsString> {
     let _lock = EnvLock::acquire();
     let previous = std::env::var_os(key);
@@ -136,6 +160,10 @@ pub fn restore_many(vars: HashMap<String, Option<OsString>>) {
 /// # Safety
 ///
 /// Caller must hold [`EnvLock`] for the duration of this call.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub unsafe fn restore_many_locked(vars: HashMap<String, Option<OsString>>) {
     for (key, val) in vars {
         if let Some(v) = val {
@@ -156,6 +184,10 @@ pub struct VarGuard {
 
 /// Run `action` with `PATH` temporarily set to `value`, restoring on drop and
 /// serialising mutations with `EnvLock`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test_support::env is the crate's process-environment boundary: these guards exist to set and restore real variables for subprocess and legacy in-process tests, which AGENTS.md sanctions"
+)]
 pub fn with_isolated_path<T>(value: &OsStr, action: impl FnOnce() -> T) -> T {
     let _lock = EnvLock::acquire();
     let original = std::env::var_os("PATH");

--- a/test_support/src/env_guard.rs
+++ b/test_support/src/env_guard.rs
@@ -33,10 +33,18 @@ pub trait Environment {
 pub struct StdEnv;
 
 impl Environment for StdEnv {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the guard's whole purpose is to mutate and restore a real process variable; injecting here would leave nothing to guard"
+    )]
     unsafe fn set_var(&mut self, key: &str, value: &OsStr) {
         unsafe { std::env::set_var(key, value) };
     }
 
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the guard's whole purpose is to mutate and restore a real process variable; injecting here would leave nothing to guard"
+    )]
     unsafe fn remove_var(&mut self, key: &str) {
         unsafe { std::env::remove_var(key) };
     }

--- a/test_support/src/env_var_guard.rs
+++ b/test_support/src/env_var_guard.rs
@@ -37,6 +37,10 @@ impl EnvVarGuard {
     /// Mutating process-global state is `unsafe` in Rust 2024. Callers must hold
     /// an [`EnvLock`](crate::env_lock::EnvLock) to serialise mutations.
     #[must_use]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the guard's whole purpose is to mutate and restore a real process variable; injecting here would leave nothing to guard"
+    )]
     pub fn set(name: impl Into<Cow<'static, str>>, val: impl AsRef<OsStr>) -> Self {
         let name = name.into();
         let prev = std::env::var_os(&*name);
@@ -54,6 +58,10 @@ impl EnvVarGuard {
     /// Callers must hold an [`EnvLock`](crate::env_lock::EnvLock) to serialise
     /// mutations of the process environment.
     #[must_use]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the guard's whole purpose is to mutate and restore a real process variable; injecting here would leave nothing to guard"
+    )]
     pub fn remove(name: impl Into<Cow<'static, str>>) -> Self {
         let name = name.into();
         let prev = std::env::var_os(&*name);

--- a/test_support/src/http.rs
+++ b/test_support/src/http.rs
@@ -276,6 +276,10 @@ fn write_response(stream: &mut TcpStream, body: &str) {
     let _ = stream.write_all(response.as_bytes());
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reads an ambient tuning variable for the stub HTTP server; the fixture is configured by the environment it runs in, and no seam reaches it"
+)]
 fn duration_from_env(var: &str, default: Duration) -> Duration {
     match env::var(var) {
         Ok(value) => {

--- a/test_support/src/netsuke.rs
+++ b/test_support/src/netsuke.rs
@@ -13,6 +13,10 @@ use std::path::PathBuf;
 ///
 /// Prefer `CARGO_BIN_EXE_netsuke` when available, otherwise fall back to a
 /// `target/(debug|release)`-derived path based on the current test binary.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reads the inherited environment to build the subprocess invocation; assert_cmd subprocess isolation is the sanctioned exemption in AGENTS.md"
+)]
 fn netsuke_executable() -> Result<PathBuf> {
     if let Some(path) = std::env::var_os("CARGO_BIN_EXE_netsuke") {
         return Ok(path.into());
@@ -90,6 +94,10 @@ pub fn run_netsuke_in(current_dir: &Path, args: &[&str]) -> Result<NetsukeRun> {
 ///
 /// Returns an error when `netsuke` cannot be located or the process cannot be
 /// spawned.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reads the inherited environment to build the subprocess invocation; assert_cmd subprocess isolation is the sanctioned exemption in AGENTS.md"
+)]
 pub fn run_netsuke_in_with_env(
     current_dir: &Path,
     args: &[&str],

--- a/tests/bdd/helpers/env_mutation.rs
+++ b/tests/bdd/helpers/env_mutation.rs
@@ -3,6 +3,11 @@
 //! Provides shared utilities for safely mutating process-global environment
 //! variables within BDD scenarios using the `EnvLock` serialization mechanism.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 use crate::bdd::fixtures::TestWorld;
 use crate::bdd::types::EnvVarKey;
 use anyhow::{Result, ensure};

--- a/tests/bdd/helpers/env_mutation.rs
+++ b/tests/bdd/helpers/env_mutation.rs
@@ -3,11 +3,6 @@
 //! Provides shared utilities for safely mutating process-global environment
 //! variables within BDD scenarios using the `EnvLock` serialization mechanism.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 use crate::bdd::fixtures::TestWorld;
 use crate::bdd::types::EnvVarKey;
 use anyhow::{Result, ensure};
@@ -32,6 +27,10 @@ use std::ffi::OsString;
 ///
 /// Returns an error if the environment variable name is empty, contains '=',
 /// or contains `'\0'`, or if `new_value` contains `'\0'`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 pub fn mutate_env_var(world: &TestWorld, key: EnvVarKey, new_value: Option<&str>) -> Result<()> {
     ensure!(
         !key.as_str().is_empty(),
@@ -85,6 +84,19 @@ mod tests {
         expect_present: bool,
     }
 
+    /// Read a variable back to confirm the mutation under test took effect.
+    ///
+    /// The expectation lives here rather than on the test because `rstest`
+    /// generates one function per case and the attribute does not survive that
+    /// expansion; a single narrow helper is tighter than a module-wide waiver.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "pending migration under #492 (rstest-bdd migration)"
+    )]
+    fn read_back(key: &str) -> Result<String, std::env::VarError> {
+        std::env::var(key)
+    }
+
     #[rstest]
     #[case::empty_key(MutationTestCase { key: "", new_value: None, expect_error: true, expect_present: false })]
     #[case::key_with_equals(MutationTestCase { key: "KEY=VALUE", new_value: Some("test"), expect_error: true, expect_present: false })]
@@ -121,7 +133,7 @@ mod tests {
 
             if tc.expect_present {
                 assert_eq!(
-                    std::env::var(tc.key).ok().as_deref(),
+                    read_back(tc.key).ok().as_deref(),
                     tc.new_value,
                     "variable should be set to expected value"
                 );
@@ -130,7 +142,7 @@ mod tests {
                     .expect("cleanup should succeed");
             } else if !tc.key.is_empty() {
                 assert!(
-                    std::env::var(tc.key).is_err(),
+                    read_back(tc.key).is_err(),
                     "variable should have been removed"
                 );
             }

--- a/tests/bdd/steps/conditional_manifest.rs
+++ b/tests/bdd/steps/conditional_manifest.rs
@@ -10,6 +10,11 @@
 //! still letting later assertions inspect the command outputs and environment
 //! mutations created by the manifest under test.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 use crate::bdd::fixtures::TestWorld;
 use anyhow::{Context, Result};
 use rstest_bdd_macros::given;

--- a/tests/bdd/steps/conditional_manifest.rs
+++ b/tests/bdd/steps/conditional_manifest.rs
@@ -10,11 +10,6 @@
 //! still letting later assertions inspect the command outputs and environment
 //! mutations created by the manifest under test.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 use crate::bdd::fixtures::TestWorld;
 use anyhow::{Context, Result};
 use rstest_bdd_macros::given;
@@ -111,6 +106,10 @@ fn mark_executable(_path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 fn prepend_path_for_child(world: &TestWorld, dir: &Path) -> Result<()> {
     let mut entries = vec![dir.to_path_buf()];
     if let Some(host_path) = std::env::var_os("PATH") {

--- a/tests/bdd/steps/fs.rs
+++ b/tests/bdd/steps/fs.rs
@@ -1,10 +1,5 @@
 //! Steps for preparing file-system fixtures used in Jinja tests (Unix only).
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 use crate::bdd::fixtures::TestWorld;
 use anyhow::{Context, Result, anyhow, ensure};
 use camino::Utf8PathBuf;
@@ -102,6 +97,10 @@ fn create_device_with_fallback(config: DeviceConfig<'_>) -> Result<Utf8PathBuf> 
     Ok(fallback)
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 fn setup_environment_variables(
     world: &TestWorld,
     root: &Utf8PathBuf,

--- a/tests/bdd/steps/fs.rs
+++ b/tests/bdd/steps/fs.rs
@@ -1,5 +1,10 @@
 //! Steps for preparing file-system fixtures used in Jinja tests (Unix only).
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 use crate::bdd::fixtures::TestWorld;
 use anyhow::{Context, Result, anyhow, ensure};
 use camino::Utf8PathBuf;

--- a/tests/bdd/steps/manifest/mod.rs
+++ b/tests/bdd/steps/manifest/mod.rs
@@ -5,6 +5,11 @@
 //! - `helpers.rs` - Typed assertion utilities and target accessor functions
 //! - `targets.rs` - Target-specific assertion steps
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 mod helpers;
 mod targets;
 

--- a/tests/bdd/steps/manifest/mod.rs
+++ b/tests/bdd/steps/manifest/mod.rs
@@ -5,11 +5,6 @@
 //! - `helpers.rs` - Typed assertion utilities and target accessor functions
 //! - `targets.rs` - Target-specific assertion steps
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 mod helpers;
 mod targets;
 
@@ -120,6 +115,10 @@ fn assert_parsed(world: &TestWorld) -> Result<()> {
 // Environment variable helpers
 // ---------------------------------------------------------------------------
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 fn parse_env_token<I>(chars: &mut std::iter::Peekable<I>) -> String
 where
     I: Iterator<Item = char>,

--- a/tests/bdd/steps/manifest_command_helpers.rs
+++ b/tests/bdd/steps/manifest_command_helpers.rs
@@ -3,6 +3,11 @@
 //! Split from `manifest_command.rs` so both files stay within the module size
 //! budget; the step definitions in the parent module call these helpers.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 use super::OutputType;
 use crate::bdd::fixtures::TestWorld;
 use crate::bdd::helpers::assertions::{assert_slot_contains, normalize_fluent_isolates};

--- a/tests/bdd/steps/manifest_command_helpers.rs
+++ b/tests/bdd/steps/manifest_command_helpers.rs
@@ -3,11 +3,6 @@
 //! Split from `manifest_command.rs` so both files stay within the module size
 //! budget; the step definitions in the parent module call these helpers.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 use super::OutputType;
 use crate::bdd::fixtures::TestWorld;
 use crate::bdd::helpers::assertions::{assert_slot_contains, normalize_fluent_isolates};
@@ -144,6 +139,10 @@ pub(super) fn netsuke_executable() -> Result<PathBuf> {
 /// - Controlled `PATH` variable
 ///
 /// Returns the configured command ready for execution.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 pub(super) fn build_netsuke_command(
     world: &TestWorld,
     args: &[&str],

--- a/tests/bdd/steps/stdlib/workspace.rs
+++ b/tests/bdd/steps/stdlib/workspace.rs
@@ -1,6 +1,11 @@
 //! Helpers for preparing stdlib workspaces during BDD scenarios, wiring
 //! up temporary directories, fixtures, and environment overrides for tests.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
+
 use crate::bdd::fixtures::{RefCellOptionExt, TestWorld};
 use crate::bdd::types::{FileContents, HelperName, HttpResponseBody, PathEntries};
 use anyhow::{Context, Result, anyhow};

--- a/tests/bdd/steps/stdlib/workspace.rs
+++ b/tests/bdd/steps/stdlib/workspace.rs
@@ -1,11 +1,6 @@
 //! Helpers for preparing stdlib workspaces during BDD scenarios, wiring
 //! up temporary directories, fixtures, and environment overrides for tests.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #492 (rstest-bdd migration)"
-)]
-
 use crate::bdd::fixtures::{RefCellOptionExt, TestWorld};
 use crate::bdd::types::{FileContents, HelperName, HttpResponseBody, PathEntries};
 use anyhow::{Context, Result, anyhow};
@@ -290,6 +285,10 @@ pub(crate) fn stdlib_path_entries(world: &TestWorld, entries: &str) -> Result<()
 }
 
 #[given("HOME points to the stdlib workspace root")]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #492 (rstest-bdd migration)"
+)]
 pub(crate) fn home_points_to_stdlib_root(world: &TestWorld) -> Result<()> {
     let root = ensure_workspace(world)?;
     let os_root = OsStr::new(root.as_str());

--- a/tests/documentation_examples_e2e_tests.rs
+++ b/tests/documentation_examples_e2e_tests.rs
@@ -1,5 +1,9 @@
 //! End-to-end contracts for user-facing build examples.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
 #![cfg(unix)]
 
 mod documentation_examples;

--- a/tests/documentation_examples_e2e_tests.rs
+++ b/tests/documentation_examples_e2e_tests.rs
@@ -1,9 +1,5 @@
 //! End-to-end contracts for user-facing build examples.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
-)]
 #![cfg(unix)]
 
 mod documentation_examples;
@@ -20,6 +16,10 @@ use test_support::fs as test_fs;
 use test_support::netsuke::{NetsukeRun, run_netsuke_in_with_env};
 use test_support::{ninja::ninja_integration_workspace, write_exec, write_exec_with_content};
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
 fn executable_path(stub_directory: &Utf8Path) -> Result<String> {
     let host_path = std::env::var("PATH").context("read host PATH")?;
     Ok(format!("{stub_directory}:{host_path}"))

--- a/tests/env_path_tests.rs
+++ b/tests/env_path_tests.rs
@@ -1,6 +1,11 @@
 //! Tests for scoped manipulation of `PATH` via `prepend_dir_to_path` and
 //! `PathGuard`.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
+
 use anyhow::{Context, Result, ensure};
 use mockable::Env;
 use rstest::rstest;

--- a/tests/env_path_tests.rs
+++ b/tests/env_path_tests.rs
@@ -1,11 +1,6 @@
 //! Tests for scoped manipulation of `PATH` via `prepend_dir_to_path` and
 //! `PathGuard`.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #493 (integration-binary migration)"
-)]
-
 use anyhow::{Context, Result, ensure};
 use mockable::Env;
 use rstest::rstest;
@@ -15,6 +10,10 @@ use test_support::env::{VarGuard, mocked_path_env, prepend_dir_to_path, system_e
 
 #[rstest]
 #[serial]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
 fn prepend_dir_to_path_sets_and_restores() -> Result<()> {
     let env = mocked_path_env();
     let original = env.raw("PATH").context("mock PATH should be set")?;
@@ -42,6 +41,10 @@ fn prepend_dir_to_path_sets_and_restores() -> Result<()> {
 
 #[rstest]
 #[serial]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
 fn prepend_dir_to_path_handles_empty_path() -> Result<()> {
     let _path_guard = VarGuard::set("PATH", OsStr::new(""));
     let env = system_env();
@@ -66,6 +69,10 @@ fn prepend_dir_to_path_handles_empty_path() -> Result<()> {
 
 #[rstest]
 #[serial]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
 fn prepend_dir_to_path_handles_missing_path() -> Result<()> {
     let _path_guard = VarGuard::unset("PATH");
     let env = system_env();

--- a/tests/env_restore_tests.rs
+++ b/tests/env_restore_tests.rs
@@ -4,6 +4,11 @@
 //! `EnvLock`. Tests verify that set variables are restored, absent variables
 //! are removed, and empty snapshots are handled gracefully.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
+)]
+
 use anyhow::{Result, ensure};
 use rstest::rstest;
 use std::collections::HashMap;

--- a/tests/env_restore_tests.rs
+++ b/tests/env_restore_tests.rs
@@ -4,11 +4,6 @@
 //! `EnvLock`. Tests verify that set variables are restored, absent variables
 //! are removed, and empty snapshots are handled gracefully.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
-)]
-
 use anyhow::{Result, ensure};
 use rstest::rstest;
 use std::collections::HashMap;
@@ -21,6 +16,10 @@ fn test_var(suffix: &str) -> String {
 }
 
 #[rstest]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
+)]
 fn restore_many_restores_previously_set_variable() -> Result<()> {
     let key = test_var("SET");
     let _previous = set_var(&key, std::ffi::OsStr::new("original"));
@@ -47,6 +46,10 @@ fn restore_many_restores_previously_set_variable() -> Result<()> {
 }
 
 #[rstest]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
+)]
 fn restore_many_removes_variable_when_prior_value_is_none() -> Result<()> {
     let key = test_var("NONE");
     let _ = set_var(&key, std::ffi::OsStr::new("transient"));
@@ -70,6 +73,10 @@ fn restore_many_handles_empty_map() {
 }
 
 #[rstest]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
+)]
 fn restore_many_restores_multiple_variables() -> Result<()> {
     let key_a = test_var("MULTI_A");
     let key_b = test_var("MULTI_B");
@@ -101,6 +108,10 @@ fn restore_many_restores_multiple_variables() -> Result<()> {
 }
 
 #[rstest]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "covers the guards being retired; deleted under #493 (integration-binary migration)"
+)]
 fn restore_many_mixed_set_and_remove() -> Result<()> {
     let key_set = test_var("MIX_SET");
     let key_remove = test_var("MIX_REMOVE");

--- a/tests/kani_cfg_ui_tests.rs
+++ b/tests/kani_cfg_ui_tests.rs
@@ -5,11 +5,6 @@
 //! misspelled cfg names should still be rejected when the same check-cfg policy
 //! is applied.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
-)]
-
 use std::{
     io,
     path::{Path, PathBuf},
@@ -103,6 +98,10 @@ fn compile_ui_fixture(source: &str, output_path: &Path) -> io::Result<Output> {
         .output()
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
 fn rustc() -> PathBuf {
     std::env::var_os("RUSTC").map_or_else(|| Path::new("rustc").to_path_buf(), PathBuf::from)
 }

--- a/tests/kani_cfg_ui_tests.rs
+++ b/tests/kani_cfg_ui_tests.rs
@@ -5,6 +5,11 @@
 //! misspelled cfg names should still be rejected when the same check-cfg policy
 //! is applied.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
+
 use std::{
     io,
     path::{Path, PathBuf},

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,10 +1,5 @@
 //! Tests for overriding the `NINJA_ENV` variable via a mock environment.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "pending migration under #493 (integration-binary migration)"
-)]
-
 use anyhow::{Context, Result, ensure};
 use mockable::MockEnv;
 use netsuke::runner::NINJA_ENV;
@@ -20,6 +15,10 @@ fn ninja_tmp() -> PathBuf {
 
 #[rstest]
 #[serial]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
 fn override_ninja_env_sets_and_restores(ninja_tmp: PathBuf) -> Result<()> {
     let before = std::env::var_os(NINJA_ENV);
     let original = before
@@ -48,6 +47,10 @@ fn override_ninja_env_sets_and_restores(ninja_tmp: PathBuf) -> Result<()> {
 
 #[rstest]
 #[serial]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
 fn override_ninja_env_unset_removes_variable(ninja_tmp: PathBuf) -> Result<()> {
     let before = std::env::var_os(NINJA_ENV);
     let mut env = MockEnv::new();

--- a/tests/ninja_env_tests.rs
+++ b/tests/ninja_env_tests.rs
@@ -1,5 +1,10 @@
 //! Tests for overriding the `NINJA_ENV` variable via a mock environment.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "pending migration under #493 (integration-binary migration)"
+)]
+
 use anyhow::{Context, Result, ensure};
 use mockable::MockEnv;
 use netsuke::runner::NINJA_ENV;

--- a/tests/packaging_smoke_tests.rs
+++ b/tests/packaging_smoke_tests.rs
@@ -4,6 +4,11 @@
 //! build-script sources remain in its manifest, where an omission would
 //! otherwise fail only during release.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
+
 use std::collections::BTreeSet;
 use std::env;
 use std::path::Path;

--- a/tests/packaging_smoke_tests.rs
+++ b/tests/packaging_smoke_tests.rs
@@ -4,11 +4,6 @@
 //! build-script sources remain in its manifest, where an omission would
 //! otherwise fail only during release.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
-)]
-
 use std::collections::BTreeSet;
 use std::env;
 use std::path::Path;
@@ -23,6 +18,10 @@ const REQUIRED_PACKAGED_FILES: [&str; 5] = [
 ];
 
 #[test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
 fn packaged_manifest_retains_build_script_sources() {
     let cargo_binary = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let publish_output = Command::new(&cargo_binary)

--- a/tests/release_help/mod.rs
+++ b/tests/release_help/mod.rs
@@ -1,5 +1,10 @@
 //! Shared fixtures for release-help generation script tests.
 
+#![expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
+
 #[cfg(test)]
 mod script_functions;
 

--- a/tests/release_help/mod.rs
+++ b/tests/release_help/mod.rs
@@ -1,10 +1,5 @@
 //! Shared fixtures for release-help generation script tests.
 
-#![expect(
-    clippy::disallowed_methods,
-    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
-)]
-
 #[cfg(test)]
 mod script_functions;
 
@@ -130,6 +125,10 @@ esac
 "#
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "locating build artefacts Cargo reports through the environment; there is no seam to inject and no process state to isolate"
+)]
 pub fn path_with_fake_cargo_orthohelp(fixture: &ScriptFixture) -> Result<OsString> {
     let existing_path = std::env::var_os("PATH").unwrap_or_default();
     let mut entries = vec![fixture.fake_bin_dir.clone()];

--- a/tests/std_filter_tests/command_filters/windows_filter_tests.rs
+++ b/tests/std_filter_tests/command_filters/windows_filter_tests.rs
@@ -83,7 +83,7 @@ impl WindowsSetupContext {
 
 #[expect(
     clippy::disallowed_methods,
-    reason = "the code under test resolves commands through the real process PATH, so the helper directory must be prepended to the inherited value rather than to an injected one; pending migration under #493 (integration-binary migration)"
+    reason = "the test must read the inherited Windows PATH so it can prepend its temporary helper directory: the code under test resolves commands through the real process environment, so an injected value would not be consulted; pending migration under #493 (integration-binary migration)"
 )]
 fn windows_command_setup(
     ctx: WindowsSetupContext,

--- a/tests/std_filter_tests/command_filters/windows_filter_tests.rs
+++ b/tests/std_filter_tests/command_filters/windows_filter_tests.rs
@@ -81,6 +81,10 @@ impl WindowsSetupContext {
     }
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "the code under test resolves commands through the real process PATH, so the helper directory must be prepended to the inherited value rather than to an injected one; pending migration under #493 (integration-binary migration)"
+)]
 fn windows_command_setup(
     ctx: WindowsSetupContext,
     helper_name: &str,


### PR DESCRIPTION
## Summary

AGENTS.md forbids ambient environment access, but nothing stopped the next contributor writing `std::env::var`. #494 proposed a `dylint` rule or a CI grep gate; Clippy's `disallowed-methods` is a better fit.

```toml
disallowed-methods = [
  { path = "std::env::var",        reason = "inject an environment reader" },
  { path = "std::env::var_os",     reason = "inject an environment reader" },
  { path = "std::env::vars",       reason = "inject an environment reader" },
  { path = "std::env::vars_os",    reason = "inject an environment reader" },
  { path = "std::env::set_var",    reason = "use a stub environment in tests" },
  { path = "std::env::remove_var", reason = "use a stub environment in tests" },
]
```

## Why this beats a grep gate

- **It runs in `make lint`**, which already gates every commit — no bespoke CI step to maintain or forget.
- **It resolves paths, not text.** A grep cannot distinguish `std::env::var` from `Command::env`, from a re-exported alias, or from the string appearing in a comment.
- **The reason surfaces in the diagnostic**, so a contributor who trips it is told what to do instead:

  ```
  warning: use of a disallowed method `std::env::var`
    --> src/hasher.rs:67:47
     = note: inject an environment reader
  ```

## `#[expect]`, not `allow` — the load-bearing choice

Every existing site is annotated with `#[expect]`. An expectation goes **unfulfilled — and warns —** once the site stops tripping the lint, so a migrated file fails the gate until its annotation is removed. The backlog cannot rot silently. `allow` would have gone stale invisibly, leaving the repository looking compliant while the annotations outlived their subjects.

Three dispositions, each carrying a reason:

| Disposition | Where | Lifetime |
| --- | --- | --- |
| Composition roots — site-level, naming the seam supplied | 8 sites in `src/` | permanent; this is the sanctioned ambient boundary |
| Build scripts and artefact discovery — module-level | `build.rs`, 4 test files | permanent; they read what Cargo reports and have no seam to inject |
| Pending migration — module-level, naming the tracking issue | 9 test files | removed as #492 and #493 land |

`test_support` is excluded from the workspace (`Cargo.toml:181-186`), so it carries its own copy of the list.

## Verification

The acceptance criterion is that the gate actually fires, so it was tested rather than assumed:

```
make lint exit with a deliberate unannotated std::env::var: 2
make lint exit after removing it:                           0
```

All gates pass: `check-fmt`, `lint`, `typecheck`, `test` (1188 nextest), `markdownlint`, `nixie`. CodeScene delta: no issues. No behavioural change — configuration and attributes only.

## Sequencing

> [!IMPORTANT]
> **Merge this after #497, #498, #499, #501, #502, #503.** It annotates `src/stdlib/which/env.rs`, `path_utils.rs`, `ninja_program.rs`, `manifest/mod.rs`, `locale_resolution.rs`, `cli/discovery.rs`, and several test files that those PRs also change. Landing it first would conflict with all six.

`path_utils.rs` already shows the overlap: this branch annotates the two inline `home_from_env` definitions on `main`, whereas #499 replaces them with extracted ladders. A rebase after #499 will move that annotation onto `home_from_env` alone.

Supersedes the enforcement half of #494.

Closes #504.
Refs #494, #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce the ambient environment access mandate via Clippy by disallowing direct use of std::env APIs, and document the policy and its sanctioned exceptions.

Enhancements:
- Configure Clippy’s disallowed-methods rule for all std::env access points, with tailored reason strings, including a mirrored configuration for the isolated test_support workspace.
- Annotate sanctioned environment access sites across core code paths, build scripts, CLI discovery, locale resolution, manifest helpers, output configuration, path and which resolution, and workspace fallback with #[expect] to keep the lint backlog self-healing.
- Mark test modules that still rely on direct environment mutation or build-artefact discovery as pending migrations or scoped exceptions, tied to tracking issues.

Documentation:
- Extend the developers’ guide with an explicit "Enforcing the environment mandate" section describing the Clippy gate, sanctioned patterns, and how to annotate sites, while tightening existing explanations of Polonius tooling and test execution.
- Update design, ADR, Polonius migration, snapshot testing, and user-facing installation docs to reflect the Polonius toolchain contract, environment access seams, and recommended workflows more clearly.

Tests:
- Add lint expectations to multiple test files that intentionally touch process environment or build artefacts, classifying them as pending migrations or permanent boundaries so make lint stays green while the environment policy is enforced.