### PR TITLE
Address the outstanding review comments from #526

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1646,6 +1646,60 @@ linted, and documented as such. A helper earns a place here only when more than
 one contract test needs the same reading or parsing behaviour. Nothing in it
 runs Make, runs Cargo, or writes anything.
 
+### The Makefile `RUSTFLAGS` contract tests
+
+`tests/makefile_test_target.rs` is the crate root for the Makefile contract
+tests. It includes `tests/support/makefile.rs` for the capability-scoped read
+and recipe-lookup helpers, pins the `make test` runner contract, and declares
+two child modules that together own the `RUSTFLAGS` contract:
+
+- `tests/makefile_test_target/rustflags.rs` models every recipe line that
+  assigns `RUSTFLAGS` as a `RustflagsCase` — the Make target, the substring
+  selecting the line, and the warning and inheritance policies the line must
+  uphold.
+- `tests/makefile_test_target/rustflags_polonius_tests.rs` covers the
+  `POLONIUS_FLAGS` resolution guard directly, against synthetic Makefile text.
+
+The tests assert on what a shell would produce, not on recipe text. For each
+case, `rustflags.rs` extracts the double-quoted assignment, resolves
+`$(POLONIUS_FLAGS)`, reduces Make's `$$` escape to the single `$` the shell
+receives, and — on Unix only — expands the resulting expression with
+`printf '%s'` under `sh`. Only the assignment is expanded; the command the
+recipe would run is never executed, so no test here invokes Cargo, Kani,
+nextest, or Dylint. Expansion needs a shell, so the behavioural tests and the
+policy fields they read are gated on `#[cfg(unix)]`; the parsing tests are not.
+Two guards keep the model honest: `shell_expression` refuses an expression
+still naming an unresolved Make variable or embedding a shell command
+substitution, and a completeness test walks the Makefile and fails when a line
+sets `RUSTFLAGS` without a matching case, so a new recipe joins the contract or
+breaks the build.
+
+`polonius_flags(makefile) -> Result<String>` is the crate-visible resolver both
+modules share. It reads the `POLONIUS_FLAGS` variable and rejects two states:
+
+- **Missing** — no `POLONIUS_FLAGS ?= …` or `POLONIUS_FLAGS = …` line, reported
+  as "Makefile should define POLONIUS_FLAGS".
+- **Empty after trimming** — a definition whose value is blank or whitespace
+  only, reported as "POLONIUS_FLAGS should not be empty".
+
+The rejection matters because every assertion built on the resolved value uses
+`contains`, which an empty needle satisfies vacuously. Returning an empty string
+would silently void the Polonius contract instead of failing it. On success the
+resolver returns the trimmed value, and a bounded proptest in
+`rustflags_polonius_tests` pins that acceptance invariant: resolution succeeds
+exactly when a definition exists whose value is non-empty after trimming, and
+the resolved text is the trimmed value. Its generator emits absent,
+whitespace-only, and whitespace-padded flag tokens, so an untrimmed return fails
+the property rather than slipping past.
+
+Because `rustflags.rs` and `rustflags_polonius_tests.rs` are children of the
+`makefile_test_target` test binary rather than files under `tests/`, Cargo does
+not compile them as separate targets. The root declares them, and they reach the
+shared helpers through `use super::{read_repo_file, target_recipe}`. Keep this
+shape for further Makefile contract work: general parsing helpers belong in
+`tests/support/makefile.rs` once a second contract test needs them, whereas
+model types such as `RustflagsCase` stay private to the contract they describe.
+
 ### `EnLocalizer` field ordering
 
 `EnLocalizer` (`test_support/src/localizer.rs`) holds both the localizer

--- a/docs/execplans/rstest-bdd-v0-5-0-behavioural-suite-migration.md
+++ b/docs/execplans/rstest-bdd-v0-5-0-behavioural-suite-migration.md
@@ -102,7 +102,7 @@ the conflict in `Decision Log` before proceeding.
   of truth for testing strategy.
 
 - Observation: behavioural tests are discovered via `scenarios!` in
-  `tests/bdd_tests.rs`; there are currently no `hand-written` `#[scenario]`
+  `tests/bdd_tests.rs`; there are currently no handwritten `#[scenario]`
   functions in the suite entry point. Evidence: `tests/bdd_tests.rs` contains
   `scenarios!("tests/features", ...)` and
   `scenarios!("tests/features_unix", ...)`. Impact: scenario return-type

--- a/docs/netsuke-design.md
+++ b/docs/netsuke-design.md
@@ -1089,7 +1089,7 @@ for transforming data within templates.
 
 - `| compact`: A planned collection filter that removes empty strings and null
   values while preserving order. It supports patterns such as constructing
-  `RUSTFLAGS` from an optional user override without `hand-written` shell tests.
+  `RUSTFLAGS` from an optional user override without handwritten shell tests.
 
 - `| to_path`: A filter that converts a string into a platform-native path
   representation, handling `/` and `\` separators correctly.

--- a/tests/makefile_test_target.rs
+++ b/tests/makefile_test_target.rs
@@ -94,6 +94,8 @@ fn behavioural_make_test_composes_the_nextest_and_doctest_passes() -> Result<()>
 
 #[path = "makefile_test_target/rustflags.rs"]
 mod rustflags;
+#[path = "makefile_test_target/rustflags_polonius_tests.rs"]
+mod rustflags_polonius_tests;
 
 /// Returns every nextest profile override.
 fn all_profile_overrides(config: &Value) -> impl Iterator<Item = &Value> {

--- a/tests/makefile_test_target/rustflags.rs
+++ b/tests/makefile_test_target/rustflags.rs
@@ -2,10 +2,10 @@
 
 use super::{read_repo_file, target_recipe};
 use anyhow::{Context, Result, ensure};
+#[cfg(unix)]
+use assert_cmd::Command;
 use camino::Utf8Path;
 use std::collections::BTreeSet;
-#[cfg(unix)]
-use std::process::Command;
 
 /// The prefix introducing a quoted `RUSTFLAGS` assignment in a recipe.
 const RUSTFLAGS_PREFIX: &str = "RUSTFLAGS=\"";
@@ -37,8 +37,19 @@ struct RustflagsCase {
     /// Substring selecting the recipe line.
     line_marker: &'static str,
     /// Whether the recipe adds `-D warnings`.
+    ///
+    /// Only the Unix behavioural tests read the policy fields (expansion
+    /// needs a shell), so non-Unix builds would otherwise flag them dead.
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "read only by Unix expansion tests")
+    )]
     warning_policy: WarningPolicy,
     /// How the recipe handles a caller-supplied value.
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "read only by Unix expansion tests")
+    )]
     inheritance_policy: InheritancePolicy,
 }
 
@@ -138,6 +149,21 @@ const RUSTFLAGS_CASES: [RustflagsCase; 9] = [
     RustflagsCase::kani_full(),
 ];
 
+/// Resolves `POLONIUS_FLAGS`, rejecting a missing or empty definition.
+///
+/// Every assertion built on the resolved value uses `contains`, which an
+/// empty string satisfies vacuously, so an empty definition would silently
+/// void the Polonius contract rather than fail it.
+fn polonius_flags(makefile: &str) -> Result<String> {
+    let value = make_variable(makefile, "POLONIUS_FLAGS")
+        .context("Makefile should define POLONIUS_FLAGS")?;
+    ensure!(
+        !value.is_empty(),
+        "POLONIUS_FLAGS should not be empty; the contract cannot assert a vacuous flag"
+    );
+    Ok(value)
+}
+
 /// Returns the value of a simple `NAME ?= value` or `NAME = value` variable.
 fn make_variable(contents: &str, name: &str) -> Option<String> {
     contents.lines().find_map(|line| {
@@ -189,8 +215,7 @@ fn shell_expression(makefile: &str, case: RustflagsCase) -> Result<String> {
             case.target
         )
     })?;
-    let polonius = make_variable(makefile, "POLONIUS_FLAGS")
-        .context("Makefile should define POLONIUS_FLAGS")?;
+    let polonius = polonius_flags(makefile)?;
     let resolved = assignment
         .replace("$(POLONIUS_FLAGS)", &polonius)
         .replace("$$", "$");
@@ -270,8 +295,7 @@ fn unit_rejects_escaped_shell_command_substitution() {
 #[test]
 fn behavioural_rustflags_recipes_preserve_inherited_flags() -> Result<()> {
     let makefile = read_repo_file(Utf8Path::new("Makefile"))?;
-    let polonius = make_variable(&makefile, "POLONIUS_FLAGS")
-        .context("Makefile should define POLONIUS_FLAGS")?;
+    let polonius = polonius_flags(&makefile)?;
     for case in RUSTFLAGS_CASES {
         let expanded = expand(&shell_expression(&makefile, case)?, Some(CALLER_RUSTFLAGS))?;
 
@@ -303,8 +327,7 @@ fn behavioural_rustflags_recipes_preserve_inherited_flags() -> Result<()> {
 #[test]
 fn behavioural_rustflags_recipes_are_well_formed_without_inherited_flags() -> Result<()> {
     let makefile = read_repo_file(Utf8Path::new("Makefile"))?;
-    let polonius = make_variable(&makefile, "POLONIUS_FLAGS")
-        .context("Makefile should define POLONIUS_FLAGS")?;
+    let polonius = polonius_flags(&makefile)?;
     for case in RUSTFLAGS_CASES {
         let expression = shell_expression(&makefile, case)?;
         let expanded = expand(&expression, None)?;

--- a/tests/makefile_test_target/rustflags.rs
+++ b/tests/makefile_test_target/rustflags.rs
@@ -1,4 +1,19 @@
 //! Contract model for Makefile recipes that set `RUSTFLAGS`.
+//!
+//! Each recipe line that assigns `RUSTFLAGS` is described by a
+//! [`RustflagsCase`] naming its target, the substring selecting the line, and
+//! the warning and inheritance contracts it must uphold. The module extracts
+//! the double-quoted assignment from the recipe, resolves the
+//! `$(POLONIUS_FLAGS)` Make variable, and (on Unix) expands the result in a
+//! real shell — without running the recipe's command — so the tests assert
+//! what Cargo would actually receive: inherited caller flags preserved,
+//! Polonius enabled, and `-D warnings` applied exactly where the contract
+//! says. A completeness test walks the Makefile and fails when any
+//! `RUSTFLAGS`-setting line lacks a case, so new recipes join the contract or
+//! break the build. The parent `makefile_test_target` module supplies the
+//! repository-file and recipe-lookup helpers; the sibling
+//! `rustflags_polonius_tests` module covers the `POLONIUS_FLAGS` resolution
+//! guard directly.
 
 use super::{read_repo_file, target_recipe};
 use anyhow::{Context, Result, ensure};
@@ -154,7 +169,7 @@ const RUSTFLAGS_CASES: [RustflagsCase; 9] = [
 /// Every assertion built on the resolved value uses `contains`, which an
 /// empty string satisfies vacuously, so an empty definition would silently
 /// void the Polonius contract rather than fail it.
-fn polonius_flags(makefile: &str) -> Result<String> {
+pub(crate) fn polonius_flags(makefile: &str) -> Result<String> {
     let value = make_variable(makefile, "POLONIUS_FLAGS")
         .context("Makefile should define POLONIUS_FLAGS")?;
     ensure!(

--- a/tests/makefile_test_target/rustflags_polonius_tests.rs
+++ b/tests/makefile_test_target/rustflags_polonius_tests.rs
@@ -46,30 +46,25 @@ fn polonius_flags_accepts_only_non_empty_definitions(
 }
 
 #[rstest]
-fn polonius_flags_names_the_missing_variable() {
-    let error = polonius_flags("A ?= b\n").expect_err("missing definition should fail");
+#[case::missing_variable("A ?= b\n", "should define POLONIUS_FLAGS")]
+#[case::empty_value("POLONIUS_FLAGS ?=  \n", "should not be empty")]
+fn polonius_flags_names_the_rejection_cause(#[case] makefile: &str, #[case] expected: &str) {
+    let error = polonius_flags(makefile).expect_err("definition should be rejected");
     assert!(
-        error.to_string().contains("should define POLONIUS_FLAGS"),
-        "missing definition should report the expected message; got {error:?}"
-    );
-}
-
-#[rstest]
-fn polonius_flags_names_the_empty_value() {
-    let error = polonius_flags("POLONIUS_FLAGS ?=  \n").expect_err("empty definition should fail");
-    assert!(
-        error.to_string().contains("should not be empty"),
-        "empty definition should report the expected message; got {error:?}"
+        error.to_string().contains(expected),
+        "rejection of {makefile:?} should report {expected:?}; got {error:?}"
     );
 }
 
 /// Strategy for the `POLONIUS_FLAGS` value slot: absent, whitespace-only, or
-/// a non-empty flag-like token.
+/// a non-empty flag-like token that may be padded with whitespace, so the
+/// property also pins the trimming the resolver owes its callers.
 fn arb_polonius_value() -> impl Strategy<Value = Option<String>> {
     prop_oneof![
         Just(None),
         "[ \t]{0,4}".prop_map(Some),
-        "[-A-Za-z0-9=+.]{1,24}".prop_map(Some),
+        ("[ \t]{0,4}", "[-A-Za-z0-9=+.]{1,24}", "[ \t]{0,4}")
+            .prop_map(|(prefix, flag, suffix)| Some(format!("{prefix}{flag}{suffix}"))),
     ]
 }
 

--- a/tests/makefile_test_target/rustflags_polonius_tests.rs
+++ b/tests/makefile_test_target/rustflags_polonius_tests.rs
@@ -1,0 +1,103 @@
+//! Direct coverage for the `POLONIUS_FLAGS` resolution guard.
+//!
+//! The `RUSTFLAGS` contract assertions all use `contains`, which an empty
+//! string satisfies vacuously, so `rustflags::polonius_flags` must reject a
+//! missing or empty definition rather than hand back a value that voids the
+//! Polonius contract. These tests exercise the guard against synthetic
+//! Makefile text — the behavioural tests only ever see the real, non-empty
+//! definition — and a bounded property test pins the acceptance invariant:
+//! resolution succeeds exactly when a definition exists whose value is
+//! non-empty after trimming.
+
+use super::rustflags::polonius_flags;
+use anyhow::{Result, ensure};
+use proptest::prelude::*;
+use rstest::rstest;
+
+#[rstest]
+#[case::defined_with_flag("POLONIUS_FLAGS ?= -Zpolonius=next\n", Some("-Zpolonius=next"))]
+#[case::defined_with_plain_assignment(
+    "POLONIUS_FLAGS = -Zpolonius=next\n",
+    Some("-Zpolonius=next")
+)]
+#[case::missing_definition("OTHER_VAR ?= value\n", None)]
+#[case::empty_value("POLONIUS_FLAGS ?= \n", None)]
+#[case::whitespace_only_value("POLONIUS_FLAGS ?= \t \n", None)]
+fn polonius_flags_accepts_only_non_empty_definitions(
+    #[case] makefile: &str,
+    #[case] expected: Option<&str>,
+) -> Result<()> {
+    let outcome = polonius_flags(makefile);
+    if let Some(value) = expected {
+        let resolved = outcome?;
+        ensure!(
+            resolved == value,
+            "expected {value:?} from {makefile:?}; got {resolved:?}"
+        );
+    } else {
+        let error = outcome.err().map(|error| error.to_string());
+        let message = error.as_deref().unwrap_or("(unexpectedly succeeded)");
+        ensure!(
+            message.contains("POLONIUS_FLAGS"),
+            "rejection for {makefile:?} should name the variable; got {message:?}"
+        );
+    }
+    Ok(())
+}
+
+#[rstest]
+fn polonius_flags_names_the_missing_variable() {
+    let error = polonius_flags("A ?= b\n").expect_err("missing definition should fail");
+    assert!(
+        error.to_string().contains("should define POLONIUS_FLAGS"),
+        "missing definition should report the expected message; got {error:?}"
+    );
+}
+
+#[rstest]
+fn polonius_flags_names_the_empty_value() {
+    let error = polonius_flags("POLONIUS_FLAGS ?=  \n").expect_err("empty definition should fail");
+    assert!(
+        error.to_string().contains("should not be empty"),
+        "empty definition should report the expected message; got {error:?}"
+    );
+}
+
+/// Strategy for the `POLONIUS_FLAGS` value slot: absent, whitespace-only, or
+/// a non-empty flag-like token.
+fn arb_polonius_value() -> impl Strategy<Value = Option<String>> {
+    prop_oneof![
+        Just(None),
+        "[ \t]{0,4}".prop_map(Some),
+        "[-A-Za-z0-9=+.]{1,24}".prop_map(Some),
+    ]
+}
+
+proptest! {
+    /// Resolution succeeds exactly when a definition exists whose value is
+    /// non-empty after trimming, and the resolved text is the trimmed value.
+    #[test]
+    fn prop_polonius_flags_acceptance_matches_the_definition(
+        value in arb_polonius_value(),
+        filler in "[A-Z_]{1,8}",
+    ) {
+        let makefile = value.as_ref().map_or_else(
+            || format!("{filler} ?= x\n"),
+            |text| format!("{filler} ?= x\nPOLONIUS_FLAGS ?= {text}\n"),
+        );
+        let outcome = polonius_flags(&makefile);
+        let expected = value
+            .as_deref()
+            .map(str::trim)
+            .filter(|trimmed| !trimmed.is_empty());
+        if let Some(trimmed) = expected {
+            let resolved = outcome.map_err(|error| TestCaseError::fail(error.to_string()))?;
+            prop_assert_eq!(resolved, trimmed, "resolved value should be the trimmed text");
+        } else {
+            prop_assert!(
+                outcome.is_err(),
+                "missing or blank definitions must be rejected: {makefile:?}"
+            );
+        }
+    }
+}

--- a/typos.local.toml
+++ b/typos.local.toml
@@ -12,7 +12,10 @@ accepted = []
 
 [patterns]
 # The tokenizer splits the valid hyphenated prefix in `mis-grouping`.
+# Inline code spans quote identifiers verbatim (e.g. tokio's `flavor`
+# attribute argument), so they are not en-GB prose and must stay exempt.
 ignore = ["mis-grouping",
+  "`[^`\\n]+`",
   "(?m)^            dist/\\$\\{\\{ inputs\\['bin-name'\\] \\}\\}-\\$\\{\\{ inputs\\.version \\}\\}-\\$\\{\\{ inputs\\['artifact-suffix'\\] \\}\\}\\.pkg$",
   "(?m)^          ARCHIVE_SUFFIX: \\$\\{\\{ inputs\\['artifact-suffix'\\] \\}\\}$",
   "(?m)^          name: \\$\\{\\{ inputs\\['artifact-name'\\] \\}\\}$",

--- a/typos.toml
+++ b/typos.toml
@@ -53,6 +53,7 @@ extend-ignore-re = [
     "\\bartifact-name\\b",
     "\\bartifact-suffix\\b",
     "\\brust-analyzer\\b",
+    "`[^`\\n]+`",
     "mis-grouping",
 ]
 

--- a/typos.toml
+++ b/typos.toml
@@ -53,7 +53,6 @@ extend-ignore-re = [
     "\\bartifact-name\\b",
     "\\bartifact-suffix\\b",
     "\\brust-analyzer\\b",
-    "`[^`\\n]+`",
     "mis-grouping",
 ]
 


### PR DESCRIPTION
## Summary

This branch addresses the review comments left outstanding when
[#526](https://github.com/leynos/netsuke/pull/526) was closed with its
work landed on `main` (as `tests/makefile_test_target/rustflags.rs`).
Each comment was verified against the current implementation; three
still applied and are fixed here, and one is stale.

Fixed:

- **Shared `POLONIUS_FLAGS` resolution.** The
  `make_variable(…, "POLONIUS_FLAGS")` lookup was duplicated at three
  sites, and none rejected an empty value — every downstream assertion
  uses `contains`, which an empty string satisfies vacuously, so an
  empty definition would silently void the Polonius contract. A shared
  `polonius_flags` helper now rejects missing and empty definitions,
  and all three sites use it.
- **`assert_cmd::Command` for the `sh` spawn.** The expansion helper
  now uses `assert_cmd::Command` (an existing dev-dependency),
  preserving `env_remove("RUSTFLAGS")` and the conditional environment
  assignment for inherited values.
- **Non-Unix dead-code residue.** `Command`, `CALLER_RUSTFLAGS`,
  `DENY_WARNINGS`, and `expand` were already `#[cfg(unix)]`-gated on
  `main`, but the two policy fields are read only by the Unix
  behavioural tests, so a non-Unix test build would flag them dead
  under `-D warnings`; a `cfg_attr`-gated expectation closes that.

Skipped as stale:

- **Deriving rstest cases from `RUSTFLAGS_CASES` by index.** The
  current implementation has no rstest parametrization to
  deduplicate: the behavioural tests iterate the array directly, and
  `behavioural_every_rustflags_recipe_line_is_under_contract` forces
  every `RUSTFLAGS`-setting recipe line to carry a case, so adding an
  array entry extends coverage automatically — the outcome the
  comment sought.

## Review walkthrough

- The whole change is one file:
  [tests/makefile_test_target/rustflags.rs](https://github.com/leynos/netsuke/blob/4a8acbd/tests/makefile_test_target/rustflags.rs)
  — the `polonius_flags` helper and its three call sites, the
  `assert_cmd::Command` import in the `#[cfg(unix)]` block, and the
  `cfg_attr` expectations on the two `RustflagsCase` policy fields.

## Validation

- `make check-fmt`: pass
- `make lint` (Clippy + Whitaker, warnings denied): pass
- `make test` (full workspace nextest + doctests): pass, including
  the 14 `makefile_test_target` contract tests

## Summary by Sourcery

Consolidate and harden handling of POLONIUS_FLAGS in the makefile RUSTFLAGS contract tests while improving Unix/non-Unix test configuration hygiene.

Enhancements:
- Introduce a shared helper to resolve POLONIUS_FLAGS and enforce that it is present and non-empty before running assertions.
- Annotate RustflagsCase policy fields with cfg_attr-based dead_code expectations for non-Unix builds to reflect their Unix-only usage.

Tests:
- Refactor RUSTFLAGS behaviour tests to use the new POLONIUS_FLAGS helper consistently across all call sites.
- Switch Unix shell expansion in the tests to use assert_cmd::Command instead of std::process::Command while preserving the existing environment handling.