### PR TITLE
Bump shared-actions pins to 8add2d9 for the MSI pre-release fix

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -93,7 +93,7 @@ jobs:
           cargo-orthohelp --version | grep '0\.8\.0'
 
       - name: Build release binary
-        uses: leynos/shared-actions/.github/actions/rust-build-release@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/rust-build-release@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           target: ${{ inputs.target }}
           bin-name: ${{ env.BIN_NAME }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Stage artefacts
         id: stage
-        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/stage-release-artefacts@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           config-file: .github/release-staging.toml
           target: ${{ inputs['stage-target'] }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Package Linux artefacts with dependencies
         if: inputs.platform == 'linux'
-        uses: leynos/shared-actions/.github/actions/linux-packages@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/linux-packages@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           project-dir: .
           package-name: ${{ inputs['bin-name'] }}
@@ -156,7 +156,7 @@ jobs:
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
-        uses: leynos/shared-actions/.github/actions/windows-package@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/windows-package@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           product-name: ${{ inputs['bin-name'] }}
           manufacturer: Leynos
@@ -174,7 +174,7 @@ jobs:
       - name: Build macOS installer package
         if: inputs.platform == 'macos'
         id: package_macos
-        uses: leynos/shared-actions/.github/actions/macos-package@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/macos-package@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           name: ${{ inputs['bin-name'] }}
           identifier: com.leynos.${{ inputs['bin-name'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           command -v awk
           awk --version
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/setup-rust@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
           components: rustfmt, clippy
@@ -107,7 +107,7 @@ jobs:
       - name: Test
         run: make test
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/generate-coverage@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           output-path: lcov.info
           format: lcov
@@ -118,7 +118,7 @@ jobs:
         if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           format: lcov
           mode: check
@@ -142,7 +142,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/setup-rust@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           toolchain: stable
       - name: Install uv

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -28,14 +28,14 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/setup-rust@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           # Match rust-toolchain.toml: the tree needs -Zpolonius=next (see
           # docs/adr-006-adopt-polonius-nightly-toolchain.md).
           toolchain: nightly-2026-06-25
           components: rustfmt, clippy
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/generate-coverage@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           output-path: lcov.info
           format: lcov
@@ -44,7 +44,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@8add2d99854a5b77548eae98cca59202e68fefc8
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@8add2d99854a5b77548eae98cca59202e68fefc8
     with:
       # test_support is deliberately omitted from extra crates: it is a
       # test-fixture crate whose survivors are noise.

--- a/.github/workflows/netsukefile-test.yml
+++ b/.github/workflows/netsukefile-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+        uses: leynos/shared-actions/.github/actions/setup-rust@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           toolchain: ${{ env.NETSUKE_RUST_TOOLCHAIN }}
       - name: Show rustc version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
       - id: release_modes
         name: Determine release modes
         uses: >-
-          leynos/shared-actions/.github/actions/determine-release-modes@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+          leynos/shared-actions/.github/actions/determine-release-modes@8add2d99854a5b77548eae98cca59202e68fefc8
       - id: ensure_version
         name: Read package version from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/ensure-cargo-version@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+          leynos/shared-actions/.github/actions/ensure-cargo-version@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           check-tag: ${{ fromJSON(steps.release_modes.outputs['should-publish']) }}
       - id: wix_extension_version
@@ -107,7 +107,7 @@ jobs:
       - id: bin_name
         name: Extract binary name from Cargo.toml
         uses: >-
-          leynos/shared-actions/.github/actions/export-cargo-metadata@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+          leynos/shared-actions/.github/actions/export-cargo-metadata@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           manifest-path: ${{ steps.manifest_path.outputs.value }}
           fields: bin-name
@@ -239,7 +239,7 @@ jobs:
       - id: upload_assets
         name: Upload artefacts to release
         uses: >-
-          leynos/shared-actions/.github/actions/upload-release-assets@2f90d1041ea108148be0620e3bbcc1fa80ac03e4
+          leynos/shared-actions/.github/actions/upload-release-assets@8add2d99854a5b77548eae98cca59202e68fefc8
         with:
           release-tag: ${{ github.ref_name }}
           bin-name: ${{ needs.metadata.outputs.bin_name }}

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -65,6 +65,14 @@ licence. Ninja must be installed separately when using the macOS or Windows
 installer. The Windows MSI installs to `C:\Program Files\netsuke` and does not
 update `PATH`.
 
+The MSI installer supports pre-release SemVer versions such as
+`0.1.0-beta1`: the pre-release suffix cannot be represented in an MSI
+product version, so the installer carries the numeric release triple
+(`0.1.0`) while the full version remains in the package and release names.
+Because successive pre-releases share that numeric version, installing a
+later pre-release MSI replaces the existing installation for that version
+series rather than installing alongside it.
+
 SHA-256 checksum files accompany standalone binaries and staged help and
 licence files. Installer packages do not have checksum sidecars in
 v0.1.0-beta1. Windows PowerShell help files are published beside each MSI as


### PR DESCRIPTION
## Summary

This branch bumps every `leynos/shared-actions` pin (nineteen
references across seven workflows) from `2f90d10` to
[`8add2d9`](https://github.com/leynos/shared-actions/commit/8add2d99854a5b77548eae98cca59202e68fefc8),
the merge commit of
[shared-actions#406](https://github.com/leynos/shared-actions/pull/406).

That merge fixes the `windows-package` action's MSI version resolution:
pre-release semver such as `0.1.0-beta1` is now stripped to a numeric
`ProductVersion` (with strict SemVer suffix validation) instead of
failing the build, and the generated WiX authoring sets
`AllowSameVersionUpgrades="yes"` so successive pre-release MSIs replace
each other. The `v0.1.0-beta1` release run previously failed on exactly
this rejection
([failed job](https://github.com/leynos/netsuke/actions/runs/31053515019/job/92465950085)),
leaving the tag with no GitHub release assets; merging this unblocks
re-running the release workflow for that tag.

## Review walkthrough

- The diff is a uniform SHA substitution — review any one hunk, e.g.
  [.github/workflows/release.yml](https://github.com/leynos/netsuke/blob/2e2f5e2/.github/workflows/release.yml),
  and confirm the remaining files carry the same change. No workflow
  logic, inputs, or structure changed.
- The pinned-SHA shape is enforced by
  [tests/workflow_contracts/mutation_testing_test.py](https://github.com/leynos/netsuke/blob/2e2f5e2/tests/workflow_contracts/mutation_testing_test.py),
  which passed against the bump.

## Validation

- `make test-workflow-contracts`: 12 passed

## Notes

- Dependabot normally owns these SHA values; this manual bump
  fast-tracks the MSI fix so the beta release can ship.
- After this merges (with #532 and #534), re-running the release
  workflow for `v0.1.0-beta1` should publish the full asset set,
  including the new cargo-binstall archives from #534.

## Summary by Sourcery

Build:
- Update pinned leynos/shared-actions SHA across all workflows that consume shared composite actions and reusable workflows to the new 8add2d9 commit.