### PR TITLE
Narrow the build script's module graph (#513)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,55 +16,48 @@ use time::{OffsetDateTime, format_description::well_known::Iso8601};
 
 const FALLBACK_DATE: &str = "1970-01-01";
 
-// The build script recompiles these library modules as its own crate so that
-// `cli::Cli::command()` (used for man-page generation) can be constructed. Only
-// a small slice of each module's public API is reachable from this binary, so
-// the compiler reports the remainder as unused. Those items are not dead: their
-// real call sites live in the library crate and are covered by its tests, where
-// dead-code and unused-import analysis applies normally. Each shared module
-// therefore carries an `#[expect]` for exactly the lints it triggers here, in
-// preference to anchoring the symbols with artificial references.
-#[expect(
-    dead_code,
-    unused_imports,
-    reason = "shared library source; the unreached API is exercised by the library crate"
-)]
-#[path = "src/cli/mod.rs"]
-mod cli;
+// The build script recompiles a slice of the library as its own crate so that
+// `cli::Cli::command()` (used for man-page generation) can be constructed, and
+// so that the localization audit can read the declared key registry.
+//
+// The slice is named file by file rather than by pulling in `src/cli/mod.rs`,
+// because that would drag the whole `cli` subtree — configuration discovery,
+// merging, diagnostics, localised value parsing — into this crate, where none
+// of it is reachable. Recompiling only what is reachable keeps rustc's
+// unused-item analysis meaningful here instead of requiring module-wide
+// `#[expect(dead_code)]` suppressions that would also mask genuinely dead
+// library code.
+//
+// The library modules below are laid out to keep this slice small:
+// `src/cli/command.rs` holds definitions only, with runtime behaviour in
+// `src/cli/preferences.rs` and `src/cli/parser.rs`; matching logic is split out
+// of `src/host_pattern.rs` into `src/host_matching.rs`. Adding a dependency on
+// anything outside this slice will surface here as a compile error, which is
+// the intended signal.
+#[path = "src/cli"]
+mod cli {
+    //! The Clap schema slice of `src/cli`, mirroring `src/cli/mod.rs`.
+
+    #[path = "config.rs"]
+    pub mod config;
+    #[path = "validation.rs"]
+    mod validation;
+
+    #[path = "command.rs"]
+    mod command;
+
+    pub use command::Cli;
+    pub use config::{AccessibilityPolicy, ColourPolicy, EmojiPolicy, ProgressPolicy};
+}
 
 #[path = "src/cli_localization.rs"]
 mod cli_localization;
 
-#[expect(
-    dead_code,
-    reason = "shared library source; the unreached API is exercised by the library crate"
-)]
-#[path = "src/cli_l10n.rs"]
-mod cli_l10n;
-
-#[expect(
-    dead_code,
-    reason = "shared library source; the unreached API is exercised by the library crate"
-)]
 #[path = "src/host_pattern.rs"]
 mod host_pattern;
 
 #[path = "src/localization/mod.rs"]
 mod localization;
-
-#[expect(
-    dead_code,
-    reason = "shared library source; the unreached API is exercised by the library crate"
-)]
-#[path = "src/output_mode.rs"]
-mod output_mode;
-
-#[expect(
-    dead_code,
-    reason = "shared library source; the unreached API is exercised by the library crate"
-)]
-#[path = "src/theme.rs"]
-mod theme;
 
 mod build_l10n_audit;
 
@@ -114,11 +107,12 @@ fn write_man_page(data: &[u8], dir: &Path, page_name: &str) -> std::io::Result<P
 }
 
 fn emit_rerun_directives() {
-    println!("cargo:rerun-if-changed=src/cli/mod.rs");
+    // Only the modules this script actually compiles need to trigger a rerun.
+    println!("cargo:rerun-if-changed=src/cli/command.rs");
     println!("cargo:rerun-if-changed=src/cli/config.rs");
-    println!("cargo:rerun-if-changed=src/cli/merge.rs");
-    println!("cargo:rerun-if-changed=src/cli/parser.rs");
-    println!("cargo:rerun-if-changed=src/cli/parsing.rs");
+    println!("cargo:rerun-if-changed=src/cli/validation.rs");
+    println!("cargo:rerun-if-changed=src/host_pattern.rs");
+    println!("cargo:rerun-if-changed=src/cli_localization.rs");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     println!("cargo:rerun-if-env-changed=CARGO_PKG_NAME");
     println!("cargo:rerun-if-env-changed=CARGO_BIN_NAME");

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -377,6 +377,39 @@ unit tests, and `rstest-bdd` release-help scenarios.
 `src/cli/config_path_precedence_tests.rs` is the canonical exhaustive
 state-enumeration example.
 
+## The build script's module slice
+
+`build.rs` recompiles part of the library as its own crate: it needs
+`cli::Cli::command()` for man-page generation and the key registry in
+`src/localization/keys.rs` for the Fluent audit. Rather than declaring
+`src/cli/mod.rs` and inheriting the whole subtree, it declares an inline `cli`
+module naming exactly three files — `src/cli/command.rs`, `src/cli/config.rs`,
+and `src/cli/validation.rs`.
+
+That slice is a maintained boundary, not an accident:
+
+- `src/cli/command.rs` holds Clap definitions only. Runtime behaviour on `Cli`
+  belongs in `src/cli/preferences.rs`, and the localization-aware parsing entry
+  point belongs in `src/cli/parser.rs`.
+- `src/cli/validation.rs` holds the shared limits and error constructor that
+  `src/cli/config.rs` needs, so neither file has to reach up into
+  `src/cli/mod.rs`.
+- `src/host_pattern.rs` covers pattern syntax; matching a concrete hostname
+  against a parsed pattern lives in `src/host_matching.rs`, which the build
+  script does not compile.
+
+Keeping the slice narrow is what lets rustc's unused-item analysis run normally
+inside the build-script crate. Widening it — for example by making
+`src/cli/command.rs` depend on the merge or discovery layers — reintroduces
+unreachable items and, with them, the module-wide `#[expect(dead_code)]`
+suppressions that issue #513 removed. Those suppressions also masked genuinely
+dead code: an unused `pub` item in `src/cli/config.rs` is reported by the
+build-script crate but not by the library, because the library exports that
+module publicly.
+
+A dependency added outside the slice surfaces as a build-script compile error.
+Prefer moving the new code into a sibling module over widening the slice.
+
 ## Local build acceleration
 
 Debug builds and tests can optionally use the [`mold`] linker and the Cranelift

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -2429,7 +2429,9 @@ the targets listed in the `defaults` section of the manifest are built.
 
 ### 8.4 Design Decisions
 
-The parser-facing `Cli` type is now defined in `src/cli/parser.rs`, while
+The parser-facing `Cli` type is now defined in `src/cli/command.rs`, with the
+localization-aware parsing entry point in `src/cli/parser.rs` and the runtime
+preference accessors in `src/cli/preferences.rs`, while
 layered configuration lives in a dedicated `CliConfig` struct derived with
 OrthoConfig in `src/cli/config.rs`. The top-level `src/cli/mod.rs` module
 re-exports that public CLI surface. This separation keeps parsing,

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,0 +1,212 @@
+//! The Clap-derived command tree.
+//!
+//! This module owns the runtime-visible [`Cli`] struct and every associated
+//! Clap definition ([`InteractionArgs`], [`BuildArgs`], [`GraphArgs`],
+//! [`Commands`]). It holds definitions only: no parsing entry point, no
+//! localisation, and no runtime behaviour.
+//!
+//! **Pipeline position:** schema layer, below [`super::parser`].
+//!
+//! The narrow dependency surface is deliberate. `build.rs` recompiles this
+//! module (plus [`super::config`] and [`super::validation`]) to obtain
+//! `Cli::command()` for man-page generation; anything reachable from here is
+//! also compiled by the build script, so behaviour that the man page does not
+//! need belongs in a sibling module instead.
+
+use clap::{Args, Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use super::config::CliConfig;
+use super::{AccessibilityPolicy, ColourPolicy, EmojiPolicy, ProgressPolicy};
+use crate::host_pattern::HostPattern;
+
+/// A modern, friendly build system that uses YAML and Jinja, powered by Ninja.
+#[derive(Debug, Parser, Serialize, Deserialize)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Path to the Netsuke manifest file to use.
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        default_value_os_t = CliConfig::default_manifest_path()
+    )]
+    pub file: PathBuf,
+
+    /// Run as if started in this directory.
+    ///
+    /// This affects manifest lookup, output paths, and config discovery.
+    #[arg(short = 'C', long, value_name = "DIR")]
+    pub directory: Option<PathBuf>,
+
+    /// Path to a configuration file, bypassing automatic discovery.
+    #[arg(long, value_name = "FILE")]
+    #[serde(skip)]
+    pub config: Option<PathBuf>,
+
+    /// Set the number of parallel build jobs.
+    ///
+    /// Values must be between 1 and 64.
+    #[arg(short, long, value_name = "N")]
+    pub jobs: Option<usize>,
+
+    /// Enable verbose diagnostic logging and completion timing summaries.
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    /// Locale tag for CLI copy (for example: en-US, es-ES).
+    #[arg(long, value_name = "LOCALE")]
+    pub locale: Option<String>,
+
+    /// Additional URL schemes allowed for the `fetch` helper.
+    #[arg(long = "fetch-allow-scheme", value_name = "SCHEME")]
+    pub fetch_allow_scheme: Vec<String>,
+
+    /// Hostnames that are permitted when default deny is enabled.
+    ///
+    /// Supports wildcards such as `*.example.com`.
+    #[arg(long = "fetch-allow-host", value_name = "HOST")]
+    pub fetch_allow_host: Vec<HostPattern>,
+
+    /// Hostnames that are always blocked, even when allowed elsewhere.
+    ///
+    /// Supports wildcards such as `*.example.com`.
+    #[arg(long = "fetch-block-host", value_name = "HOST")]
+    pub fetch_block_host: Vec<HostPattern>,
+
+    /// Deny all hosts by default; only allow the declared allowlist.
+    #[arg(long = "fetch-default-deny")]
+    pub fetch_default_deny: bool,
+
+    /// Emit machine-readable JSON output.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Interaction policy flags.
+    #[command(flatten)]
+    pub interaction: InteractionArgs,
+
+    /// Select the colour policy for terminal output.
+    #[arg(long, value_name = "POLICY", default_value_t)]
+    pub color: ColourPolicy,
+
+    /// Select the emoji policy for terminal output.
+    #[arg(long, value_name = "POLICY", default_value_t)]
+    pub emoji: EmojiPolicy,
+
+    /// Select the progress-rendering policy.
+    #[arg(long, value_name = "POLICY", default_value_t)]
+    pub progress: ProgressPolicy,
+
+    /// Select the accessible-output policy.
+    #[arg(long, value_name = "POLICY", default_value_t)]
+    pub accessibility: AccessibilityPolicy,
+
+    /// Default build targets used when none are specified on the CLI.
+    #[arg(long = "default-target", value_name = "TARGET")]
+    pub default_targets: Vec<String>,
+
+    /// Optional subcommand to execute; defaults to `build` when omitted.
+    #[serde(skip)]
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+impl Cli {
+    /// Apply the default command if none was specified.
+    #[must_use]
+    pub fn with_default_command(mut self) -> Self {
+        if self.command.is_none() {
+            self.command = Some(Commands::Build(BuildArgs::default()));
+        }
+        self
+    }
+}
+
+impl Default for Cli {
+    fn default() -> Self {
+        Self {
+            file: CliConfig::default_manifest_path(),
+            directory: None,
+            config: None,
+            jobs: None,
+            verbose: false,
+            locale: None,
+            fetch_allow_scheme: Vec::new(),
+            fetch_allow_host: Vec::new(),
+            fetch_block_host: Vec::new(),
+            fetch_default_deny: false,
+            json: false,
+            interaction: InteractionArgs::default(),
+            color: ColourPolicy::Auto,
+            emoji: EmojiPolicy::Auto,
+            progress: ProgressPolicy::Auto,
+            accessibility: AccessibilityPolicy::Auto,
+            default_targets: Vec::new(),
+            command: None,
+        }
+        .with_default_command()
+    }
+}
+
+/// Arguments controlling whether Netsuke may read interactive input.
+#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct InteractionArgs {
+    /// Never read interactive input.
+    #[arg(long, default_value_t = true)]
+    pub no_input: bool,
+}
+
+impl Default for InteractionArgs {
+    fn default() -> Self {
+        Self { no_input: true }
+    }
+}
+
+/// Arguments accepted by the `build` command.
+#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct BuildArgs {
+    /// A list of specific targets to build.
+    #[serde(default)]
+    pub targets: Vec<String>,
+}
+
+/// Arguments accepted by the `graph` command.
+///
+/// `html` and `output` are per-invocation flags and are intentionally excluded
+/// from `OrthoConfig` layering (`#[serde(skip)]`); layering them through a
+/// configuration file would silently change the artefact destination.
+#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
+pub struct GraphArgs {
+    /// Render the graph as a self-contained HTML page instead of DOT.
+    #[arg(long)]
+    #[serde(skip)]
+    pub html: bool,
+
+    /// Write the graph artefact to FILE. Use `-` for stdout.
+    #[arg(long, value_name = "FILE")]
+    #[serde(skip)]
+    pub output: Option<PathBuf>,
+}
+
+/// Available top-level commands for Netsuke.
+#[derive(Debug, Subcommand, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Commands {
+    /// Build specified targets (or default targets if none are given).
+    Build(BuildArgs),
+
+    /// Remove build artefacts and intermediate files.
+    Clean,
+
+    /// Display the build dependency graph in DOT format for visualisation.
+    Graph(GraphArgs),
+
+    /// Generate the Ninja manifest without invoking Ninja.
+    Generate {
+        /// Write the generated Ninja manifest to FILE instead of stdout.
+        #[arg(long, value_name = "FILE")]
+        output: Option<PathBuf>,
+    },
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use super::validation_error;
+use super::validation::validation_error;
 use crate::host_pattern::HostPattern;
 
 /// Required non-interactive execution setting.
@@ -275,7 +275,7 @@ impl CliConfig {
     }
 }
 
-const MAX_JOBS: usize = super::MAX_JOBS;
+const MAX_JOBS: usize = super::validation::MAX_JOBS;
 
 const fn jobs_out_of_bounds(jobs: usize) -> bool {
     jobs == 0 || jobs > MAX_JOBS

--- a/src/cli/diag.rs
+++ b/src/cli/diag.rs
@@ -11,8 +11,8 @@ use ortho_config::{OrthoError, OrthoResult};
 use serde_json::Value;
 use std::sync::Arc;
 
+use super::command::Cli;
 use super::discovery::{EnvProvider, StdEnvProvider, collect_diag_file_layers_with_env};
-use super::parser::Cli;
 
 const JSON_ENV_VAR: &str = "NETSUKE_JSON";
 

--- a/src/cli/discovery.rs
+++ b/src/cli/discovery.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, debug_span};
 
-use super::parser::Cli;
+use super::command::Cli;
 
 #[path = "discovery_diagnostics.rs"]
 mod diagnostics;

--- a/src/cli/merge.rs
+++ b/src/cli/merge.rs
@@ -30,10 +30,10 @@ use serde::Serialize;
 
 use serde_json::{Map, Value, json};
 
+use super::command::{BuildArgs, Cli, Commands};
 use super::config::{BuildConfig, CliConfig};
 use super::discovery::push_file_layers;
-use super::parser::{BuildArgs, Cli, Commands};
-use super::validation_error;
+use super::validation::validation_error;
 
 const ENV_PREFIX: &str = "NETSUKE_";
 
@@ -191,7 +191,7 @@ fn apply_config(parsed: &Cli, config: CliConfig) -> Cli {
         fetch_block_host: config.fetch_block_host,
         fetch_default_deny: config.fetch_default_deny,
         json: config.json,
-        interaction: super::parser::InteractionArgs {
+        interaction: super::command::InteractionArgs {
             no_input: config.no_input.is_enabled(),
         },
         color: config.color,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,35 +4,27 @@
 //! syntax, while [`CliConfig`] is the authoritative OrthoConfig-derived schema
 //! used to merge defaults, configuration files, environment variables, and CLI
 //! overrides into the runtime shape consumed by the runner.
+//!
+//! The module is split so that `build.rs` can compile the Clap schema alone.
+//! `command`, [`config`], and `validation` form that self-contained slice;
+//! every other submodule here is library-only. See the note in `build.rs`.
 
-use ortho_config::OrthoError;
-use std::sync::Arc;
-
+mod command;
 pub mod config;
 mod diag;
 mod discovery;
 mod merge;
 mod parser;
 mod parsing;
+mod preferences;
+mod validation;
 
 #[cfg(test)]
 pub(crate) mod test_support;
 
+pub use command::{BuildArgs, Cli, Commands, GraphArgs};
 pub use config::{AccessibilityPolicy, CliConfig, ColourPolicy, EmojiPolicy, ProgressPolicy};
 pub use diag::{resolve_merged_json, resolve_merged_json_with_env};
 pub use discovery::{EnvProvider as ConfigEnvProvider, StdEnvProvider as ConfigStdEnvProvider};
 pub use merge::merge_with_config;
-pub use parser::{
-    BuildArgs, Cli, Commands, GraphArgs, json_hint_from_args, locale_hint_from_args,
-    parse_with_localizer_from,
-};
-
-/// Maximum number of jobs accepted by the CLI.
-pub(super) const MAX_JOBS: usize = 64;
-
-pub(super) fn validation_error(key: &str, message: &str) -> Arc<OrthoError> {
-    Arc::new(OrthoError::Validation {
-        key: key.to_owned(),
-        message: message.to_owned(),
-    })
-}
+pub use parser::{json_hint_from_args, locale_hint_from_args, parse_with_localizer_from};

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -1,39 +1,31 @@
-//! Clap-facing parser types and localisation helpers.
+//! Localisation-aware Clap parsing entry point.
 //!
-//! This module owns the runtime-visible [`Cli`] struct and all associated
-//! Clap definitions ([`BuildArgs`], [`Commands`]).  It also provides
-//! [`parse_with_localizer_from`], which localises the Clap command, installs
-//! localisation-aware [`LocalizedValueParser`] instances for every typed
-//! argument, and returns `(Cli, ArgMatches)` for downstream processing.
+//! This module provides [`parse_with_localizer_from`], which localises the
+//! Clap command declared by [`super::command`], installs localisation-aware
+//! [`LocalizedValueParser`] instances for every typed argument, and returns
+//! `(Cli, ArgMatches)` for downstream processing.
 //!
 //! **Pipeline position:** parsing layer.
 //!
 //! - Receives raw `OsStr` arguments from the process entry point.
 //! - Delegates value validation to [`super::parsing`] helpers.
 //! - Returns a `Cli`/`ArgMatches` pair consumed by [`super::merge`].
-//!
-//! [`LocalizedValueParser`]: self::LocalizedValueParser
 
 use clap::builder::{TypedValueParser, ValueParser};
 use clap::error::ErrorKind;
-use clap::{ArgMatches, Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{ArgMatches, CommandFactory, FromArgMatches};
 use ortho_config::localize_clap_error_with_command;
 use ortho_config::{LocalizationArgs, Localizer};
-use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::config::CliConfig;
+use super::command::Cli;
 use super::parsing::{
     parse_accessibility_policy, parse_color_policy, parse_emoji_policy, parse_host_pattern,
     parse_jobs, parse_locale, parse_progress_policy, parse_scheme,
 };
-use super::{AccessibilityPolicy, ColourPolicy, EmojiPolicy, ProgressPolicy};
 use crate::cli_l10n::localize_command;
 pub use crate::cli_l10n::{json_hint_from_args, locale_hint_from_args};
-use crate::host_pattern::HostPattern;
-use crate::theme::ThemePreference;
 
 #[derive(Clone)]
 struct LocalizedValueParser<F> {
@@ -76,228 +68,6 @@ pub(super) fn validation_message(
     fallback: &str,
 ) -> String {
     localizer.message(key, args, fallback)
-}
-
-/// A modern, friendly build system that uses YAML and Jinja, powered by Ninja.
-#[derive(Debug, Parser, Serialize, Deserialize)]
-#[command(author, version, about, long_about = None)]
-pub struct Cli {
-    /// Path to the Netsuke manifest file to use.
-    #[arg(
-        short,
-        long,
-        value_name = "FILE",
-        default_value_os_t = CliConfig::default_manifest_path()
-    )]
-    pub file: PathBuf,
-
-    /// Run as if started in this directory.
-    ///
-    /// This affects manifest lookup, output paths, and config discovery.
-    #[arg(short = 'C', long, value_name = "DIR")]
-    pub directory: Option<PathBuf>,
-
-    /// Path to a configuration file, bypassing automatic discovery.
-    #[arg(long, value_name = "FILE")]
-    #[serde(skip)]
-    pub config: Option<PathBuf>,
-
-    /// Set the number of parallel build jobs.
-    ///
-    /// Values must be between 1 and 64.
-    #[arg(short, long, value_name = "N")]
-    pub jobs: Option<usize>,
-
-    /// Enable verbose diagnostic logging and completion timing summaries.
-    #[arg(short, long)]
-    pub verbose: bool,
-
-    /// Locale tag for CLI copy (for example: en-US, es-ES).
-    #[arg(long, value_name = "LOCALE")]
-    pub locale: Option<String>,
-
-    /// Additional URL schemes allowed for the `fetch` helper.
-    #[arg(long = "fetch-allow-scheme", value_name = "SCHEME")]
-    pub fetch_allow_scheme: Vec<String>,
-
-    /// Hostnames that are permitted when default deny is enabled.
-    ///
-    /// Supports wildcards such as `*.example.com`.
-    #[arg(long = "fetch-allow-host", value_name = "HOST")]
-    pub fetch_allow_host: Vec<HostPattern>,
-
-    /// Hostnames that are always blocked, even when allowed elsewhere.
-    ///
-    /// Supports wildcards such as `*.example.com`.
-    #[arg(long = "fetch-block-host", value_name = "HOST")]
-    pub fetch_block_host: Vec<HostPattern>,
-
-    /// Deny all hosts by default; only allow the declared allowlist.
-    #[arg(long = "fetch-default-deny")]
-    pub fetch_default_deny: bool,
-
-    /// Emit machine-readable JSON output.
-    #[arg(long)]
-    pub json: bool,
-
-    /// Interaction policy flags.
-    #[command(flatten)]
-    pub interaction: InteractionArgs,
-
-    /// Select the colour policy for terminal output.
-    #[arg(long, value_name = "POLICY", default_value_t)]
-    pub color: ColourPolicy,
-
-    /// Select the emoji policy for terminal output.
-    #[arg(long, value_name = "POLICY", default_value_t)]
-    pub emoji: EmojiPolicy,
-
-    /// Select the progress-rendering policy.
-    #[arg(long, value_name = "POLICY", default_value_t)]
-    pub progress: ProgressPolicy,
-
-    /// Select the accessible-output policy.
-    #[arg(long, value_name = "POLICY", default_value_t)]
-    pub accessibility: AccessibilityPolicy,
-
-    /// Default build targets used when none are specified on the CLI.
-    #[arg(long = "default-target", value_name = "TARGET")]
-    pub default_targets: Vec<String>,
-
-    /// Optional subcommand to execute; defaults to `build` when omitted.
-    #[serde(skip)]
-    #[command(subcommand)]
-    pub command: Option<Commands>,
-}
-
-impl Cli {
-    /// Apply the default command if none was specified.
-    #[must_use]
-    pub fn with_default_command(mut self) -> Self {
-        if self.command.is_none() {
-            self.command = Some(Commands::Build(BuildArgs::default()));
-        }
-        self
-    }
-
-    /// Return the effective theme preference for emoji policy resolution.
-    #[must_use]
-    pub const fn theme_preference(&self) -> Option<ThemePreference> {
-        match self.emoji {
-            EmojiPolicy::Auto => None,
-            EmojiPolicy::Always => Some(ThemePreference::Unicode),
-            EmojiPolicy::Never => Some(ThemePreference::Ascii),
-        }
-    }
-
-    /// Return an explicit accessible-output override, if configured.
-    #[must_use]
-    pub const fn accessibility_override(&self) -> Option<bool> {
-        match self.accessibility {
-            AccessibilityPolicy::Auto => None,
-            AccessibilityPolicy::On => Some(true),
-            AccessibilityPolicy::Off => Some(false),
-        }
-    }
-
-    /// Return whether interactive input is disabled.
-    #[must_use]
-    pub const fn no_input(&self) -> bool {
-        self.interaction.no_input
-    }
-
-    /// Return whether progress summaries should be enabled.
-    #[must_use]
-    pub const fn progress_enabled(&self) -> bool {
-        !matches!(self.progress, ProgressPolicy::Never)
-    }
-}
-
-impl Default for Cli {
-    fn default() -> Self {
-        Self {
-            file: CliConfig::default_manifest_path(),
-            directory: None,
-            config: None,
-            jobs: None,
-            verbose: false,
-            locale: None,
-            fetch_allow_scheme: Vec::new(),
-            fetch_allow_host: Vec::new(),
-            fetch_block_host: Vec::new(),
-            fetch_default_deny: false,
-            json: false,
-            interaction: InteractionArgs::default(),
-            color: ColourPolicy::Auto,
-            emoji: EmojiPolicy::Auto,
-            progress: ProgressPolicy::Auto,
-            accessibility: AccessibilityPolicy::Auto,
-            default_targets: Vec::new(),
-            command: None,
-        }
-        .with_default_command()
-    }
-}
-
-/// Arguments controlling whether Netsuke may read interactive input.
-#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct InteractionArgs {
-    /// Never read interactive input.
-    #[arg(long, default_value_t = true)]
-    pub no_input: bool,
-}
-
-impl Default for InteractionArgs {
-    fn default() -> Self {
-        Self { no_input: true }
-    }
-}
-
-/// Arguments accepted by the `build` command.
-#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
-pub struct BuildArgs {
-    /// A list of specific targets to build.
-    #[serde(default)]
-    pub targets: Vec<String>,
-}
-
-/// Arguments accepted by the `graph` command.
-///
-/// `html` and `output` are per-invocation flags and are intentionally excluded
-/// from `OrthoConfig` layering (`#[serde(skip)]`); layering them through a
-/// configuration file would silently change the artefact destination.
-#[derive(Debug, Args, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
-pub struct GraphArgs {
-    /// Render the graph as a self-contained HTML page instead of DOT.
-    #[arg(long)]
-    #[serde(skip)]
-    pub html: bool,
-
-    /// Write the graph artefact to FILE. Use `-` for stdout.
-    #[arg(long, value_name = "FILE")]
-    #[serde(skip)]
-    pub output: Option<PathBuf>,
-}
-
-/// Available top-level commands for Netsuke.
-#[derive(Debug, Subcommand, PartialEq, Eq, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum Commands {
-    /// Build specified targets (or default targets if none are given).
-    Build(BuildArgs),
-
-    /// Remove build artefacts and intermediate files.
-    Clean,
-
-    /// Display the build dependency graph in DOT format for visualisation.
-    Graph(GraphArgs),
-
-    /// Generate the Ninja manifest without invoking Ninja.
-    Generate {
-        /// Write the generated Ninja manifest to FILE instead of stdout.
-        #[arg(long, value_name = "FILE")]
-        output: Option<PathBuf>,
-    },
 }
 
 /// Parse CLI arguments with localized clap output.

--- a/src/cli/parsing.rs
+++ b/src/cli/parsing.rs
@@ -31,17 +31,17 @@ pub(super) fn parse_jobs(localizer: &dyn Localizer, s: &str) -> Result<usize, St
             &format!("{s} is not a valid number"),
         )
     })?;
-    if (1..=super::MAX_JOBS).contains(&value) {
+    if (1..=super::validation::MAX_JOBS).contains(&value) {
         Ok(value)
     } else {
         let mut args = LocalizationArgs::default();
         args.insert("min", 1.to_string().into());
-        args.insert("max", super::MAX_JOBS.to_string().into());
+        args.insert("max", super::validation::MAX_JOBS.to_string().into());
         Err(super::parser::validation_message(
             localizer,
             keys::CLI_JOBS_OUT_OF_RANGE,
             Some(&args),
-            &format!("jobs must be between 1 and {}", super::MAX_JOBS),
+            &format!("jobs must be between 1 and {}", super::validation::MAX_JOBS),
         ))
     }
 }

--- a/src/cli/preferences.rs
+++ b/src/cli/preferences.rs
@@ -1,0 +1,45 @@
+//! Runtime preferences derived from parsed CLI flags.
+//!
+//! These accessors translate the raw policy flags carried by
+//! [`Cli`](super::command::Cli) into the preference values the runner and
+//! presentation layers consume. They live beside the command schema rather
+//! than inside it so that [`super::command`] keeps a dependency surface narrow
+//! enough for `build.rs` to compile on its own.
+
+use super::command::Cli;
+use super::{AccessibilityPolicy, EmojiPolicy, ProgressPolicy};
+use crate::theme::ThemePreference;
+
+impl Cli {
+    /// Return the effective theme preference for emoji policy resolution.
+    #[must_use]
+    pub const fn theme_preference(&self) -> Option<ThemePreference> {
+        match self.emoji {
+            EmojiPolicy::Auto => None,
+            EmojiPolicy::Always => Some(ThemePreference::Unicode),
+            EmojiPolicy::Never => Some(ThemePreference::Ascii),
+        }
+    }
+
+    /// Return an explicit accessible-output override, if configured.
+    #[must_use]
+    pub const fn accessibility_override(&self) -> Option<bool> {
+        match self.accessibility {
+            AccessibilityPolicy::Auto => None,
+            AccessibilityPolicy::On => Some(true),
+            AccessibilityPolicy::Off => Some(false),
+        }
+    }
+
+    /// Return whether interactive input is disabled.
+    #[must_use]
+    pub const fn no_input(&self) -> bool {
+        self.interaction.no_input
+    }
+
+    /// Return whether progress summaries should be enabled.
+    #[must_use]
+    pub const fn progress_enabled(&self) -> bool {
+        !matches!(self.progress, ProgressPolicy::Never)
+    }
+}

--- a/src/cli/validation.rs
+++ b/src/cli/validation.rs
@@ -1,0 +1,20 @@
+//! Shared validation limits and error construction for the CLI module tree.
+//!
+//! These items are needed by both [`super::config`] (layered-configuration
+//! validation) and [`super::parsing`] (Clap value validation), so they live in
+//! their own leaf module rather than in [`super`]. Keeping them free of
+//! dependencies lets the build script compile [`super::config`] without
+//! dragging in the rest of the `cli` subtree.
+
+use ortho_config::OrthoError;
+use std::sync::Arc;
+
+/// Maximum number of jobs accepted by the CLI.
+pub(super) const MAX_JOBS: usize = 64;
+
+pub(super) fn validation_error(key: &str, message: &str) -> Arc<OrthoError> {
+    Arc::new(OrthoError::Validation {
+        key: key.to_owned(),
+        message: message.to_owned(),
+    })
+}

--- a/src/host_matching.rs
+++ b/src/host_matching.rs
@@ -1,0 +1,65 @@
+//! Matching of concrete hostnames against parsed host patterns.
+//!
+//! Pattern *syntax* lives in [`crate::host_pattern`]; the matching rules that
+//! consume a parsed pattern live here. The split keeps
+//! [`crate::host_pattern`] free of anything the Clap schema does not need, so
+//! `build.rs` can compile it for man-page generation without recompiling
+//! runtime policy evaluation. See the note in `build.rs`.
+
+use crate::host_pattern::HostPattern;
+
+/// A concrete hostname being tested against a [`HostPattern`].
+#[derive(Copy, Clone)]
+pub(crate) struct HostCandidate<'a>(pub(crate) &'a str);
+
+impl<'a> HostCandidate<'a> {
+    const fn as_str(self) -> &'a str {
+        self.0
+    }
+}
+
+impl HostPattern {
+    /// Return whether `candidate` is covered by this pattern.
+    pub(crate) fn matches(&self, candidate: HostCandidate<'_>) -> bool {
+        let host = candidate.as_str().to_ascii_lowercase();
+        if self.wildcard {
+            // Wildcard patterns match only subdomains, not the apex domain.
+            // Example: "*.example.com" matches "sub.example.com" but not
+            // "example.com".
+            host.strip_suffix(&self.pattern)
+                .and_then(|prefix| prefix.strip_suffix('.'))
+                .is_some_and(|prefix| !prefix.is_empty())
+        } else {
+            host == self.pattern
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for wildcard and exact host matching.
+    use super::*;
+
+    use anyhow::{Result, ensure};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("example.com", "example.com", true)]
+    #[case("example.com", "sub.example.com", false)]
+    #[case("*.example.com", "sub.example.com", true)]
+    #[case("*.example.com", "example.com", false)]
+    #[case("*.example.com", "deep.sub.example.com", true)]
+    #[case("*.example.com", "other.com", false)]
+    fn host_pattern_matches_expected(
+        #[case] pattern: &str,
+        #[case] host: &str,
+        #[case] expected: bool,
+    ) -> Result<()> {
+        let parsed = HostPattern::parse(pattern)?;
+        ensure!(
+            parsed.matches(HostCandidate(host)) == expected,
+            "expected match={expected} for {host} against {pattern}",
+        );
+        Ok(())
+    }
+}

--- a/src/host_pattern.rs
+++ b/src/host_pattern.rs
@@ -1,7 +1,10 @@
 //! Shared host pattern validation helpers.
 //!
-//! The module centralises normalisation and matching logic so CLI parsing and
-//! runtime policy evaluation agree on allowable host syntax.
+//! The module centralises host pattern normalisation so CLI parsing and
+//! runtime policy evaluation agree on allowable host syntax. Matching a
+//! concrete hostname against a parsed pattern lives in
+//! `crate::host_matching`, which keeps this module's dependency surface
+//! narrow enough for `build.rs` to compile it for man-page generation.
 
 use crate::localization::{self, LocalizedMessage, keys};
 use serde::{Deserialize, Serialize};
@@ -12,15 +15,6 @@ use thiserror::Error;
 struct HostPatternInput<'a>(&'a str);
 
 impl<'a> HostPatternInput<'a> {
-    const fn as_str(self) -> &'a str {
-        self.0
-    }
-}
-
-#[derive(Copy, Clone)]
-pub(crate) struct HostCandidate<'a>(pub(crate) &'a str);
-
-impl<'a> HostCandidate<'a> {
     const fn as_str(self) -> &'a str {
         self.0
     }
@@ -218,20 +212,6 @@ impl HostPattern {
             wildcard,
         })
     }
-
-    pub(crate) fn matches(&self, candidate: HostCandidate<'_>) -> bool {
-        let host = candidate.as_str().to_ascii_lowercase();
-        if self.wildcard {
-            // Wildcard patterns match only subdomains, not the apex domain.
-            // Example: "*.example.com" matches "sub.example.com" but not
-            // "example.com".
-            host.strip_suffix(&self.pattern)
-                .and_then(|prefix| prefix.strip_suffix('.'))
-                .is_some_and(|prefix| !prefix.is_empty())
-        } else {
-            host == self.pattern
-        }
-    }
 }
 
 impl<'a> TryFrom<&'a str> for HostPattern {
@@ -284,7 +264,7 @@ impl<'de> Deserialize<'de> for HostPattern {
 
 #[cfg(test)]
 mod tests {
-    //! Unit tests for host pattern parsing and wildcard matching.
+    //! Unit tests for host pattern parsing and normalisation.
     use super::*;
 
     use anyhow::{Result, ensure};
@@ -302,26 +282,6 @@ mod tests {
         ensure!(
             parsed.wildcard == wildcard,
             "expected wildcard {wildcard} for pattern {pattern}",
-        );
-        Ok(())
-    }
-
-    #[rstest]
-    #[case("example.com", "example.com", true)]
-    #[case("example.com", "sub.example.com", false)]
-    #[case("*.example.com", "sub.example.com", true)]
-    #[case("*.example.com", "example.com", false)]
-    #[case("*.example.com", "deep.sub.example.com", true)]
-    #[case("*.example.com", "other.com", false)]
-    fn host_pattern_matches_expected(
-        #[case] pattern: &str,
-        #[case] host: &str,
-        #[case] expected: bool,
-    ) -> Result<()> {
-        let parsed = HostPattern::parse(pattern)?;
-        ensure!(
-            parsed.matches(HostCandidate(host)) == expected,
-            "expected match={expected} for {host} against {pattern}",
         );
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod diagnostics;
 pub mod graph_view;
 pub mod hasher;
 pub mod hex;
+mod host_matching;
 pub mod host_pattern;
 pub mod ir;
 mod json_envelope;

--- a/src/stdlib/network/policy/mod.rs
+++ b/src/stdlib/network/policy/mod.rs
@@ -9,7 +9,8 @@ use crate::localization::{self, LocalizedMessage, keys};
 use thiserror::Error;
 use url::Url;
 
-use crate::host_pattern::{HostCandidate, HostPattern, HostPatternError};
+use crate::host_matching::HostCandidate;
+use crate::host_pattern::{HostPattern, HostPatternError};
 
 /// Declarative allow- and deny-list policy for outbound network requests.
 ///


### PR DESCRIPTION
Closes #513

## Problem

`build.rs` recompiles part of the library so it can call `cli::Cli::command()`
for man-page generation. It declared `src/cli/mod.rs`, which pulled the whole
`cli` subtree — merging, discovery, diagnostics, localized value parsing — plus
`cli_l10n`, `host_pattern`, `output_mode`, and `theme`. Removing the five
module-wide `#[expect(dead_code, ...)]` attributes and building produced **110**
unused-item diagnostics, which is what those attributes were suppressing.

The suppressions also masked genuinely dead code. Appending an unused
`pub fn` to `src/cli/config.rs` on `main` produced **no diagnostic from any
compilation unit**: the library exports `cli::config` publicly so it is not
dead-code linted there, and the build script's module-wide expectation covered
it here.

## Change

`build.rs` now declares an inline `cli` facade naming exactly the three files
the Clap schema needs, rather than inheriting the subtree:

```rust
#[path = "src/cli"]
mod cli {
    #[path = "config.rs"] pub mod config;
    #[path = "validation.rs"] mod validation;
    #[path = "command.rs"] mod command;

    pub use command::Cli;
    pub use config::{AccessibilityPolicy, ColourPolicy, EmojiPolicy, ProgressPolicy};
}
```

The library is split along the same seam so that slice is self-contained:

| New module | Contents | Why it moved |
| --- | --- | --- |
| `src/cli/command.rs` | The Clap definitions (`Cli`, `InteractionArgs`, `BuildArgs`, `GraphArgs`, `Commands`) | Was the top half of `src/cli/parser.rs`; the schema is all the man page needs |
| `src/cli/preferences.rs` | The four `Cli` output-policy accessors | `theme_preference` was the only reason the build script compiled `theme` and, transitively, `output_mode` |
| `src/cli/validation.rs` | `MAX_JOBS`, `validation_error` | Lets `src/cli/config.rs` stop reaching up into `src/cli/mod.rs` |
| `src/host_matching.rs` | `HostCandidate`, `HostPattern::matches` | The only items in `src/host_pattern.rs` the schema does not need |

`src/cli/parser.rs` keeps the localization-aware parsing entry point;
`cli_l10n`, `output_mode`, and `theme` are no longer declared by the build
script at all.

## Result

- **All five** module-wide expectations removed. `cargo check --all-targets`
  emits no unused-item diagnostics.
- The probe that was silent on `main` now reports: an unused `pub fn` in
  `src/cli/config.rs` produces
  `warning: function ... is never used` from the build-script crate.
- The generated man page is byte-identical (verified by diffing the artefact
  before and after).
- No dependency added, no public API change, nothing under `locales/` or
  `src/localization/` touched. The `locale_catalogues`/`localization`
  declarations were already correct and are untouched.
- Rerun directives now track the modules actually compiled.
- No file exceeds the 400-line cap (largest touched: `src/cli/config.rs` at
  321, `src/host_pattern.rs` down from 344 to 304).

`docs/developers-guide.md` gains a section recording the slice as a maintained
boundary: widening it reintroduces unreachable items, and a dependency added
outside it surfaces as a build-script compile error.

## Gates

| Gate | Status |
| --- | --- |
| `cargo fmt -- --check` | pass |
| `make lint-clippy` (`cargo doc` + clippy) | pass |
| `make test` | pass — 1312 nextest, 47 doctests |
| `make markdownlint` | pass |
| `make nixie` | pass |

Two gates fail identically on unmodified `origin/main` in this environment and
are not caused by this change:

- `make check-fmt` runs `cargo fmt --all`, which fails resolving the
  `test_support` path dependency's workspace. `cargo fmt -- --check` on the
  root package passes.
- `make lint`'s Whitaker pass reports `no_std_fs_operations` against
  `build.rs` and `build_l10n_audit.rs` — 9 findings on `main`, 8 after this
  change, all in `std::fs` calls this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Narrow the build script’s recompiled module slice for man-page/localization generation while keeping the CLI surface and behaviour unchanged.

Enhancements:
- Split CLI schema, runtime preference accessors, and shared validation utilities into dedicated modules to form a self-contained slice usable by the build script.
- Factor host matching logic into a new module so host pattern syntax can be compiled independently for the build script.
- Adjust internal imports and re-exports across CLI and networking code to use the new command, preferences, validation, and host-matching modules.
- Tighten `cargo:rerun-if-changed` directives in the build script to track only the modules it actually recompiles.

Documentation:
- Document the build script’s maintained module slice boundary and its purpose in the developers’ guide.
- Update the design document to reflect the new locations of the CLI schema and parsing/preference layers.

Tests:
- Move host matching tests to the new host-matching module, keeping coverage of wildcard and exact pattern behaviour.