### PR TITLE
Strip the pre-release suffix from the MSI version

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -153,6 +153,18 @@ jobs:
         shell: bash
         run: rm -rf dist/.man dist/nfpm.yaml
 
+      - name: Derive the numeric MSI version
+        if: inputs.platform == 'windows'
+        id: msi_version
+        shell: bash
+        # MSI ProductVersion accepts only numeric major.minor.build, so the
+        # windows-package action rejects pre-release identifiers such as
+        # 0.1.0-beta1. The suffix is stripped for the installer alone; every
+        # other artefact keeps the full crate version.
+        run: |
+          version="${{ inputs.version }}"
+          echo "value=${version%%-*}" >> "$GITHUB_OUTPUT"
+
       - name: Build Windows installer package
         if: inputs.platform == 'windows'
         id: package_windows
@@ -164,7 +176,7 @@ jobs:
           application-path: ${{ steps.stage_paths.outputs.binary_path }}
           license-rtf-path: ${{ steps.stage_paths.outputs.license_path }}
           architecture: ${{ inputs['msi-arch'] }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.msi_version.outputs.value }}
           output-basename: ${{ inputs['bin-name'] }}
           output-directory: dist
           license-plaintext-path: LICENSE


### PR DESCRIPTION
Every pull request's `release / build-windows` check currently fails with `Invalid MSI version '0.1.0-beta1'`: MSI ProductVersion accepts only numeric `major.minor.build`, and the pinned `windows-package` shared action validates that before building. Main never runs the release dry-run on push, so only PRs surface it.

The Windows packaging step now derives a numeric version by stripping the pre-release identifier (`0.1.0-beta1` → `0.1.0`) for the installer alone; Linux, macOS, and archive artefacts keep the full crate version. Workflow contract tests (`workflow_build_and_package`, `polonius_toolchain_contract`, `workflow_release`) pass unchanged.

An estate-level alternative — teaching the shared action a pre-release mapping — can supersede this, but the local derivation unblocks all open PRs now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Adjust the build-and-package GitHub Actions workflow to compute a numeric MSI version from the crate version by dropping any pre-release suffix and pass that to the windows-package action for Windows installers.