### PR TITLE
Propose release-hardening and code-health RFCs

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -58,6 +58,9 @@ operator, user, and contributor references are easier to find.
 - [RFC 0001: Harden release integrity and admission](rfcs/0001-release-hardening.md):
   Proposed release-profile invariants, secret and dependency policy, and
   exact-commit release admission.
+- [RFC 0002: Repository-wide code-health contracts and fuzzing](rfcs/0002-code-health.md):
+  Proposed workflow-policy validation, gate self-consistency, health-signal
+  ownership, and scheduled coverage-guided fuzzing.
 
 ## User and operator guides
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -53,6 +53,12 @@ operator, user, and contributor references are easier to find.
   Manifest telemetry decision record, separating observability from evaluation
   and bounding and redacting the emitted metrics and spans.
 
+## Requests for comments
+
+- [RFC 0001: Harden release integrity and admission](rfcs/0001-release-hardening.md):
+  Proposed release-profile invariants, secret and dependency policy, and
+  exact-commit release admission.
+
 ## User and operator guides
 
 - [quickstart.md](quickstart.md): First-run walkthrough for building with

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -18,7 +18,8 @@ output and some leaf files so the long-lived structure remains visible.
 ├── cyclopts/
 ├── docs/
 │   ├── archive/
-│   └── execplans/
+│   ├── execplans/
+│   └── rfcs/
 ├── examples/
 │   └── hello-world/
 ├── installer/
@@ -67,6 +68,8 @@ output and some leaf files so the long-lived structure remains visible.
   after active roadmap work moves on.
 - `docs/execplans/`: Execution plans used as implementation handoff documents
   for scoped tasks.
+- `docs/rfcs/`: Numbered Requests for Comments that propose reviewable changes
+  before they become binding decisions.
 - `examples/`: Example Netsuke manifests and minimal runnable sample projects.
 - `installer/`: Installer packaging assets and platform-specific packaging
   definitions.
@@ -121,6 +124,10 @@ that users or operators need to understand,
 Place new production Rust modules under the `src/` subtree that owns the
 feature boundary. Use `test_support/` for reusable integration-test helpers and
 keep one-off fixtures close to the tests that consume them.
+
+Place proposed, cross-cutting changes under `docs/rfcs/` using the numbering
+and status conventions in the documentation style guide. Link each RFC from
+`docs/contents.md` when it is first committed.
 
 The crates.io package is named `netsuke-build`, while its library and binary
 targets remain named `netsuke`. Keep command-line help, manual pages, release

--- a/docs/rfcs/0001-release-hardening.md
+++ b/docs/rfcs/0001-release-hardening.md
@@ -1,0 +1,356 @@
+# RFC 0001: Harden release integrity and admission
+
+## Preamble
+
+- **RFC number:** 0001
+- **Status:** Proposed
+- **Created:** 2026-08-11
+
+## Summary
+
+This RFC proposes release-mode arithmetic checks, continuous secret scanning,
+dependency and licence policy, and a release-admission gate for Netsuke. The
+gate would publish artefacts only when deterministic quality, security, and
+integrity evidence exists for the exact commit being released. The proposal is
+inspired by the actual upstream
+[VTCode repository](https://github.com/vinhnx/VTCode), but retains Netsuke's
+stronger existing pinning, verification, and release contracts.
+
+## Problem
+
+Netsuke's [Cargo manifest](../../Cargo.toml) has no explicit
+`[profile.release]`. Cargo therefore builds release binaries with overflow
+checks and debug assertions disabled, even though six production `debug_assert`
+sites express assumptions about valid state. A release-only arithmetic defect
+or violated assumption can consequently become an undiagnosed correctness or
+safety problem.
+
+The repository also has no Gitleaks, `cargo-audit`, `cargo-deny`,
+`cargo-about`, or `cargo-unmaintained` gate. Existing quality checks are useful
+but are not assembled into one admission decision, and no machine-readable
+record currently proves that the commit, checks, security scans, and uploaded
+artefacts are the same release candidate. A failed check can therefore be
+noticed without being mechanically connected to publication.
+
+Secret exposure is especially difficult to contain after a commit has entered
+history. A working-tree scan catches the candidate currently under review, but
+only a history scan can find a credential introduced and later removed. A
+scheduled history scan also provides a recurring check for secrets that were
+missed by an earlier review.
+
+## Current state
+
+- `Cargo.toml` has no `[profile.release]`; release overflow checks and debug
+  assertions therefore use Cargo's defaults.
+- Six production `debug_assert` sites exist. The current test and lint gates
+  do not establish that every release path is safe when those assertions are
+  enabled.
+- The [CI workflow](../../.github/workflows/ci.yml) already uses SHA-pinned
+  GitHub Actions, the pinned nightly toolchain and Polonius,
+  all-target/all-feature Clippy and rustdoc checks, Whitaker, Kani, Proptest,
+  and the repository's other documented quality gates.
+- The [release staging policy](../../.github/release-staging.toml) already
+  requires a target archive and matching `.sha256` sidecar. The release
+  workflow hoists those pairs before upload, and the `cargo-binstall` metadata
+  depends on their names and locations.
+- There is no repository-wide policy that combines quality evidence, security
+  evidence, release-profile measurements, and checksum verification into a
+  publication decision.
+
+The relevant VTCode precedent is pinned to commit
+`f188bcb0e47d7386886ab0c3db7e338b297a3d07`. It enables release overflow checks
+and debug assertions, scans secrets, and runs licence and unmaintained-
+dependency checks. Its secret-scan workflow at that commit uses an unpinned
+checkout, and its workflow-policy rules reject that pattern. Netsuke must take
+the useful policy intent without copying that weakness.
+
+## Goals and non-goals
+
+- Goals:
+  - Enable release overflow checks and debug assertions, with measured and
+    reviewable performance and size budgets.
+  - Block changes with secrets in the working tree and make a scheduled scan of
+    reachable history part of release admission.
+  - Define advisory, licence, notice, and unmaintained-dependency policy using
+    `cargo-audit`, `cargo-deny`, `cargo-about`, and a
+    `cargo-unmaintained` advisory.
+  - Make release publication depend on deterministic evidence for the exact
+    tag commit, including existing checksum sidecars.
+  - Preserve SHA-pinned actions, the pinned Polonius toolchain, Kani,
+    all-target/all-feature gates, and the current release naming and checksum
+    contracts.
+- Non-goals:
+  - Replacing Proptest, Kani, Clippy, rustdoc, Whitaker, or existing test gates.
+  - Changing Netsuke's public command-line or manifest behaviour deliberately.
+  - Copying VTCode's action pinning, workflow layout, thresholds, or download
+    mechanisms without verifying them against Netsuke's contracts.
+  - Introducing a new package manager, signing service, or runtime telemetry
+    system.
+
+## Proposed design
+
+### Release-mode invariants
+
+Add an explicit release profile with `overflow-checks = true` and
+`debug-assertions = true`. The profile must apply to every release target and
+must not be silently overridden by a packaging job. Release builds continue to
+use the pinned nightly toolchain and `-Zpolonius=next` wherever the existing
+release workflow supplies that requirement.
+
+The release test set must exercise every supported command path that can reach
+the six production assertions, including boundary inputs for arithmetic that
+can overflow. A valid supported input must not fail because a newly enabled
+assertion detects a violated internal invariant. An intentional rejection must
+remain a documented, deterministic error rather than an accidental assertion
+failure.
+
+Before enabling the profile as a blocking requirement, CI must record a
+baseline from the current profile and a candidate measurement from the new
+profile. Both measurements use the same pinned toolchain, target, runner class,
+inputs, and build flags. The baseline and candidate are retained with the
+release evidence so a later comparison is reproducible.
+
+### Secret scanning
+
+Use a SHA-pinned Gitleaks action or pinned executable. The working-tree scan is
+blocking on pull requests, pushes, and release candidates. It covers tracked,
+staged, and untracked candidate files, subject only to a small, reviewed list
+of generated paths. A finding fails the job; suppressions must identify the
+false-positive pattern, path, reviewer, and expiry, and must not disable the
+whole repository scan.
+
+A scheduled job scans the full reachable Git history rather than a shallow
+checkout. Its result is a blocking security signal: release admission requires
+a successful history scan for the repository within the configured freshness
+window, and a new finding fails admission until it is removed or explicitly
+dispositioned. The schedule and freshness window must be recorded in the
+workflow contract so a missed schedule cannot be mistaken for a passing scan.
+
+All checkout and scanning actions, including any newly introduced action, must
+remain pinned to immutable commit SHAs. No release-hardening workflow may use
+an unpinned download URL or an unpinned action tag.
+
+### Dependency and licence policy
+
+The repository will maintain versioned policy files and generate their outputs
+in CI:
+
+- `cargo-audit` fails on every vulnerability or unsoundness advisory unless a
+  narrowly scoped waiver names the advisory, affected dependency, reason,
+  owner, and expiry.
+- `cargo-deny` fails on denied advisories, banned crates or sources, and
+  licences outside the explicitly permitted set. Unknown licence metadata is a
+  failure, not an implicit approval.
+- `cargo-about` generates the notices and licence inventory shipped or retained
+  for each release. Missing or unrenderable metadata fails the gate.
+- `cargo-unmaintained` supplies an advisory report. A newly introduced direct
+  dependency reported as unmaintained blocks admission until an owner records
+  an approved, expiring exception or the dependency is replaced. Transitive
+  findings are reported for review and do not silently become permanent
+  approvals.
+
+Tool versions, registry/index state, policy files, and lockfile are inputs to
+the evidence record. Waivers are exceptional, auditable, and time-limited; they
+cannot turn a failed release job green by editing generated output.
+
+### Release-admission evidence
+
+Add a read-only admission job before any job with permission to publish release
+assets. It consumes a machine-readable evidence manifest containing at least:
+
+- the tag, commit SHA, repository, Rust toolchain, and versions of each policy
+  tool;
+- the result and log identity for formatting, lint, tests, rustdoc, Whitaker,
+  Kani, and all existing all-target/all-feature gates;
+- release-profile performance and size measurements against their baseline;
+- working-tree and sufficiently recent scheduled history scan results;
+- advisory, licence, notice, and unmaintained-dependency results; and
+- every staged archive name, target, byte size, and SHA-256 digest.
+
+Admission succeeds only when every required result is successful, the evidence
+manifest names the exact release commit, and every archive has exactly one
+matching `.sha256` sidecar. The publication job must depend on admission and
+must not run on a missing, stale, malformed, or mismatched manifest. A dry run
+may build and inspect artefacts, but it must not bypass admission for a real
+publication.
+
+### Failure modes and mitigations
+
+- A release assertion or overflow check fails: the release is rejected; the
+  failing input and assertion are reported, and the profile is not disabled to
+  make the job pass.
+- A performance or size budget is exceeded: admission fails and retains the
+  measurements for review. The budget can change only through a reviewed
+  decision, not through an environment variable or an ad hoc workflow edit.
+- A scan or advisory tool is unavailable: the result is `unknown`, not
+  `passed`, so publication waits for a deterministic rerun.
+- A scheduled history scan is late: its evidence expires and admission fails
+  until the scan completes within the freshness window.
+- A secret, disallowed licence, or unwaived advisory is found: publication is
+  blocked, and the failure identifies the finding without printing secret
+  material.
+- An archive or sidecar is missing, duplicated, or mismatched: staging and
+  admission fail before any release asset is uploaded.
+- A policy waiver expires during a release: the gate fails closed and names the
+  expired waiver for renewal or remediation.
+
+## Requirements
+
+### Functional requirements
+
+- Release binaries must compile with overflow checks and debug assertions
+  enabled for every supported target.
+- Working-tree secret scanning must block pull requests, pushes, and release
+  candidates; scheduled full-history scanning must produce fresh evidence that
+  release admission requires.
+- `cargo-audit`, `cargo-deny`, `cargo-about`, and the
+  `cargo-unmaintained` advisory must run against the committed lockfile and
+  versioned policy.
+- Release publication must be impossible unless the admission job has passed
+  for the exact tag commit.
+- Existing archive names, target coverage, `.sha256` sidecars, and
+  `cargo-binstall` resolution must remain compatible.
+
+### Technical requirements
+
+- Existing action SHA pins, the pinned nightly toolchain, Polonius,
+  all-target/all-feature quality gates, Kani, and checksum contracts must not
+  be weakened or replaced.
+- New actions and downloaded executables must be pinned immutably and verified
+  by the repository's established supply-chain policy.
+- Evidence must be deterministic, machine-readable, retained with the workflow
+  run, and linked to the exact commit and tool versions that produced it.
+- Secret findings must be redacted from logs; suppressions must be narrow,
+  reviewed, and expiring.
+- The policy must fail closed on unknown, stale, missing, or contradictory
+  evidence.
+
+### Measurable acceptance criteria
+
+- Across five repeated runs on the same runner class, the candidate's median
+  representative-workload time must be no more than 5% slower than the baseline
+  for any supported target.
+- The stripped release binary must be no more than 10% larger than the
+  baseline for any supported target. The report must include unstripped size as
+  a diagnostic, but the stripped-size limit is the admission criterion.
+- The release-profile test suite must pass for all supported targets and must
+  cover every production `debug_assert` site and selected arithmetic boundary
+  cases without assertion or overflow failures.
+- A clean candidate must produce zero unwaived Gitleaks findings, zero denied
+  or unknown licences, zero unwaived dependency advisories, a complete notice
+  inventory, and a current history-scan result.
+- The admission manifest must identify one passing result for every required
+  gate, the exact tag commit, every release target, and every archive/sidecar
+  digest. Any missing field fails admission.
+- Existing release workflow contract tests and checksum tests must continue to
+  pass without changing their expected archive or sidecar names.
+
+## Compatibility and migration
+
+The profile change may expose latent arithmetic defects or assertions that were
+previously compiled out. That is an intentional compatibility check: supported
+inputs must be repaired or covered before the profile becomes blocking. Users
+should not observe a command-line change for valid inputs, but release binaries
+may be modestly slower or larger within the stated budgets.
+
+Migration is phased so each new failure has a useful baseline:
+
+### Phase 1: Measure and inventory
+
+Record the current release profile, assertion call sites, representative
+workloads, target sizes, release archive layout, and existing gate outputs. Add
+policy-file and evidence-manifest schemas without making publication depend on
+them.
+
+### Phase 2: Enable release invariants
+
+Add the explicit release profile, boundary tests, and performance/size
+measurements. Run the new checks in required CI with a short baseline period;
+fix defects and tune only the documented workload and budgets. Keep Polonius,
+Kani, and all-target/all-feature gates unchanged.
+
+### Phase 3: Enforce security and dependency policy
+
+Introduce the pinned working-tree scan, scheduled history scan, dependency
+advisories, licence checks, notices, and unmaintained-dependency review. Triage
+existing findings with expiring waivers before making the checks blocking.
+
+### Phase 4: Turn on admission
+
+Require the evidence manifest and admission job in the release workflow. Make
+the publishing job depend on admission, verify the tag-to-commit binding, and
+retain the existing archive and checksum-sidecar tests. Exercise the workflow
+with dry runs and intentionally incomplete evidence before enabling real
+publication.
+
+Rollback is limited to disabling publication while retaining the checks and
+evidence. The release profile must not be removed merely to bypass a failed
+admission; if a threshold is unsafe, record a revised threshold through a
+reviewed decision and repeat the measurement phase.
+
+## Alternatives considered
+
+### Option A: Keep Cargo defaults and rely on tests
+
+This avoids release overhead and configuration changes, but leaves six
+production assertions disabled and does not detect release-only overflow. It
+does not address secret history, dependency policy, or the absence of a single
+publication decision, so it is rejected.
+
+### Option B: Copy VTCode's workflows verbatim
+
+The commit-pinned [VTCode release profile][vtcode-release-profile],
+[secret scan][vtcode-secret-scan], and
+[licence and unmaintained checks][vtcode-dependency-checks] are useful
+precedents. Copying them would import assumptions about action pinning,
+workflow permissions, thresholds, and artefact layout. In particular, the
+secret-scan workflow at that commit uses an unpinned checkout, which is not
+acceptable for Netsuke. This option is rejected in favour of adapting the
+intent to Netsuke's contracts.
+
+### Option C: Run checks but leave publication independent
+
+This provides diagnostic information but permits a release job to publish when
+a check is missing, stale, or failed. It makes the evidence advisory rather
+than an invariant and is rejected because release integrity depends on a
+fail-closed admission decision.
+
+## Open questions
+
+- Should the history scan freshness window be 24 hours, seven days, or another
+  interval that matches the release cadence?
+- Which representative workloads and runner classes best predict user-visible
+  performance across all supported targets?
+- Should a transitive dependency reported by `cargo-unmaintained` ever become a
+  hard blocker, and who owns that escalation?
+- Where should the generated `cargo-about` notice inventory be retained, and
+  which release formats must embed it rather than publish it as a sidecar?
+- Should release evidence be signed or attested by an external service, or is
+  commit-bound workflow retention sufficient for the first implementation?
+- What approval authority and maximum duration should apply to each waiver
+  category?
+
+## References
+
+- [Cargo profiles](https://doc.rust-lang.org/cargo/reference/profiles.html).
+- [Gitleaks](https://github.com/gitleaks/gitleaks).
+- [`cargo-about`](https://github.com/EmbarkStudios/cargo-about).
+- [`cargo-audit`](https://github.com/RustSec/rustsec/tree/main/cargo-audit).
+- [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny).
+- [VTCode upstream repository](https://github.com/vinhnx/VTCode).
+- [VTCode release profile at commit `f188bcb0`][vtcode-release-profile].
+- [VTCode secret scan at commit `f188bcb0`][vtcode-secret-scan].
+- [VTCode dependency checks at commit `f188bcb0`][vtcode-dependency-checks].
+
+[vtcode-dependency-checks]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/.github/workflows/ci.yml#L165-L230
+[vtcode-release-profile]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/Cargo.toml#L415-L430
+[vtcode-secret-scan]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/.github/workflows/secret-scan.yml#L1-L65
+
+## Recommendation
+
+Adopt this RFC as the release-hardening direction: enable the explicit release
+invariants, add pinned and fail-closed security and dependency checks, measure
+their cost, and make exact-commit admission evidence a prerequisite for
+publication. This gives Netsuke the useful release-health lessons from VTCode
+while preserving Netsuke's existing SHA pins, Polonius, Kani, all-target and
+all-feature quality gates, and checksum contracts.

--- a/docs/rfcs/0002-code-health.md
+++ b/docs/rfcs/0002-code-health.md
@@ -1,0 +1,433 @@
+# RFC 0002: Repository-wide code-health contracts and fuzzing
+
+## Preamble
+
+- **RFC number:** 0002
+- **Status:** Proposed
+- **Created:** 2026-08-11
+
+## Summary
+
+Netsuke should make its repository-wide health policy executable. A single
+validator should check GitHub workflow policy, gate self-consistency, exception
+hygiene, and documentation links and references. Scheduled `cargo-fuzz` targets
+should exercise hostile manifest, Jinja, interpolation, path, and
+Ninja-emission inputs. Pull requests should receive fast, deterministic
+blocking signals, while longer coverage and mutation signals remain scheduled
+and clearly labelled.
+
+This proposal is inspired by the actual upstream [VTCode repository][vtcode],
+but is not a copy of its implementation. The pinned
+[VTCode workflow-policy script][vtcode-policy] and
+[cargo-fuzz manifest][vtcode-fuzz-manifest] show useful patterns; Netsuke must
+adapt them to its own gates and stronger safety policy.
+
+## Problem
+
+Netsuke has several good checks, but their contracts are distributed across
+Make targets, workflow YAML, scripts, and documentation. Existing workflow
+contract tests cover important release and mutation-testing callers, yet they
+do not provide one policy for every workflow. A workflow can therefore refer to
+a missing Make target, profile, configuration file, local reusable workflow, or
+stale exception without a consistent failure at the point of change.
+
+The repository also has no coverage-guided fuzzing boundary for the input
+surfaces most likely to turn malformed data into a panic, an unexpected path,
+or invalid Ninja output. Example tests and Proptest provide valuable structured
+coverage, but hostile byte streams and combinations of malformed YAML, Jinja,
+paths, and interpolation deserve a separate harness.
+
+Finally, health signals are not uniformly classified as per-pull-request
+blocking or scheduled information. This makes it harder to distinguish a
+regression that must stop a merge from a trend that needs investigation. The
+drift in the
+[formal-verification guide](../formal-verification-methods-in-netsuke.md),
+which describes verification support as absent despite current Proptest and
+Kani work, is a concrete example of the cost of that ambiguity.
+
+## Current state
+
+The top-level [Makefile](../../Makefile) exposes `check-fmt`, `lint`, `test`,
+`test-workflow-contracts`, `markdownlint`, `nixie`, changed-tooling checks, and
+Kani targets. The [main CI workflow](../../.github/workflows/ci.yml) runs
+formatting, linting, spelling, workflow contracts, the Rust test suite,
+changed-line coverage, and a PR Kani smoke job. The
+[mutation-testing workflow](../../.github/workflows/mutation-testing.yml) is
+scheduled and calls a pinned reusable workflow. These are useful existing
+contracts and should remain authoritative for their respective checks.
+
+Cargo already denies `unsafe` code and broad classes of Clippy hazards. The
+repository also uses Proptest, Kani, changed-line coverage, and scheduled
+mutation testing. Fuzzing therefore supplements the current verification
+portfolio; it must not weaken or silently replace any of those tools. The
+repository's no-blanket-retry policy also applies to the new jobs: a retry may
+address infrastructure recovery only when it is explicitly scoped and
+observable, never a failing health assertion.
+
+The existing workflow files use pinned action commits, but policy validation is
+currently spread across individual tests. The current contract-test layout is a
+suitable home for focused fixtures and regression cases while the validator
+itself remains a small, repository-level tool.
+
+## Goals and non-goals
+
+- Goals:
+  - Validate every GitHub workflow's security and reference policy with one
+    deterministic, reviewable command.
+  - Prove that workflow references, Make targets, profiles, configuration
+    files, and declared health jobs exist and agree with one another.
+  - Add scheduled, resource-bounded `cargo-fuzz` targets for the hostile input
+    surfaces that cross the manifest-to-Ninja boundary.
+  - Classify health signals by their per-PR or scheduled role, with explicit
+    ownership, failure meaning, and escalation.
+  - Make exceptions finite, owned, justified, scoped, and time-bounded.
+  - Detect broken documentation links and stale references to gates or tools.
+  - Preserve the existing unsafe, Clippy/Whitaker, Proptest, Kani, coverage,
+    mutation, and no-blanket-retry policies.
+- Non-goals:
+  - Replacing unit, integration, behavioural, snapshot, Proptest, Kani,
+    coverage, mutation, or Whitaker checks with fuzzing.
+  - Introducing a new release-security policy; release admission belongs to
+    [RFC 0001](0001-release-hardening.md).
+  - Requiring full mutation testing, full coverage, or every fuzz target on
+    every pull request.
+  - Copying VTCode's workflow scripts, action choices, or policy exceptions.
+  - Expanding the proposal into a runtime sandbox, a new build system, or a
+    change to Netsuke's manifest semantics.
+
+## Proposed design
+
+### Repository-wide workflow-policy validator
+
+Add one deterministic validator, called by an existing or new Make target, that
+parses every workflow under `.github/workflows/` and reports violations with a
+file, YAML path, rule identifier, and remediation. The validator should be
+testable without GitHub credentials and should consume repository files only.
+
+The initial policy should enforce these invariants:
+
+1. Every external action and reusable workflow reference uses a full,
+   lower-case, 40-character commit SHA. Local references beginning with `./`
+   are permitted only when the referenced file exists in the repository.
+2. Workflow and job permissions are explicit. The default token permission is
+   empty, and a job may add only the scopes it needs. Any broader scope is an
+   exception with an owner, rationale, issue or pull-request reference, and
+   expiry.
+3. `pull_request_target` jobs have an explicit policy exception and cannot
+   execute untrusted checkout content or interpolate untrusted pull-request
+   text into a shell command.
+4. Every `needs` job name, local workflow, local action, script path, Make
+   target, nextest profile, and configuration path named by a workflow exists.
+5. Workflow triggers, concurrency, and cancellation settings follow the
+   repository policy. A job must not hide a failed health check behind
+   `continue-on-error` unless that job is classified as scheduled or has an
+   explicit, unexpired exception.
+6. Health jobs identify their tier in their name or metadata, and their
+   failure or informational status is not contradictory to the tier registry.
+
+The validator must parse YAML rather than use regular expressions for YAML
+structure. It may use narrow text inspection for shell commands and comments,
+but each such rule must have a fixture proving that quoting, multiline values,
+and comments do not create false positives.
+
+### Gate self-consistency contracts
+
+The validator should build a reference inventory before applying policy. The
+inventory is the set of paths, targets, profiles, jobs, and tools named by
+workflows and the canonical Makefile. A reference is valid only when its
+resolved target exists and its invocation shape agrees with the owning contract.
+
+The first contracts should include the following:
+
+- A literal `make TARGET` in a workflow names a declared Make target, including
+  the repository's documented phony targets.
+- A local reusable workflow or action resolves to a tracked file of the
+  expected kind.
+- A `--profile NAME` argument resolves to a `[profile.NAME]` section in the
+  configured nextest file; a referenced tool-version file exists and is
+  non-empty.
+- A path passed to a workflow cache, upload, coverage, mutation, Kani, or
+  spelling step exists at checkout time or is created by an earlier step in the
+  same job.
+- Every `needs` reference names a job in that workflow, and every declared
+  tier has at least one producing job.
+- A documentation link or indexed documentation path resolves to a tracked
+  file. References to `make TARGET` and named quality gates resolve to current
+  targets or to an explicitly marked historical reference.
+
+Existing focused contract tests remain valuable. They should call the shared
+inventory and add domain-specific assertions, rather than duplicate parsers or
+silence a failure that the repository-wide validator has found.
+
+### Scheduled cargo-fuzz targets
+
+Create a fuzz workspace using `cargo-fuzz` with one target per boundary. The
+initial target names are descriptive and may be adjusted during implementation,
+but the coverage contract is fixed:
+
+- `manifest_yaml`: arbitrary bytes are parsed as hostile manifest input.
+- `jinja_expansion`: malformed templates, undefined values, nested control
+  flow, and expansion-size pressure are exercised.
+- `command_interpolation`: placeholder boundaries, quoting, backticks,
+  repeated substitutions, and malformed UTF-8 are exercised.
+- `path_processing`: absolute, parent-traversal, separator, NUL, and very
+  deep path inputs are exercised within the current capability boundary.
+- `ninja_emission`: valid and rejected IR values are rendered, with hostile
+  names and command text included.
+
+Each harness must be a pure library boundary: it must not invoke a user's
+shell, run Ninja, access the network, or write outside a test-controlled
+temporary directory. Invalid UTF-8 and malformed syntax are inputs to reject,
+not reasons for the harness to panic. Harnesses must bound input and output
+sizes, avoid unbounded recursion, and make the same input produce the same
+classification and output.
+
+The first assertions should encode current behaviour, not invent a new language
+contract:
+
+- Parsing and expansion return a typed error or a bounded value, never a panic.
+- Successful expansion preserves the existing control-key and binding rules.
+- Interpolation rewrites only the existing whole-placeholder forms and
+  rejects unmatched delimiters according to the current contract.
+- Path handling preserves the permitted root and rejects inputs that escape
+  it.
+- Ninja emission is deterministic for the same IR and either produces output
+  accepted by the existing renderer contract or a typed error.
+
+Run short smoke corpora on pull requests only when they fit the deterministic
+blocking budget. Run longer fuzzing sessions on a schedule, archive new
+crashers as minimized regression inputs, and make every crash a blocking
+regression test before deleting or quarantining it.
+
+### Health tiers and exception/allowlist registry
+
+Maintain a small machine-readable registry describing each health signal: name,
+owning workflow or Make target, tier, blocking status, schedule, owner, and
+failure response. The registry is documentation for humans and input to the
+self-consistency validator; it is not a second implementation of a gate.
+
+Per-PR blocking signals should include workflow-policy validation, gate
+self-consistency, formatting, linting, the existing Rust tests, workflow
+contracts, and documentation consistency. Existing changed-line coverage and PR
+Kani smoke remain blocking where they are already required. Scheduled mutation
+testing, extended fuzzing, full coverage trend reporting, and other
+resource-heavy analyses remain scheduled signals until their cost and stability
+justify promotion.
+
+Every exception must be represented in the registry with exactly one owner, one
+rationale, one issue or pull-request reference, a narrow rule and file scope, a
+creation date, and an expiry date. The validator rejects expired, duplicate,
+ownerless, broad, or unknown exceptions. It also rejects a policy rule that is
+bypassed inline when no corresponding registry entry exists. Expiring an
+exception is a deliberate review event; silently extending it is not an
+acceptable repair. An allowlist entry is an exception with the same metadata
+and expiry requirements, never a wildcard bypass for a whole workflow or
+directory.
+
+### Documentation consistency
+
+The documentation check should begin with finite, high-value contracts:
+
+- links in `docs/contents.md` and Markdown files resolve to existing files or
+  valid external URLs;
+- examples naming Make targets, workflow files, profiles, or tool-version
+  files resolve to the current repository;
+- the documented per-PR and scheduled gate lists match the tier registry; and
+- statements about Proptest, Kani, coverage, mutation, and fuzzing are checked
+  against the current workflow and Makefile contracts.
+
+The check should report stale prose for correction rather than rewrite prose
+automatically. Markdown formatting, `en-GB-oxendict` spelling, and Mermaid
+validation remain their existing gates.
+
+### Inspiration and boundary
+
+The actual upstream [VTCode repository][vtcode] provides the inspiration for
+repository workflow policy and a cargo-fuzz layout. Its
+[workflow-policy script][vtcode-policy] and [fuzz runner][vtcode-fuzz-runner]
+are useful reference points at commit
+`f188bcb0e47d7386886ab0c3db7e338b297a3d07`. Netsuke should not copy them
+verbatim: the pinned evidence shows a workflow case where an unpinned checkout
+would violate Netsuke's own policy, and Netsuke's existing gate and permission
+contracts differ.
+
+## Requirements
+
+### Functional requirements
+
+- The validator must inspect every tracked workflow and fail with actionable,
+  stable rule identifiers.
+- A clean checkout of Netsuke must have zero unresolved workflow, Make target,
+  profile, configuration, job, and documentation references.
+- Five fuzz targets must cover the manifest, Jinja, interpolation,
+  path, and Ninja-emission boundaries, with malformed input cases included.
+- Every health signal must have exactly one tier, owner, schedule or PR event,
+  and failure meaning.
+- Every exception must be narrow, owned, justified, referenced, and unexpired.
+- Fuzz crashes must become reproducible regression inputs before the corpus is
+  considered healthy.
+
+### Technical requirements
+
+- Keep all workflow action and reusable-workflow references pinned to full
+  commit SHAs, with no untracked mutable-reference escape hatch.
+- Preserve `unsafe` forbiddance, warnings-denied Clippy and Whitaker, Proptest,
+  Kani, changed-line coverage, scheduled mutation testing, and no blanket
+  retries.
+- Keep fuzz harnesses deterministic, resource-bounded, offline, and free of
+  shell or Ninja execution.
+- Keep per-PR checks deterministic and fast enough for normal review; put
+  unbounded or resource-heavy work in scheduled jobs with explicit budgets.
+- Test every validator rule with valid and invalid fixtures, including YAML
+  quoting, multiline commands, local references, and documented exceptions.
+- Use the repository's existing Markdown formatting and spelling conventions,
+  including 80-column prose wrapping and en-GB-oxendict spelling.
+
+### Acceptance criteria
+
+- A clean checkout passes the validator, and fixture tests demonstrate a
+  failure for every policy class: mutable action reference, permission
+  escalation, unsafe `pull_request_target` use, missing reference, broken tier,
+  and invalid exception.
+- Every tracked workflow has zero unresolved local references, Make targets,
+  profiles, configuration paths, job dependencies, or documentation links.
+- No external workflow reference is mutable, and every exception has all
+  required metadata, a narrow scope, and an expiry later than the validation
+  date.
+- Each of the five fuzz boundaries has a checked-in smoke corpus containing
+  valid, malformed, and boundary inputs, and each target completes its smoke
+  run without a panic, timeout, or uncontrolled filesystem access.
+- Twenty consecutive scheduled fuzz runs publish the target name, corpus
+  revision, execution budget, and crash result; any new crash is reproduced by
+  a deterministic regression test before the run is considered healthy.
+- The per-PR policy and documentation checks complete in under two minutes on
+  the standard CI runner across twenty measured runs, without a blanket retry.
+- The tier registry and the workflow inventory agree for every health signal,
+  and the documentation checker reports zero stale gate or tool claims on the
+  release branch.
+
+## Compatibility and migration
+
+The proposal is additive to application behaviour. It changes CI acceptance
+only for repository policy violations and introduces no new manifest syntax or
+runtime dependency for Netsuke users. Migration should proceed in phases so
+existing contributors can distinguish policy defects from product defects.
+
+### Phase 1: Inventory and report
+
+Extract the workflow, Make target, profile, configuration, health-tier, and
+documentation inventories. Run the validator in report-only mode and record
+real findings as small, owned work items. Do not create a permanent baseline
+that hides existing violations; each accepted exception must be explicit and
+expiring.
+
+### Phase 2: Block deterministic contracts
+
+Add fixture-driven validator tests and make workflow-policy, self-consistency,
+exception hygiene, and documentation-link checks blocking on pull requests.
+Keep existing focused workflow tests, but have them share the inventory where
+appropriate. Correct the known formal-verification documentation drift in the
+same phase.
+
+### Phase 3: Add scheduled fuzzing
+
+Add the fuzz workspace, bounded smoke corpus, and the five boundary targets.
+Run smoke cases where practical and longer sessions on a scheduled workflow.
+Publish minimized crashers as regression fixtures, retain failure artefacts,
+and document the schedule and resource budget in the tier registry.
+
+### Phase 4: Ratchet and review
+
+Measure policy findings, fuzz execution, crash regressions, coverage trends,
+mutation survivors, and exception age for at least one release cycle. Promote
+only stable scheduled signals to per-PR blocking status. Review the exception
+registry each release and remove entries whose underlying policy defect is
+fixed.
+
+### Failure modes and responses
+
+- Failure in a blocking check stops the pull request with the rule identifier
+  and remediation. The validator must not downgrade the failure because a
+  reference is inconvenient to parse.
+- A scheduled fuzz failure opens or updates an owned investigation with its
+  corpus, revision, and artefact links. It must not be hidden by a blanket
+  retry or represented as a passing check.
+- A fuzz timeout, out-of-memory result, or uncontrolled filesystem access is a
+  harness defect and blocks promotion of that target until bounded.
+- Tool or runner outages are reported separately from product failures and may
+  use a narrowly scoped, observable infrastructure retry if policy permits.
+- A false-positive validator result is corrected with a fixture and a rule
+  change, not with a broad allowlist entry. An exception is acceptable only
+  while the issue, owner, and expiry remain visible.
+
+## Alternatives considered
+
+### Option A: Copy VTCode's scripts and workflow layout
+
+This would be quick, but it would import assumptions about action pinning,
+permissions, tools, and repository structure. The
+[VTCode workflow-policy script][vtcode-policy] is inspiration rather than a
+compatible contract, and copying it would risk weakening Netsuke's existing
+gates. Rejected.
+
+### Option B: Keep only focused workflow contract tests
+
+Focused tests are useful for detailed caller semantics, but they do not provide
+complete inventory coverage or one consistent exception policy. They also leave
+documentation and gate self-consistency outside the contract. Rejected as the
+complete design; retained as a complement.
+
+### Option C: Run all fuzzing and mutation testing on every pull request
+
+This would produce strong signals but would make review latency and runner
+capacity unpredictable. It would encourage retries or truncated runs when the
+real problem is resource pressure. Rejected; use bounded PR smoke checks and
+scheduled depth.
+
+### Option D: Use a hosted fuzzing service first
+
+A hosted service could provide longer campaigns, but it adds credentials,
+external state, and operational dependency before the harness contracts are
+stable. Rejected for the first phase; the local `cargo-fuzz` boundary can later
+feed a hosted service if an accepted design provides the required controls.
+
+## Open questions
+
+- Which runner and schedule provide enough fuzzing budget without competing
+  with release, coverage, or mutation workflows?
+- Should the fuzz corpus live under `fuzz/corpus/` in Git, in workflow
+  artefacts, or in both, and what size limit should apply to checked-in inputs?
+- Which existing workflow permissions need temporary exceptions, and who owns
+  their expiry review?
+- Should the first documentation consistency check validate only repository
+  links and named gates, or also check examples against generated CLI help?
+- Which changed-line coverage and mutation trends, if any, should become
+  blocking after the first release-cycle measurement?
+- Should the tier registry be YAML, TOML, or a typed Rust/Python data file so
+  its schema is easiest to validate without duplicating workflow parsing?
+
+## References
+
+- [Actual upstream VTCode repository][vtcode]
+- [VTCode workflow-policy script at a pinned commit][vtcode-policy]
+- [VTCode cargo-fuzz manifest at a pinned commit][vtcode-fuzz-manifest]
+- [VTCode fuzz runner at a pinned commit][vtcode-fuzz-runner]
+- [GitHub Actions secure-use guidance][github-actions-security]
+- [cargo-fuzz project documentation][cargo-fuzz]
+
+[cargo-fuzz]: https://github.com/rust-fuzz/cargo-fuzz
+[github-actions-security]: https://docs.github.com/en/actions/reference/security/secure-use
+[vtcode]: https://github.com/vinhnx/VTCode
+[vtcode-fuzz-manifest]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/fuzz/Cargo.toml#L1-L46
+[vtcode-fuzz-runner]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/scripts/fuzz-test.sh#L1-L104
+[vtcode-policy]: https://github.com/vinhnx/VTCode/blob/f188bcb0e47d7386886ab0c3db7e338b297a3d07/scripts/check_workflow_security.sh#L1-L55
+
+## Recommendation
+
+Adopt the repository-wide validator and tier registry first, then add the
+bounded scheduled fuzz targets once their harness contracts are covered by
+fixtures. This gives Netsuke immediate, deterministic protection against
+workflow and documentation drift while preserving its stronger existing
+verification policy. Treat VTCode as a useful upstream reference, pin all
+external workflow references, and make every exception and scheduled signal
+visible, owned, and measurable.


### PR DESCRIPTION
## Summary

This branch proposes complementary release-hardening and code-health RFCs so
that Netsuke can review stronger release admission, repository-wide policy
validation, and fuzzing contracts before implementation begins. The proposals
draw explicit inspiration from the upstream
[VTCode repository](https://github.com/vinhnx/VTCode) while retaining Netsuke's
existing Polonius, Whitaker, property-testing, model-checking, mutation-testing,
and release-integrity practices.

It also establishes the numbered RFC directory in the documentation index and
repository layout.

## Review walkthrough

- Start with
  [RFC 0001](https://github.com/leynos/netsuke/blob/091b85dcb152101d6e0e65cb2947d9df78a50169/docs/rfcs/0001-release-hardening.md)
  for the proposed release-profile invariants, secret and dependency policy,
  and exact-commit admission evidence.
- Then review
  [RFC 0002](https://github.com/leynos/netsuke/blob/091b85dcb152101d6e0e65cb2947d9df78a50169/docs/rfcs/0002-code-health.md)
  for workflow-policy validation, gate self-consistency, exception hygiene,
  and scheduled coverage-guided fuzzing.
- Finish with the
  [documentation contents](https://github.com/leynos/netsuke/blob/091b85dcb152101d6e0e65cb2947d9df78a50169/docs/contents.md)
  and
  [repository layout](https://github.com/leynos/netsuke/blob/091b85dcb152101d6e0e65cb2947d9df78a50169/docs/repository-layout.md)
  entries that make the RFC series discoverable.

## Validation

- `make fmt`: passed
- `make markdownlint`: passed; 80 Markdown files checked with zero errors
- `make nixie`: passed; all Mermaid diagrams validated
- `git diff --check origin/main...HEAD`: passed

## Notes

This is a documentation-only, pre-implementation proposal. Adoption decisions,
tool versions, budgets, and staged implementation details remain subject to RFC
review.

## Summary by Sourcery

Introduce numbered RFCs for release hardening and repository-wide code health, and integrate them into the documentation index and layout.

Enhancements:
- Clarify contributor guidance by defining where cross-cutting proposals live and how RFCs should be numbered, linked, and maintained in the repo.

Documentation:
- Add RFC 0001 documenting proposed release integrity, secret scanning, dependency/licence policy, and exact-commit release admission requirements.
- Add RFC 0002 documenting proposed workflow-policy validation, gate self-consistency, exception hygiene, and scheduled fuzzing and health-tier contracts.
- Update documentation contents and repository layout to establish the `docs/rfcs/` directory and make RFCs discoverable from the docs index.