### PR TITLE
Derive the shared-actions pin in the toolchain contract

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -295,8 +295,9 @@ independently edited pin would let the two disagree.
 enforces all four callers. For each one it asserts:
 
 - the job uses the expected shared-action reference — path *and* pinned
-  revision (see "Workflow pins and Dependabot" below for why the exact
-  revision is asserted here);
+  revision, the latter derived from the checked workflows themselves rather
+  than restated in the test (see "Workflow pins and Dependabot" below for why
+  the revision is asserted here);
 - the `with.rustflags` value matches the table above in full, not merely that
   it contains `-Zpolonius=next`, so a dropped `-D warnings` is caught too;
 - the job declares no `env.RUSTFLAGS`;
@@ -530,14 +531,22 @@ an unrecognized `with:` key on a composite action is a warning, not an error —
 it simply never exports the flag, so the build fails later as a borrow-check
 error rather than as a configuration error.
 
-`tests/polonius_toolchain_contract.rs` therefore asserts each of those
-workflows' exact shared-action path *and* pinned revision, held in the
-`SETUP_RUST_ACTION` and `RUST_BUILD_RELEASE_ACTION` constants. A Dependabot
-bump of these four references is expected to fail the test until someone
-updates the constants, and that failure is the point: it forces a human to
-confirm the new revision still implements the `rustflags` input contract before
-the bump lands. Restrict this exception to callers with a genuine
-revision-level dependency; everywhere else, the shape-only policy applies.
+`tests/polonius_toolchain_contract.rs` therefore requires the four workflows'
+shared-action references to agree, rather than restating the expected pin as a
+constant. It extracts every `leynos/shared-actions` reference from the checked
+workflows with the shared YAML-parsing helper in
+`tests/support/shared_actions.rs`, validates that each is a full
+40-character lowercase-hex commit SHA, and derives the pin the workflows must
+share from that set. A complete bump — Dependabot's or a manual one — moves
+every reference together and passes with no test edit. A partial bump, where
+some workflows move and others are left behind, fails on the disagreement
+between references: the same failure that previously broke `main` when a bump
+missed the hand-maintained constants this contract used to hold. The
+revision-level dependency on the `rustflags` input is now protected by that
+agreement requirement together with `shared-actions`' own contract tests
+upstream, rather than by a constant edited by hand here. Restrict this
+exception to callers with a genuine revision-level dependency; everywhere
+else, the shape-only policy applies.
 
 If a workflow's behaviour does not depend on a feature from a particular commit
 onwards, do not assert its SHA — express any advisory note as a comment or a
@@ -1815,6 +1824,29 @@ compile time. This refusal is itself a tested contract:
 regressing to a doc-comment promise. `tests/locale_stub_strictness_tests.rs`
 covers the panic, the trichotomy, and the last-declaration-wins rule with
 both example-based and property tests.
+
+#### Locale-stub UI harness and split build directories
+
+`tests/locale_stub_ui_tests.rs` builds `test_support` with `cargo build
+--message-format=json` and parses the resulting Cargo JSON messages rather
+than assuming its dependencies sit beside the uplifted `test_support` rlib.
+For every `compiler-artifact` message it records the parent directory of each
+rlib the message names, and passes the whole set to `rustc` as `-L
+dependency=` directories when compiling the UI fixtures. This keeps the
+harness correct when Cargo's `build.build-dir` setting splits intermediate
+artefacts — where dependency rlibs live — from the final, uplifted ones;
+deriving the directories from what Cargo actually reports, rather than from a
+single assumed location, means the harness does not need to special-case that
+split.
+
+`harness_compiles_under_a_split_build_dir` is the regression test for this:
+it forces a split layout with its own private `CARGO_TARGET_DIR` and
+`CARGO_BUILD_BUILD_DIR` roots, confirms the collected dependency directories
+span the split, and then compiles a fixture against them. The roots are
+private to the test rather than the ambient target directory because the
+`#[once]` `test_support_rlib` fixture builds concurrently in the other test;
+sharing a target directory between the two races on the uplifted rlibs and
+fails with version-skew errors (`E0460`).
 
 ### Manifest `env()` reader
 

--- a/tests/locale_stub_ui_tests.rs
+++ b/tests/locale_stub_ui_tests.rs
@@ -89,12 +89,24 @@ impl TestSupportRlib {
     /// with the same Polonius flags as the rest of the suite — the property
     /// trybuild could not preserve.
     fn build() -> io::Result<Self> {
-        let output = Command::new(cargo())
+        Self::build_with(&[])
+    }
+
+    /// Build `test_support` with additional environment variables applied.
+    ///
+    /// The split-layout regression test uses this to force Cargo's
+    /// `build.build-dir` into a separate directory.
+    fn build_with(env: &[(&str, &Path)]) -> io::Result<Self> {
+        let mut command = Command::new(cargo());
+        command
             .arg("build")
             .arg("--manifest-path")
             .arg(manifest_dir().join("test_support/Cargo.toml"))
-            .arg("--message-format=json")
-            .output()?;
+            .arg("--message-format=json");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let output = command.output()?;
         if !output.status.success() {
             return Err(io::Error::other(format!(
                 "building test_support failed:\n{}",
@@ -152,18 +164,18 @@ impl TestSupportRlib {
     }
 }
 
-/// Extract the parent directories of every rlib in one Cargo JSON message.
-fn rlib_parents_in_message(line: &str) -> Vec<PathBuf> {
-    let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
-        return Vec::new();
-    };
-    if message
-        .get("reason")
-        .is_none_or(|reason| reason != "compiler-artifact")
-    {
-        return Vec::new();
+/// Extract a compiler-artifact message's target name and rlib paths.
+///
+/// Returns `None` for lines that are not valid JSON, not compiler-artifact
+/// messages, or that lack a target name; the rlib list may be empty for
+/// artefacts that emit no rlib.
+fn compiler_artifact_rlibs(line: &str) -> Option<(String, Vec<PathBuf>)> {
+    let message: serde_json::Value = serde_json::from_str(line).ok()?;
+    if message.get("reason")? != "compiler-artifact" {
+        return None;
     }
-    message
+    let name = message.get("target")?.get("name")?.as_str()?.to_owned();
+    let rlibs = message
         .get("filenames")
         .and_then(serde_json::Value::as_array)
         .into_iter()
@@ -174,30 +186,29 @@ fn rlib_parents_in_message(line: &str) -> Vec<PathBuf> {
                 .extension()
                 .is_some_and(|extension| extension.eq_ignore_ascii_case("rlib"))
         })
-        .filter_map(|filename| Path::new(filename).parent().map(Path::to_path_buf))
-        .collect()
+        .map(PathBuf::from)
+        .collect();
+    Some((name, rlibs))
+}
+
+/// Extract the parent directories of every rlib in one Cargo JSON message.
+fn rlib_parents_in_message(line: &str) -> Vec<PathBuf> {
+    compiler_artifact_rlibs(line)
+        .map(|(_name, rlibs)| {
+            rlibs
+                .iter()
+                .filter_map(|rlib| rlib.parent().map(Path::to_path_buf))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Extract the `test_support` rlib path from one Cargo JSON message, if any.
 fn test_support_rlib_in_message(line: &str) -> Option<PathBuf> {
-    let message: serde_json::Value = serde_json::from_str(line).ok()?;
-    if message.get("reason")? != "compiler-artifact"
-        || message.get("target")?.get("name")? != "test_support"
-    {
-        return None;
-    }
-    message
-        .get("filenames")?
-        .as_array()?
-        .iter()
-        .filter_map(|filename| filename.as_str())
-        .filter(|filename| {
-            Path::new(filename)
-                .extension()
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("rlib"))
-        })
-        .map(PathBuf::from)
-        .next_back()
+    let (name, rlibs) = compiler_artifact_rlibs(line)?;
+    (name == "test_support")
+        .then(|| rlibs.into_iter().next_back())
+        .flatten()
 }
 
 fn manifest_dir() -> PathBuf {
@@ -222,4 +233,90 @@ fn rustc() -> PathBuf {
 
 fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// A synthetic Cargo message with two rlibs in different directories,
+/// mirroring a split `build.build-dir` layout.
+const SPLIT_LAYOUT_MESSAGE: &str = r#"{"reason":"compiler-artifact","target":{"name":"anyhow"},"filenames":["/build/debug/deps/libanyhow-1.rlib","/target/debug/libanyhow-1.rlib"]}"#;
+
+#[rstest]
+fn parser_collects_every_rlib_directory_from_a_message() {
+    let parents = rlib_parents_in_message(SPLIT_LAYOUT_MESSAGE);
+    assert_eq!(
+        parents,
+        vec![
+            PathBuf::from("/build/debug/deps"),
+            PathBuf::from("/target/debug"),
+        ],
+        "both rlib directories should be collected in message order"
+    );
+}
+
+#[rstest]
+#[case::malformed_json("not json at all")]
+#[case::other_reason(r#"{"reason":"build-script-executed","target":{"name":"anyhow"}}"#)]
+#[case::missing_target(r#"{"reason":"compiler-artifact","filenames":["/a/lib.rlib"]}"#)]
+fn parser_ignores_non_artifact_messages(#[case] line: &str) {
+    assert!(
+        rlib_parents_in_message(line).is_empty(),
+        "non-artifact input should yield no directories: {line:?}"
+    );
+    assert!(
+        test_support_rlib_in_message(line).is_none(),
+        "non-artifact input should yield no test_support rlib: {line:?}"
+    );
+}
+
+#[rstest]
+fn parser_selects_the_test_support_rlib_by_target_name() {
+    let message = r#"{"reason":"compiler-artifact","target":{"name":"test_support"},"filenames":["/deps/libtest_support-1.rlib","/final/libtest_support.rlib"]}"#;
+    assert_eq!(
+        test_support_rlib_in_message(message),
+        Some(PathBuf::from("/final/libtest_support.rlib")),
+        "the last-listed rlib should win, matching Cargo's uplift ordering"
+    );
+    assert!(
+        test_support_rlib_in_message(SPLIT_LAYOUT_MESSAGE).is_none(),
+        "other targets' artefacts should not be mistaken for test_support"
+    );
+}
+
+/// Forcing a split `build.build-dir` must still yield a working harness:
+/// the dependency rlibs land apart from the uplifted `test_support` rlib, so
+/// the collected `-L dependency=` set has to span the split for the control
+/// fixture to compile. This pins the regression where a single derived
+/// directory missed the dependencies entirely.
+#[rstest]
+fn harness_compiles_under_a_split_build_dir() -> io::Result<()> {
+    // Both roots are private to this test: sharing the ambient target dir
+    // with the concurrently building `#[once]` fixture races on the
+    // uplifted rlibs and fails with version-skew errors (E0460).
+    let target_dir = tempfile::tempdir()?;
+    let build_dir = tempfile::tempdir()?;
+    let harness = TestSupportRlib::build_with(&[
+        ("CARGO_TARGET_DIR", target_dir.path()),
+        ("CARGO_BUILD_BUILD_DIR", build_dir.path()),
+    ])?;
+
+    let spans_split_dir = harness
+        .deps_dirs
+        .iter()
+        .any(|dir| dir.starts_with(build_dir.path()));
+    if !spans_split_dir {
+        return Err(io::Error::other(format!(
+            "the dependency directories should include the split build dir {}; found {:?}",
+            build_dir.path().display(),
+            harness.deps_dirs,
+        )));
+    }
+
+    let output = harness.compile("tests/ui/stub_env_strict_compile_pass.rs")?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "the control fixture should compile under a split build dir:
+{}",
+            stderr(&output),
+        )));
+    }
+    Ok(())
 }

--- a/tests/locale_stub_ui_tests.rs
+++ b/tests/locale_stub_ui_tests.rs
@@ -76,10 +76,10 @@ fn stub_env_builders_compile_under_the_same_harness(
     Ok(())
 }
 
-/// The `test_support` rlib and the deps directory holding its dependencies.
+/// The `test_support` rlib and the directories holding its dependencies.
 struct TestSupportRlib {
     rlib: PathBuf,
-    deps_dir: PathBuf,
+    deps_dirs: Vec<PathBuf>,
 }
 
 impl TestSupportRlib {
@@ -108,18 +108,23 @@ impl TestSupportRlib {
             .filter_map(test_support_rlib_in_message)
             .next_back()
             .ok_or_else(|| io::Error::other("cargo reported no test_support rlib artefact"))?;
-        // Cargo uplifts the top-level package's rlib out of `deps/` into the
-        // profile directory, so the rlib's own parent is not where the
-        // dependency rlibs live.
-        let parent = rlib
-            .parent()
-            .ok_or_else(|| io::Error::other("the rlib path should have a parent"))?;
-        let deps_dir = if parent.file_name() == Some(std::ffi::OsStr::new("deps")) {
-            parent.to_path_buf()
-        } else {
-            parent.join("deps")
-        };
-        Ok(Self { rlib, deps_dir })
+        // Dependency rlibs do not necessarily sit beside the uplifted
+        // `test_support` rlib: Cargo's `build.build-dir` setting splits
+        // intermediate artefacts (where dependencies live) from final ones.
+        // Every compiler-artifact message names its rlib's real location, so
+        // collect each artefact's parent directory for `-L dependency=`.
+        let mut deps_dirs: Vec<PathBuf> = Vec::new();
+        for parent in stdout.lines().flat_map(rlib_parents_in_message) {
+            if !deps_dirs.contains(&parent) {
+                deps_dirs.push(parent);
+            }
+        }
+        if deps_dirs.is_empty() {
+            return Err(io::Error::other(
+                "cargo reported no rlib artefacts to derive dependency dirs from",
+            ));
+        }
+        Ok(Self { rlib, deps_dirs })
     }
 
     /// Type-check `source` against the rlib without linking a binary.
@@ -135,12 +140,42 @@ impl TestSupportRlib {
             .arg(manifest_dir().join(source))
             .arg("--extern")
             .arg(format!("test_support={}", self.rlib.display()))
-            .arg("-L")
-            .arg(format!("dependency={}", self.deps_dir.display()))
+            .args(self.deps_dirs.iter().flat_map(|dir| {
+                [
+                    std::ffi::OsString::from("-L"),
+                    format!("dependency={}", dir.display()).into(),
+                ]
+            }))
             .arg("-o")
             .arg(output_dir.path().join("stub-env-ui.rmeta"))
             .output()
     }
+}
+
+/// Extract the parent directories of every rlib in one Cargo JSON message.
+fn rlib_parents_in_message(line: &str) -> Vec<PathBuf> {
+    let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
+        return Vec::new();
+    };
+    if message
+        .get("reason")
+        .is_none_or(|reason| reason != "compiler-artifact")
+    {
+        return Vec::new();
+    }
+    message
+        .get("filenames")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .filter(|filename| {
+            Path::new(filename)
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("rlib"))
+        })
+        .filter_map(|filename| Path::new(filename).parent().map(Path::to_path_buf))
+        .collect()
 }
 
 /// Extract the `test_support` rlib path from one Cargo JSON message, if any.

--- a/tests/locale_stub_ui_tests.rs
+++ b/tests/locale_stub_ui_tests.rs
@@ -14,6 +14,7 @@
 //! flags — and the fixtures are compiled directly with the workspace `rustc`
 //! against that rlib.
 
+use camino::{Utf8Path, Utf8PathBuf};
 use rstest::{fixture, rstest};
 use std::{
     io,
@@ -78,8 +79,8 @@ fn stub_env_builders_compile_under_the_same_harness(
 
 /// The `test_support` rlib and the directories holding its dependencies.
 struct TestSupportRlib {
-    rlib: PathBuf,
-    deps_dirs: Vec<PathBuf>,
+    rlib: Utf8PathBuf,
+    deps_dirs: Vec<Utf8PathBuf>,
 }
 
 impl TestSupportRlib {
@@ -125,7 +126,7 @@ impl TestSupportRlib {
         // intermediate artefacts (where dependencies live) from final ones.
         // Every compiler-artifact message names its rlib's real location, so
         // collect each artefact's parent directory for `-L dependency=`.
-        let mut deps_dirs: Vec<PathBuf> = Vec::new();
+        let mut deps_dirs: Vec<Utf8PathBuf> = Vec::new();
         for parent in stdout.lines().flat_map(rlib_parents_in_message) {
             if !deps_dirs.contains(&parent) {
                 deps_dirs.push(parent);
@@ -151,13 +152,12 @@ impl TestSupportRlib {
             .arg("--emit=metadata")
             .arg(manifest_dir().join(source))
             .arg("--extern")
-            .arg(format!("test_support={}", self.rlib.display()))
-            .args(self.deps_dirs.iter().flat_map(|dir| {
-                [
-                    std::ffi::OsString::from("-L"),
-                    format!("dependency={}", dir.display()).into(),
-                ]
-            }))
+            .arg(format!("test_support={}", self.rlib))
+            .args(
+                self.deps_dirs
+                    .iter()
+                    .flat_map(|dir| [String::from("-L"), format!("dependency={dir}")]),
+            )
             .arg("-o")
             .arg(output_dir.path().join("stub-env-ui.rmeta"))
             .output()
@@ -169,7 +169,7 @@ impl TestSupportRlib {
 /// Returns `None` for lines that are not valid JSON, not compiler-artifact
 /// messages, or that lack a target name; the rlib list may be empty for
 /// artefacts that emit no rlib.
-fn compiler_artifact_rlibs(line: &str) -> Option<(String, Vec<PathBuf>)> {
+fn compiler_artifact_rlibs(line: &str) -> Option<(String, Vec<Utf8PathBuf>)> {
     let message: serde_json::Value = serde_json::from_str(line).ok()?;
     if message.get("reason")? != "compiler-artifact" {
         return None;
@@ -182,37 +182,37 @@ fn compiler_artifact_rlibs(line: &str) -> Option<(String, Vec<PathBuf>)> {
         .flatten()
         .filter_map(serde_json::Value::as_str)
         .filter(|filename| {
-            Path::new(filename)
+            Utf8Path::new(filename)
                 .extension()
                 .is_some_and(|extension| extension.eq_ignore_ascii_case("rlib"))
         })
-        .map(PathBuf::from)
+        .map(Utf8PathBuf::from)
         .collect();
     Some((name, rlibs))
 }
 
 /// Extract the parent directories of every rlib in one Cargo JSON message.
-fn rlib_parents_in_message(line: &str) -> Vec<PathBuf> {
+fn rlib_parents_in_message(line: &str) -> Vec<Utf8PathBuf> {
     compiler_artifact_rlibs(line)
         .map(|(_name, rlibs)| {
             rlibs
                 .iter()
-                .filter_map(|rlib| rlib.parent().map(Path::to_path_buf))
+                .filter_map(|rlib| rlib.parent().map(Utf8Path::to_path_buf))
                 .collect()
         })
         .unwrap_or_default()
 }
 
 /// Extract the `test_support` rlib path from one Cargo JSON message, if any.
-fn test_support_rlib_in_message(line: &str) -> Option<PathBuf> {
+fn test_support_rlib_in_message(line: &str) -> Option<Utf8PathBuf> {
     let (name, rlibs) = compiler_artifact_rlibs(line)?;
     (name == "test_support")
         .then(|| rlibs.into_iter().next_back())
         .flatten()
 }
 
-fn manifest_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+fn manifest_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
 #[expect(
@@ -245,8 +245,8 @@ fn parser_collects_every_rlib_directory_from_a_message() {
     assert_eq!(
         parents,
         vec![
-            PathBuf::from("/build/debug/deps"),
-            PathBuf::from("/target/debug"),
+            Utf8PathBuf::from("/build/debug/deps"),
+            Utf8PathBuf::from("/target/debug"),
         ],
         "both rlib directories should be collected in message order"
     );
@@ -272,7 +272,7 @@ fn parser_selects_the_test_support_rlib_by_target_name() {
     let message = r#"{"reason":"compiler-artifact","target":{"name":"test_support"},"filenames":["/deps/libtest_support-1.rlib","/final/libtest_support.rlib"]}"#;
     assert_eq!(
         test_support_rlib_in_message(message),
-        Some(PathBuf::from("/final/libtest_support.rlib")),
+        Some(Utf8PathBuf::from("/final/libtest_support.rlib")),
         "the last-listed rlib should win, matching Cargo's uplift ordering"
     );
     assert!(

--- a/tests/polonius_toolchain_contract.rs
+++ b/tests/polonius_toolchain_contract.rs
@@ -22,15 +22,10 @@ use toml::Value as TomlValue;
 
 const POLONIUS_FLAG: &str = "-Zpolonius=next";
 const POLONIUS_VAR: &str = "$(POLONIUS_FLAGS)";
-const SETUP_RUST_ACTION: &str = concat!(
-    "leynos/shared-actions/.github/actions/setup-rust@",
-    "2f90d1041ea108148be0620e3bbcc1fa80ac03e4"
-);
-const RUST_BUILD_RELEASE_ACTION: &str = concat!(
-    "leynos/shared-actions/.github/actions/rust-build-release@",
-    "2f90d1041ea108148be0620e3bbcc1fa80ac03e4"
-);
+const SETUP_RUST_ACTION: &str = "leynos/shared-actions/.github/actions/setup-rust";
+const RUST_BUILD_RELEASE_ACTION: &str = "leynos/shared-actions/.github/actions/rust-build-release";
 const WARNINGS_POLONIUS_RUSTFLAGS: &str = "-D warnings -Zpolonius=next";
+const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/";
 
 /// Describes one workflow's shared-action and toolchain contract.
 struct WorkflowExpectation {
@@ -69,6 +64,64 @@ const PACKAGING_WORKFLOW: WorkflowExpectation = WorkflowExpectation {
     rustflags: POLONIUS_FLAG,
     pins_toolchain_env: false,
 };
+
+/// Every workflow under the shared-action toolchain contract.
+const WORKFLOW_EXPECTATIONS: [WorkflowExpectation; 4] = [
+    CI_WORKFLOW,
+    NETSUKEFILE_WORKFLOW,
+    COVERAGE_WORKFLOW,
+    PACKAGING_WORKFLOW,
+];
+
+/// Extracts every shared-actions commit pin from workflow `contents`.
+fn shared_action_pins(contents: &str) -> Vec<String> {
+    contents
+        .split(SHARED_ACTIONS_MARKER)
+        .skip(1)
+        .filter_map(|piece| piece.split_once('@'))
+        .map(|(_action, rest)| {
+            rest.chars()
+                .take_while(char::is_ascii_hexdigit)
+                .collect::<String>()
+        })
+        .collect()
+}
+
+/// Returns the single shared-actions commit SHA the checked workflows pin.
+///
+/// The SHA's value is owned by the workflow files (and the pin-bump process
+/// that updates them); this contract derives it rather than restating it, so
+/// a complete bump stays green while a partial bump — some workflows moved,
+/// others left behind — fails on the disagreement.
+fn shared_actions_sha() -> Result<String> {
+    let mut shas = std::collections::BTreeSet::new();
+    for expectation in WORKFLOW_EXPECTATIONS {
+        let contents = read_repo_file(Utf8Path::new(expectation.path))?;
+        let pins = shared_action_pins(&contents);
+        ensure!(
+            !pins.is_empty(),
+            "{} should pin at least one shared action",
+            expectation.path
+        );
+        shas.extend(pins);
+    }
+    ensure!(
+        shas.len() == 1,
+        "the checked workflows disagree on the shared-actions pin: {shas:?}"
+    );
+    let sha = shas
+        .into_iter()
+        .next()
+        .context("one shared-actions pin should remain")?;
+    ensure!(
+        sha.len() == 40
+            && sha
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the shared-actions pin should be a 40-character lowercase commit SHA, found {sha:?}"
+    );
+    Ok(sha)
+}
 
 /// Returns the dated nightly channel pinned in `rust-toolchain.toml`.
 ///
@@ -147,10 +200,11 @@ fn workflows_pass_polonius_rustflags_to_shared_actions(
     let WorkflowExpectation {
         path,
         job,
-        action: expected_action,
+        action,
         rustflags: expected_rustflags,
         pins_toolchain_env,
     } = expectation;
+    let expected_action = &format!("{action}@{}", shared_actions_sha()?);
     let workflow: YamlValue = serde_yaml::from_str(&read_repo_file(Utf8Path::new(path))?)
         .with_context(|| format!("parse {path}"))?;
     ensure!(
@@ -165,7 +219,7 @@ fn workflows_pass_polonius_rustflags_to_shared_actions(
         .with_context(|| format!("{path} job {job} should declare steps"))?;
     let shared_action = steps
         .iter()
-        .find(|step| yaml_str(step, &["uses"]) == Some(expected_action))
+        .find(|step| yaml_str(step, &["uses"]) == Some(expected_action.as_str()))
         .with_context(|| format!("{path} job {job} should use {expected_action}"))?;
     let rustflags = yaml_str(shared_action, &["with", "rustflags"])
         .with_context(|| format!("{path} {expected_action} should pass rustflags"))?;

--- a/tests/polonius_toolchain_contract.rs
+++ b/tests/polonius_toolchain_contract.rs
@@ -85,7 +85,10 @@ fn shared_actions_sha() -> Result<String> {
     let mut refs = Vec::new();
     for expectation in WORKFLOW_EXPECTATIONS {
         let contents = read_repo_file(Utf8Path::new(expectation.path))?;
-        let extracted = shared_actions::extract_shared_actions_uses(&contents);
+        let extracted =
+            shared_actions::extract_shared_actions_uses(&contents).with_context(|| {
+                format!("extract shared-action references from {}", expectation.path)
+            })?;
         ensure!(
             !extracted.is_empty(),
             "{} should pin at least one shared action",

--- a/tests/polonius_toolchain_contract.rs
+++ b/tests/polonius_toolchain_contract.rs
@@ -12,6 +12,8 @@
 
 #[path = "support/makefile.rs"]
 mod makefile;
+#[path = "support/shared_actions.rs"]
+pub mod shared_actions;
 
 use anyhow::{Context, Result, ensure};
 use camino::Utf8Path;
@@ -25,7 +27,6 @@ const POLONIUS_VAR: &str = "$(POLONIUS_FLAGS)";
 const SETUP_RUST_ACTION: &str = "leynos/shared-actions/.github/actions/setup-rust";
 const RUST_BUILD_RELEASE_ACTION: &str = "leynos/shared-actions/.github/actions/rust-build-release";
 const WARNINGS_POLONIUS_RUSTFLAGS: &str = "-D warnings -Zpolonius=next";
-const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/";
 
 /// Describes one workflow's shared-action and toolchain contract.
 struct WorkflowExpectation {
@@ -73,54 +74,26 @@ const WORKFLOW_EXPECTATIONS: [WorkflowExpectation; 4] = [
     PACKAGING_WORKFLOW,
 ];
 
-/// Extracts every shared-actions commit pin from workflow `contents`.
-fn shared_action_pins(contents: &str) -> Vec<String> {
-    contents
-        .split(SHARED_ACTIONS_MARKER)
-        .skip(1)
-        .filter_map(|piece| piece.split_once('@'))
-        .map(|(_action, rest)| {
-            rest.chars()
-                .take_while(char::is_ascii_hexdigit)
-                .collect::<String>()
-        })
-        .collect()
-}
-
 /// Returns the single shared-actions commit SHA the checked workflows pin.
 ///
 /// The SHA's value is owned by the workflow files (and the pin-bump process
 /// that updates them); this contract derives it rather than restating it, so
 /// a complete bump stays green while a partial bump — some workflows moved,
-/// others left behind — fails on the disagreement.
+/// others left behind — fails on the disagreement. The broader shape-only
+/// sweep across every workflow lives in `workflow_shared_actions_pins`.
 fn shared_actions_sha() -> Result<String> {
-    let mut shas = std::collections::BTreeSet::new();
+    let mut refs = Vec::new();
     for expectation in WORKFLOW_EXPECTATIONS {
         let contents = read_repo_file(Utf8Path::new(expectation.path))?;
-        let pins = shared_action_pins(&contents);
+        let extracted = shared_actions::extract_shared_actions_uses(&contents);
         ensure!(
-            !pins.is_empty(),
+            !extracted.is_empty(),
             "{} should pin at least one shared action",
             expectation.path
         );
-        shas.extend(pins);
+        refs.extend(extracted);
     }
-    ensure!(
-        shas.len() == 1,
-        "the checked workflows disagree on the shared-actions pin: {shas:?}"
-    );
-    let sha = shas
-        .into_iter()
-        .next()
-        .context("one shared-actions pin should remain")?;
-    ensure!(
-        sha.len() == 40
-            && sha
-                .chars()
-                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
-        "the shared-actions pin should be a 40-character lowercase commit SHA, found {sha:?}"
-    );
-    Ok(sha)
+    shared_actions::consistent_pin(&refs)
 }
 
 /// Returns the dated nightly channel pinned in `rust-toolchain.toml`.

--- a/tests/support/shared_actions.rs
+++ b/tests/support/shared_actions.rs
@@ -9,26 +9,58 @@
 //! complete bump needs no test edit.
 
 use anyhow::{Context, Result, ensure};
+use serde_yaml::Value as YamlValue;
 use std::collections::BTreeSet;
 
 /// Path prefix common to every shared-actions action reference.
 pub const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/.github/actions/";
 
-/// Extracts every shared-actions `uses:` token from workflow `contents`.
+/// Extracts every shared-actions `uses:` reference from workflow YAML.
 ///
-/// Each returned token is the full reference, for example
-/// `leynos/shared-actions/.github/actions/setup-rust@<sha>`.
-#[must_use]
-pub fn extract_shared_actions_uses(contents: &str) -> Vec<String> {
-    contents
-        .lines()
-        .filter_map(|line| {
-            let start = line.find(SHARED_ACTIONS_MARKER)?;
-            let rest = line.get(start..)?;
-            let token = rest.split_whitespace().next()?;
-            (!token.is_empty()).then(|| token.to_owned())
-        })
-        .collect()
+/// The workflow is parsed as YAML and only scalar `uses:` values are
+/// considered, so quoted references normalize to their unquoted form and
+/// commented-out lines or lookalike tokens inside comments and other strings
+/// never leak into the result. Each returned reference is the full value,
+/// for example `leynos/shared-actions/.github/actions/setup-rust@<sha>`.
+///
+/// # Errors
+///
+/// Fails when `contents` is not valid YAML.
+pub fn extract_shared_actions_uses(contents: &str) -> Result<Vec<String>> {
+    let document: YamlValue = serde_yaml::from_str(contents).context("parse workflow YAML")?;
+    let mut uses = Vec::new();
+    collect_uses(&document, &mut uses);
+    Ok(uses)
+}
+
+/// Returns the shared-actions reference held by a `uses:` mapping entry.
+fn shared_action_use<'a>(key: &YamlValue, entry: &'a YamlValue) -> Option<&'a str> {
+    if key.as_str() != Some("uses") {
+        return None;
+    }
+    entry
+        .as_str()
+        .filter(|reference| reference.starts_with(SHARED_ACTIONS_MARKER))
+}
+
+/// Walks `value` collecting shared-actions references from `uses:` scalars.
+fn collect_uses(value: &YamlValue, out: &mut Vec<String>) {
+    match value {
+        YamlValue::Mapping(mapping) => {
+            for (key, entry) in mapping {
+                if let Some(reference) = shared_action_use(key, entry) {
+                    out.push(reference.to_owned());
+                }
+                collect_uses(entry, out);
+            }
+        }
+        YamlValue::Sequence(sequence) => {
+            for entry in sequence {
+                collect_uses(entry, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Splits a shared-actions reference into its action name and pin.

--- a/tests/support/shared_actions.rs
+++ b/tests/support/shared_actions.rs
@@ -1,0 +1,81 @@
+//! Shared helpers for parsing `leynos/shared-actions` workflow references.
+//!
+//! Two integration tests consume these with deliberately different scopes:
+//! `workflow_shared_actions_pins` sweeps every workflow and asserts only the
+//! *shape* of each reference (a full lowercase commit SHA rather than a
+//! branch or tag), while `polonius_toolchain_contract` additionally requires
+//! the references across its checked workflows to *agree*, deriving the
+//! expected pin instead of restating it so a partial bump fails while a
+//! complete bump needs no test edit.
+
+use anyhow::{Context, Result, ensure};
+use std::collections::BTreeSet;
+
+/// Path prefix common to every shared-actions action reference.
+pub const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/.github/actions/";
+
+/// Extracts every shared-actions `uses:` token from workflow `contents`.
+///
+/// Each returned token is the full reference, for example
+/// `leynos/shared-actions/.github/actions/setup-rust@<sha>`.
+#[must_use]
+pub fn extract_shared_actions_uses(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .filter_map(|line| {
+            let start = line.find(SHARED_ACTIONS_MARKER)?;
+            let rest = line.get(start..)?;
+            let token = rest.split_whitespace().next()?;
+            (!token.is_empty()).then(|| token.to_owned())
+        })
+        .collect()
+}
+
+/// Splits a shared-actions reference into its action name and pin.
+///
+/// Returns `None` when the reference lacks the marker prefix or an `@`.
+#[must_use]
+pub fn split_shared_action_ref(reference: &str) -> Option<(&str, &str)> {
+    reference
+        .strip_prefix(SHARED_ACTIONS_MARKER)?
+        .split_once('@')
+}
+
+/// Reports whether `pin` is a full 40-character lowercase-hex commit SHA.
+#[must_use]
+pub fn is_commit_sha_pin(pin: &str) -> bool {
+    pin.len() == 40
+        && pin
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+/// Returns the single commit SHA shared by every reference in `refs`.
+///
+/// # Errors
+///
+/// Fails when `refs` is empty, when any reference is malformed or pinned to
+/// something other than a commit SHA, or when the references disagree.
+pub fn consistent_pin(refs: &[String]) -> Result<String> {
+    ensure!(
+        !refs.is_empty(),
+        "expected at least one shared-actions reference to derive the pin from"
+    );
+    let mut shas = BTreeSet::new();
+    for reference in refs {
+        let (name, pin) = split_shared_action_ref(reference)
+            .with_context(|| format!("malformed shared-actions reference {reference:?}"))?;
+        ensure!(
+            !name.is_empty() && is_commit_sha_pin(pin),
+            "shared-actions reference should pin a 40-hex commit SHA, found {reference:?}"
+        );
+        shas.insert(pin.to_owned());
+    }
+    ensure!(
+        shas.len() == 1,
+        "shared-actions references disagree on the pin: {shas:?}"
+    );
+    shas.into_iter()
+        .next()
+        .context("one shared-actions pin should remain")
+}

--- a/tests/workflow_shared_actions_pins.rs
+++ b/tests/workflow_shared_actions_pins.rs
@@ -1,17 +1,22 @@
 //! Verify shared-actions references are pinned to a full commit SHA.
 //!
 //! Dependabot owns the SHA value for each `leynos/shared-actions` action
-//! reference and bumps callers one at a time, so this test does not assert
+//! reference and bumps callers one at a time, so this sweep does not assert
 //! that every reference shares an identical pin. It only asserts the shape
 //! of each reference: the correct `.github/actions/<name>` path, pinned to a
 //! 40-character lowercase-hex commit SHA rather than a mutable branch or tag
-//! such as `main`.
+//! such as `main`. The stricter agreement check — deriving one pin the
+//! toolchain-contract workflows must share — lives in
+//! `polonius_toolchain_contract`; both consume the parsing helpers in
+//! `tests/support/shared_actions.rs`.
+
+#[path = "support/shared_actions.rs"]
+pub mod shared_actions;
 
 use anyhow::{Context, Result, ensure};
+use shared_actions::{extract_shared_actions_uses, split_shared_action_ref};
 use std::fs;
 use std::path::{Path, PathBuf};
-
-const SHARED_ACTIONS_MARKER: &str = "leynos/shared-actions/.github/actions/";
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -26,32 +31,11 @@ fn read_workflow(path: &Path) -> Result<String> {
         .with_context(|| format!("workflow file {} should be readable", path.display()))
 }
 
-fn extract_shared_actions_uses(contents: &str) -> Vec<String> {
-    contents
-        .lines()
-        .filter_map(|line| {
-            let start = line.find(SHARED_ACTIONS_MARKER)?;
-            let rest = line.get(start..)?;
-            let token = rest.split_whitespace().next()?;
-            (!token.is_empty()).then(|| token.to_owned())
-        })
-        .collect()
-}
-
 /// Returns true when `reference` is `leynos/shared-actions/.github/actions/<name>`
 /// pinned to a full 40-character lowercase-hex commit SHA.
 fn is_pinned_shared_action_ref(reference: &str) -> bool {
-    let Some(rest) = reference.strip_prefix(SHARED_ACTIONS_MARKER) else {
-        return false;
-    };
-    let Some((name, pin)) = rest.split_once('@') else {
-        return false;
-    };
-    !name.is_empty()
-        && pin.len() == 40
-        && pin
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    split_shared_action_ref(reference)
+        .is_some_and(|(name, pin)| !name.is_empty() && shared_actions::is_commit_sha_pin(pin))
 }
 
 #[test]

--- a/tests/workflow_shared_actions_pins.rs
+++ b/tests/workflow_shared_actions_pins.rs
@@ -39,21 +39,66 @@ fn is_pinned_shared_action_ref(reference: &str) -> bool {
 }
 
 #[test]
-fn unit_extracts_uses_from_workflow_lines() {
+fn unit_extracts_uses_from_workflow_yaml() -> Result<()> {
     let sample = r"
-      - uses: leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567
-      - uses: leynos/shared-actions/.github/actions/generate-coverage@0123456789abcdef0123456789abcdef01234567
-    ";
+- uses: leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567
+- uses: leynos/shared-actions/.github/actions/generate-coverage@0123456789abcdef0123456789abcdef01234567
+";
 
-    let uses = extract_shared_actions_uses(sample);
+    let uses = extract_shared_actions_uses(sample)?;
 
-    assert_eq!(
-        uses,
-        vec![
+    ensure!(
+        uses == vec![
             "leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567",
             "leynos/shared-actions/.github/actions/generate-coverage@0123456789abcdef0123456789abcdef01234567",
-        ]
+        ],
+        "both nested uses values should be extracted, got {uses:?}"
     );
+    Ok(())
+}
+
+#[test]
+fn unit_normalizes_quoted_uses_values() -> Result<()> {
+    let sample = concat!(
+        "steps:\n",
+        "  - uses: \"leynos/shared-actions/.github/actions/setup-rust@",
+        "0123456789abcdef0123456789abcdef01234567\"\n",
+        "  - uses: 'leynos/shared-actions/.github/actions/generate-coverage@",
+        "0123456789abcdef0123456789abcdef01234567'\n",
+    );
+
+    let uses = extract_shared_actions_uses(sample)?;
+
+    ensure!(
+        uses.len() == 2,
+        "quoted uses values should extract, got {uses:?}"
+    );
+    for reference in &uses {
+        ensure!(
+            is_pinned_shared_action_ref(reference),
+            "quoted values should normalize to bare references: {reference:?}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn unit_ignores_shared_action_tokens_in_comments() -> Result<()> {
+    let sample = concat!(
+        "steps:\n",
+        "  # uses: leynos/shared-actions/.github/actions/setup-rust@main\n",
+        "  - run: echo hello\n",
+        "  - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567",
+        " # leynos/shared-actions/.github/actions/setup-rust@main\n",
+    );
+
+    let uses = extract_shared_actions_uses(sample)?;
+
+    ensure!(
+        uses.is_empty(),
+        "commented-out or comment-embedded tokens should not extract: {uses:?}"
+    );
+    Ok(())
 }
 
 #[test]
@@ -83,7 +128,11 @@ fn behavioural_shared_actions_pins_are_full_commit_shas() -> Result<()> {
         if path.extension().and_then(|ext| ext.to_str()) != Some("yml") {
             continue;
         }
-        refs.extend(extract_shared_actions_uses(&read_workflow(&path)?));
+        let contents = read_workflow(&path)?;
+        refs.extend(
+            extract_shared_actions_uses(&contents)
+                .with_context(|| format!("extract references from {}", path.display()))?,
+        );
     }
 
     ensure!(

--- a/tests/workflow_shared_actions_pins.rs
+++ b/tests/workflow_shared_actions_pins.rs
@@ -14,7 +14,7 @@
 pub mod shared_actions;
 
 use anyhow::{Context, Result, ensure};
-use shared_actions::{extract_shared_actions_uses, split_shared_action_ref};
+use shared_actions::{consistent_pin, extract_shared_actions_uses, split_shared_action_ref};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -97,4 +97,80 @@ fn behavioural_shared_actions_pins_are_full_commit_shas() -> Result<()> {
         );
     }
     Ok(())
+}
+
+const VALID_REF_A: &str =
+    "leynos/shared-actions/.github/actions/setup-rust@0123456789abcdef0123456789abcdef01234567";
+
+/// Build a full reference for `pin` on an arbitrary action name.
+fn reference_with_pin(pin: &str) -> String {
+    format!("leynos/shared-actions/.github/actions/rust-build-release@{pin}")
+}
+
+#[test]
+fn unit_consistent_pin_accepts_agreeing_references() -> Result<()> {
+    let refs = vec![
+        VALID_REF_A.to_owned(),
+        reference_with_pin("0123456789abcdef0123456789abcdef01234567"),
+    ];
+    let pin = consistent_pin(&refs)?;
+    ensure!(
+        pin == "0123456789abcdef0123456789abcdef01234567",
+        "agreeing references should yield their shared pin, got {pin:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn unit_consistent_pin_rejects_an_empty_reference_list() {
+    let error = consistent_pin(&[]).expect_err("no references should reject");
+    assert!(
+        error.to_string().contains("at least one"),
+        "the empty-list rejection should say so; got {error:?}"
+    );
+}
+
+#[test]
+fn unit_consistent_pin_rejects_malformed_references() {
+    for reference in [
+        "leynos/shared-actions/.github/actions/setup-rust", // no pin separator
+        "actions/checkout@0123456789abcdef0123456789abcdef01234567", // wrong prefix
+    ] {
+        let error = consistent_pin(&[reference.to_owned()])
+            .expect_err("a malformed reference should reject");
+        assert!(
+            error.to_string().contains("malformed"),
+            "{reference:?} should be reported as malformed; got {error:?}"
+        );
+    }
+}
+
+#[test]
+fn unit_consistent_pin_rejects_non_sha_pins() {
+    for pin in [
+        "main",
+        "v1.2.3",
+        "0123456789ABCDEF0123456789ABCDEF01234567",
+        "abc123",
+    ] {
+        let error =
+            consistent_pin(&[reference_with_pin(pin)]).expect_err("a non-SHA pin should reject");
+        assert!(
+            error.to_string().contains("40-hex commit SHA"),
+            "pin {pin:?} should be rejected for its shape; got {error:?}"
+        );
+    }
+}
+
+#[test]
+fn unit_consistent_pin_rejects_disagreeing_shas() {
+    let refs = vec![
+        VALID_REF_A.to_owned(),
+        reference_with_pin("fedcba9876543210fedcba9876543210fedcba98"),
+    ];
+    let error = consistent_pin(&refs).expect_err("disagreeing pins should reject");
+    assert!(
+        error.to_string().contains("disagree"),
+        "the disagreement rejection should say so; got {error:?}"
+    );
 }


### PR DESCRIPTION
## Summary

This branch unbreaks `make test` on `main`. The shared-actions pin bump
in [#535](https://github.com/leynos/netsuke/pull/535) updated every
workflow to `8add2d9` but missed the two constants in
`tests/polonius_toolchain_contract.rs` that hardcoded the previous
commit (`2f90d10`), so four workflow-contract cases now fail on `main`.
This was an authoring miss in #535 (only the workflow-contract pytest
gate was run for that PR, not the full suite).

Rather than restating the new SHA — recreating the scattered-literal
failure mode the recent version-contract work eliminated elsewhere —
the contract now derives the pin from the workflows themselves: it
collects every `leynos/shared-actions` reference across the four
checked workflow files, requires them all to agree, and validates the
40-character lowercase commit-SHA shape. A complete bump stays green
with no test edit; a partial bump fails on the disagreement, which is
a stronger contract than the old hardcoded value.

The branch also fixes a latent environment sensitivity this
investigation surfaced: the locale-stub UI harness derived its
`-L dependency=` directory from the uplifted `test_support` rlib's
location, which breaks under Cargo's `build.build-dir` split (the
dependency rlibs live in the build dir). The harness now collects the
dependency directories from every compiler-artifact message, so it is
layout-agnostic. In split layouts the old derivation pointed at a
directory whose only `anyhow` artefacts were stale stable-toolchain
leftovers, failing both fixtures with harness faults (E0514/E0463).

## Review walkthrough

- Start with [tests/polonius_toolchain_contract.rs](https://github.com/leynos/netsuke/blob/1260052/tests/polonius_toolchain_contract.rs#L23-L100)
  — the action constants lose their embedded SHAs, and
  `shared_action_pins` / `shared_actions_sha` derive and validate the
  pin, with `WORKFLOW_EXPECTATIONS` enumerating the swept files.
- Then [tests/locale_stub_ui_tests.rs](https://github.com/leynos/netsuke/blob/1260052/tests/locale_stub_ui_tests.rs#L100-L200)
  for the multi-directory `-L dependency=` collection via
  `rlib_parents_in_message`.

## Validation

- `make check-fmt`: pass
- `make lint` (Clippy + Whitaker, warnings denied): pass
- `make test` (full workspace nextest + doctests): pass — including
  the four previously failing `polonius_toolchain_contract` cases and
  both `locale_stub_ui_tests` fixtures

## Notes

- Merging this restores a green `main`; #534 and #537 both carry the
  same red inherited from main until then.
- Two stale stable-rustc (`1.89.0`) `anyhow` artefacts from July were
  removed from the shared target directory during diagnosis; they were
  masking the harness bug by half-satisfying the old single-directory
  probe.

## Summary by Sourcery

Derive the shared-actions commit pin used in workflow toolchain tests from the workflows themselves and make the locale stub UI harness resilient to Cargo build directory layouts.

Bug Fixes:
- Fix polonius toolchain contract tests by inferring a single shared-actions pin SHA from all covered workflows and validating it.
- Fix locale stub UI tests by collecting dependency search directories from all compiler-artifact messages instead of assuming a single deps directory.

Enhancements:
- Enforce consistency of leynos/shared-actions pins across CI, netsukefile, coverage, and packaging workflows and validate their SHA format.
- Improve the locale stub UI harness to pass multiple -L dependency paths, making it robust to split build directories.