### PR TITLE
Update shared-actions pins to 2f90d10

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -93,7 +93,7 @@ jobs:
           cargo-orthohelp --version | grep '0\.8\.0'
 
       - name: Build release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/rust-build-release@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ env.BIN_NAME }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Stage artefacts
         id: stage
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           config-file: .github/release-staging.toml
           target: ${{ inputs['stage-target'] }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Package Linux artefacts with dependencies
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/linux-packages@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           project-dir: .
           package-name: ${{ inputs['bin-name'] }}
@@ -156,7 +156,7 @@ jobs:
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
-        uses: leynos/shared-actions/.github/actions/windows-package@4d696e72fff6db49f34302ccf119ba978f1032c9
+        uses: leynos/shared-actions/.github/actions/windows-package@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           product-name: ${{ inputs['bin-name'] }}
           manufacturer: Leynos
@@ -174,7 +174,7 @@ jobs:
       - name: Build macOS installer package
         if: inputs.platform == 'macos'
         id: package_macos
-        uses: leynos/shared-actions/.github/actions/macos-package@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/macos-package@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           name: ${{ inputs['bin-name'] }}
           identifier: com.leynos.${{ inputs['bin-name'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           # the pull request's merge base once the gate is wired in.
           fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
+        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
           components: rustfmt, clippy
@@ -90,7 +90,7 @@ jobs:
       - name: Test
         run: make test
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/generate-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           output-path: lcov.info
           format: lcov
@@ -101,7 +101,7 @@ jobs:
         if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           format: lcov
           mode: check
@@ -125,7 +125,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
+        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           toolchain: stable
       - name: Install uv

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -28,14 +28,14 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
+        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           # Match rust-toolchain.toml: the tree needs -Zpolonius=next (see
           # docs/adr-006-adopt-polonius-nightly-toolchain.md).
           toolchain: nightly-2026-06-25
           components: rustfmt, clippy
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/generate-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           output-path: lcov.info
           format: lcov
@@ -44,7 +44,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@4d696e72fff6db49f34302ccf119ba978f1032c9
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@4d696e72fff6db49f34302ccf119ba978f1032c9
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
     with:
       # test_support is deliberately omitted from extra crates: it is a
       # test-fixture crate whose survivors are noise.

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@4d696e72fff6db49f34302ccf119ba978f1032c9
+        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
       - name: Show rustc version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+          leynos/shared-actions/.github/actions/determine-release-modes@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+          leynos/shared-actions/.github/actions/ensure-cargo-version@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs['should-publish']) }}
       - id: wix_extension_version
@@ -107,7 +107,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+          leynos/shared-actions/.github/actions/export-cargo-metadata@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -239,7 +239,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@18bed1ca49a6de3d8882bd72635a32ae3f023d57
+          leynos/shared-actions/.github/actions/upload-release-assets@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}


### PR DESCRIPTION
## Summary

Advances every `leynos/shared-actions` reference in `.github/workflows/` from the two pins previously in tree (`4d696e7` and `18bed1c`) to the single SHA `2f90d1041ea108148be0620e3bbcc1fa80ac03e4`. That upstream commit is "Skip inapplicable CodeScene coverage checks and surface diagnostics (#395) (#399)", which stops the changed-line coverage gate from failing on pull requests whose base is not the analysed default branch — stacked pull requests, most notably.

## Files touched

| Workflow | References updated |
| --- | --- |
| `build-and-package.yml` | `rust-build-release`, `stage-release-artefacts`, `linux-packages`, `windows-package`, `macos-package` |
| `ci.yml` | `setup-rust` (×2), `generate-coverage`, `upload-codescene-coverage` |
| `coverage-main.yml` | `setup-rust`, `generate-coverage`, `upload-codescene-coverage` |
| `dependabot-automerge.yml` | `dependabot-automerge.yml` reusable workflow |
| `mutation-testing.yml` | `mutation-cargo.yml` reusable workflow |
| `netsukefile-test.yml` | `setup-rust` |
| `release.yml` | `determine-release-modes`, `ensure-cargo-version`, `export-cargo-metadata`, `upload-release-assets` |

## Compatibility

The intervening upstream changes to the consumed action definitions are additive, so no caller-side input changes are needed:

- `setup-rust` gains an optional `rustflags` input defaulting to `-D warnings`, matching the behaviour the previous pin hard-coded.
- `generate-coverage` gains an optional `language` input defaulting to `auto`, which preserves the existing manifest-based detection, and hardens its artefact-upload step against empty artefact names.
- `upload-codescene-coverage` short-circuits its `check` mode with a warning annotation, rather than a failure, when the pull request base is not the repository default branch. This is the behaviour change motivating the bump.

## Verification

- `make test-workflow-contracts` — 6 passed. This is the gate that asserts the mutation-testing caller matches the reusable workflow contract.
- The target SHA was confirmed to exist on `leynos/shared-actions` via the GitHub API.
- No other gates were run: the diff is confined to CI workflow pins and touches no Rust, Markdown, or Mermaid sources.

## References

- Lody session: https://lody.ai/leynos/sessions/e52c07e4-3d4b-403e-b22d-312a85bb5dfd
- Upstream commit: https://github.com/leynos/shared-actions/commit/2f90d1041ea108148be0620e3bbcc1fa80ac03e4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Bump all leynos/shared-actions references in CI workflows to SHA 2f90d1041ea108148be0620e3bbcc1fa80ac03e4, replacing older mixed pins for build, coverage, release, mutation testing, Dependabot automerge, and Netsukefile tests.