### PR TITLE
Use impersonal phrasing in the developer guide (#510)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -429,7 +429,7 @@ the location with `DEV_FAST_PREFIX`. Every `dev-*` recipe prepends
 `$(DEV_FAST_PREFIX)/bin` to `PATH`, so an overridden prefix is the one actually
 selected — `-fuse-ld=mold` resolves by `PATH` order, and the Makefile otherwise
 puts `~/.local/bin` first unconditionally. Invoking the scripts directly rather
-than through `make` means arranging that `PATH` order yourself.
+than through `make` means arranging that `PATH` order manually.
 
 `make dev-fast-check` prints the resolved `mold` path alongside its version, so
 an unexpected pick is visible. A version that differs from the pin fails the
@@ -723,7 +723,7 @@ isolates Cranelift and `mold` rather than also capturing a toolchain change —
 earlier figures in this document did not, and overstated the gain. And the
 benchmark builds only `--bin netsuke`, the smallest useful target, so it
 under-represents what `make dev-test` sees, where Cranelift has every test
-binary's codegen to save on. Measure your own workload before concluding the
+binary's codegen to save on. Measure the actual workload before concluding the
 acceleration is or is not worth the setup.
 
 ## Formal-verification tooling


### PR DESCRIPTION
Closes #510

## What changed

`docs/developers-guide.md` addressed the reader in the second person in two
places, which is inconsistent with the impersonal register used throughout the
rest of the guide. Both are rephrased impersonally, preserving the instructions
and their meaning exactly:

- **`PATH` ordering note (dev-fast prefix section):** "…means arranging that
  `PATH` order yourself." → "…means arranging that `PATH` order manually."
- **Cranelift benchmark caveat:** "Measure your own workload before
  concluding…" → "Measure the actual workload before concluding…"

A sweep of the whole file for second-person pronouns
(`grep -nEi "\byou\b|\byour\b|\byourself\b" docs/developers-guide.md`) found
exactly these two occurrences and now returns nothing. No occurrences beyond
the two named in the issue were found.

## Scope

Wording only. No sections restructured, no paragraphs reflowed, no other files
touched — the diff is two lines. Markdown was deliberately not reformatted
wholesale, since unrelated reflow churn has drawn review objections on this
repository before.

## Validation

- `make markdownlint` — exit status 0
- `make nixie` — exit status 0

`make test` and `make lint` were not run: this is a Markdown-only change that
touches no Rust source, and the shared Cargo cache is in use by other work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Reword two sentences in the developer guide to avoid second-person pronouns while preserving their original meaning.