### PR TITLE
Split CHANGELOG into v0.1.0-beta1 and v0.1.0-beta2 releases

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -17,6 +17,7 @@
     "**/target/**",
     ".terraform/**",
     ".uv-cache/**",
+    ".vtcode/**",
     "CRUSH.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ## [0.1.0-beta1] - 2026-08-05
 
+<!-- markdownlint-disable-next-line MD024 -->
 ### Added
 
 - Ship 33 further locale catalogues, so `--locale` now selects any of `ar`,
@@ -73,6 +74,7 @@
   `zh-Hant`, with `en-US` remaining the source and fallback locale
   ([#466](https://github.com/leynos/netsuke/issues/466))
 
+<!-- markdownlint-disable-next-line MD024 -->
 ### Changed
 
 - Select catalogues by exact locale tag with deliberate per-language fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@
 - Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
   `nightly-2026-06-25` toolchain; checkout builds pick this up automatically via
   `rustup`, while registry installs must pass the toolchain and flag explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`)
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke-build`)
   ([#465](https://github.com/leynos/netsuke/issues/465))
 - Remove the `rust-version = "1.89.0"` minimum-supported-Rust-version
   declaration from `Cargo.toml`; `rust-toolchain.toml` is now the single source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,5 @@
   of truth for the compiler contract
   ([#465](https://github.com/leynos/netsuke/issues/465))
 
-## [0.1.0] - 2026-07-28
-
-_Initial release._
-
 [0.1.0-beta2]: https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta2
 [0.1.0-beta1]: https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta1
-[0.1.0]: https://github.com/leynos/netsuke/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Changelog
 
-## Unreleased
+## [0.1.0-beta2] - 2026-08-19
 
 ### Added
 
-- Ship 33 further locale catalogues, so `--locale` now selects any of `ar`,
-  `cs`, `cy`, `da`, `de`, `el`, `en-GB`, `en-US`, `es-419`, `es-ES`, `fa`, `fi`,
-  `fr`, `gd`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`,
-  `pt-BR`, `pt-PT`, `ro`, `ru`, `sv`, `th`, `tr`, `uk`, `vi`, `zh-Hans` or
-  `zh-Hant`, with `en-US` remaining the source and fallback locale
-  ([#466](https://github.com/leynos/netsuke/issues/466))
 - Add [docs/v0-1-0-migration-guide.md](docs/v0-1-0-migration-guide.md)
   signposting the child-environment API additions, and recording that every
   Rust API surface outside the Netsukefile format and the graph export is
@@ -17,10 +11,10 @@
 - Export `runner::CommandEnv` together with the `runner::NinjaBuildRequest` and
   `runner::NinjaToolRequest` bundles and the `runner::run_ninja_with` and
   `runner::run_ninja_tool_with` entry points, so an embedder can set the
-  environment of the spawned Ninja process — `PATH` included — without
-  mutating its own. Overrides are additive and `CommandEnv::inherit()`
-  reproduces the existing behaviour, so `run_ninja` and `run_ninja_tool` keep
-  their signatures and no embedder needs to change
+  environment of the spawned Ninja process — `PATH` included — without mutating
+  its own. Overrides are additive and `CommandEnv::inherit()` reproduces the
+  existing behaviour, so `run_ninja` and `run_ninja_tool` keep their signatures
+  and no embedder needs to change
   ([#490](https://github.com/leynos/netsuke/issues/490))
 - Accept a non-empty ordered list of commands for a rule or target `command`
   recipe, executed as a single fail-fast `&&` shell chain, so the build stops
@@ -32,31 +26,6 @@
 
 ### Changed
 
-- Select catalogues by exact locale tag with deliberate per-language fallback
-  rules, so `es-419` and `es-ES`, `pt-BR` and `pt-PT`, and `zh-Hans` and
-  `zh-Hant` stay distinct instead of collapsing onto one catalogue per language
-  ([#466](https://github.com/leynos/netsuke/issues/466))
-- Make `src/locale_catalogues.rs` the authoritative locale registry, read by
-  the embedded catalogues, the build-time audit, the `rerun-if-changed`
-  directives, packaging, and the tests; the build now fails if `Cargo.toml`'s
-  `ortho_config` locale metadata drifts from it
-  ([#466](https://github.com/leynos/netsuke/issues/466))
-- Extend the build-time localization audit to every declared locale and to
-  interpolation variables, so a message that drops or invents a `{ $variable }`
-  fails the build ([#466](https://github.com/leynos/netsuke/issues/466))
-
-- Route graph-view node registration through a borrow-returning
-  `NodePathRegistry` accessor that looks paths up once on hits and clones a
-  path only on insertion ([#465](https://github.com/leynos/netsuke/issues/465))
-- Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
-  `nightly-2026-06-25` toolchain; checkout builds pick this up automatically via
-  `rustup`, while registry installs must pass the toolchain and flag explicitly
-  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`)
-  ([#465](https://github.com/leynos/netsuke/issues/465))
-- Remove the `rust-version = "1.89.0"` minimum-supported-Rust-version
-  declaration from `Cargo.toml`; `rust-toolchain.toml` is now the single source
-  of truth for the compiler contract
-  ([#465](https://github.com/leynos/netsuke/issues/465))
 - Move the `StringOrList` conversion helpers out of
   `src/ir/from_manifest_support.rs` and onto the type itself as `map_each`,
   `to_string_vec` and `as_single`, so the behaviour lives with the data it
@@ -64,21 +33,20 @@
   lowering treats these manifest strings as filesystem paths
   ([#73](https://github.com/leynos/netsuke/issues/73))
 - Reject manifest `vars` keys named `env` or `glob` at parse time, since
-  MiniJinja shares one namespace for template functions and global
-  variables and such a key would otherwise silently shadow the built-in
-  helper; manifests that previously used either name as a variable now fail
-  to parse ([#79](https://github.com/leynos/netsuke/issues/79))
+  MiniJinja shares one namespace for template functions and global variables
+  and such a key would otherwise silently shadow the built-in helper; manifests
+  that previously used either name as a variable now fail to parse
+  ([#79](https://github.com/leynos/netsuke/issues/79))
 - Open the capability used for glob metadata checks at the pattern's longest
   literal directory prefix rather than at the filesystem root or the working
   directory, so glob expansion holds only the authority its pattern can reach;
   a pattern whose literal prefix is missing or names something other than a
   directory now expands to no matches, and a match reached through a symbolic
-  link — the match itself or an intermediate directory — that resolves
-  outside that prefix or dangles is skipped rather than failing the
-  expansion, though a cyclic symbolic link still fails the expansion; opening
-  a symbolic-link prefix now fails, and glob tracing redacts caller-controlled
-  path fields as `<redacted>`
-  ([#173](https://github.com/leynos/netsuke/issues/173))
+  link — the match itself or an intermediate directory — that resolves outside
+  that prefix or dangles is skipped rather than failing the expansion, though a
+  cyclic symbolic link still fails the expansion; opening a symbolic-link
+  prefix now fails, and glob tracing redacts caller-controlled path fields as
+  `<redacted>` ([#173](https://github.com/leynos/netsuke/issues/173))
 
 ### Removed
 
@@ -94,8 +62,48 @@
   were rejected as sandbox escapes
   ([#173](https://github.com/leynos/netsuke/issues/173))
 
+## [0.1.0-beta1] - 2026-08-05
+
+### Added
+
+- Ship 33 further locale catalogues, so `--locale` now selects any of `ar`,
+  `cs`, `cy`, `da`, `de`, `el`, `en-GB`, `en-US`, `es-419`, `es-ES`, `fa`, `fi`,
+  `fr`, `gd`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`,
+  `pt-BR`, `pt-PT`, `ro`, `ru`, `sv`, `th`, `tr`, `uk`, `vi`, `zh-Hans` or
+  `zh-Hant`, with `en-US` remaining the source and fallback locale
+  ([#466](https://github.com/leynos/netsuke/issues/466))
+
+### Changed
+
+- Select catalogues by exact locale tag with deliberate per-language fallback
+  rules, so `es-419` and `es-ES`, `pt-BR` and `pt-PT`, and `zh-Hans` and
+  `zh-Hant` stay distinct instead of collapsing onto one catalogue per language
+  ([#466](https://github.com/leynos/netsuke/issues/466))
+- Make `src/locale_catalogues.rs` the authoritative locale registry, read by
+  the embedded catalogues, the build-time audit, the `rerun-if-changed`
+  directives, packaging, and the tests; the build now fails if `Cargo.toml`'s
+  `ortho_config` locale metadata drifts from it
+  ([#466](https://github.com/leynos/netsuke/issues/466))
+- Extend the build-time localization audit to every declared locale and to
+  interpolation variables, so a message that drops or invents a `{ $variable }`
+  fails the build ([#466](https://github.com/leynos/netsuke/issues/466))
+- Route graph-view node registration through a borrow-returning
+  `NodePathRegistry` accessor that looks paths up once on hits and clones a
+  path only on insertion ([#465](https://github.com/leynos/netsuke/issues/465))
+- Build with the Polonius borrow checker (`-Zpolonius=next`) on the pinned
+  `nightly-2026-06-25` toolchain; checkout builds pick this up automatically via
+  `rustup`, while registry installs must pass the toolchain and flag explicitly
+  (`RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke`)
+  ([#465](https://github.com/leynos/netsuke/issues/465))
+- Remove the `rust-version = "1.89.0"` minimum-supported-Rust-version
+  declaration from `Cargo.toml`; `rust-toolchain.toml` is now the single source
+  of truth for the compiler contract
+  ([#465](https://github.com/leynos/netsuke/issues/465))
+
 ## [0.1.0] - 2026-07-28
 
 _Initial release._
 
+[0.1.0-beta2]: https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta2
+[0.1.0-beta1]: https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta1
 [0.1.0]: https://github.com/leynos/netsuke/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ checksum = "c07971c6281a9a50979e8426fa6c6c618a42b729180847cb4363a794fdc4e607"
 
 [[package]]
 name = "netsuke-build"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2860,7 +2860,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test_support"
-version = "0.1.0"
+version = "0.1.0-beta2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netsuke-build"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2"
 edition = "2024"
 include = [
     "/src/**",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Netsuke currently requires:
 
 ### Installation
 
-Netsuke v0.1.0-beta1 is available from crates.io. Where
+Netsuke v0.1.0-beta2 is available from crates.io. Where
 [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is available,
 prefer it: it fetches a prebuilt release binary and avoids the toolchain
 requirement below.
@@ -66,7 +66,7 @@ RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke-build
 ```
 
 Pre-built installers are available from the
-[v0.1.0-beta1 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta1):
+[v0.1.0-beta2 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta2):
 
 | Platform | Architectures                        | Packages                         |
 | -------- | ------------------------------------ | -------------------------------- |
@@ -79,7 +79,7 @@ as a dependency. Ninja must be installed separately when using the macOS or
 Windows installer. The Windows MSI installs to `C:\Program Files\netsuke` and
 does not update `PATH`. SHA-256 checksum files accompany standalone binaries
 and staged help and licence files. Installer packages do not have checksum
-sidecars in v0.1.0-beta1. See the
+sidecars in v0.1.0-beta2. See the
 [user's guide](docs/users-guide.md#install-netsuke) for platform-specific
 commands and Windows setup.
 
@@ -148,14 +148,14 @@ The core build-system compiler is implemented:
 - unit, behavioural, integration, property, snapshot, and initial Kani
   verification coverage.
 
-The v0.1.0-beta1 release provides packages for Linux, macOS, and Windows,
+The v0.1.0-beta2 release provides packages for Linux, macOS, and Windows,
 including platform help artefacts. It is the first public release of this work.
 
 ______________________________________________________________________
 
-## v0.1.0-beta1 status
+## v0.1.0-beta2 status
 
-v0.1.0-beta1 is a useful preview for early adopters, not a declaration that
+v0.1.0-beta2 is a useful preview for early adopters, not a declaration that
 Netsuke is finished or that every interface is stable. The compiler pipeline
 and ordinary local-build workflow are substantial; the command-line interface,
 configuration vocabulary, and advanced recipe model are still evolving.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1,10 +1,10 @@
 # Netsuke user's guide
 
-This guide is for people evaluating or using Netsuke v0.1.0-beta1. It covers
+This guide is for people evaluating or using Netsuke v0.1.0-beta2. It covers
 the first build, the manifest format, templating, command-line usage,
 configuration, diagnostics, accessibility, and the current safety boundary.
 
-Netsuke v0.1.0-beta1 is an early-adopter release. The compiler pipeline is
+Netsuke v0.1.0-beta2 is an early-adopter release. The compiler pipeline is
 useful, but command names, flags, diagnostic schemas, and some manifest details
 may change before 1.0. Pin the Netsuke version in automated workflows.
 
@@ -18,7 +18,7 @@ Inside a checkout both settings are inherited automatically: `rustup` installs
 the pinned toolchain, and the repository's `.cargo/config.toml` supplies
 `RUSTFLAGS=-Zpolonius=next`. Neither has to be passed on the command line.
 
-Netsuke v0.1.0-beta1 is available from crates.io. Where
+Netsuke v0.1.0-beta2 is available from crates.io. Where
 [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) is available,
 prefer it: it fetches a prebuilt release binary and avoids the toolchain
 requirement below.
@@ -41,7 +41,7 @@ RUSTFLAGS=-Zpolonius=next cargo +nightly-2026-06-25 install netsuke-build
 ```
 
 Pre-built installers are available from the
-[v0.1.0-beta1 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta1):
+[v0.1.0-beta2 GitHub release](https://github.com/leynos/netsuke/releases/tag/v0.1.0-beta2):
 
 | Platform | Architectures                        | Packages                         |
 | -------- | ------------------------------------ | -------------------------------- |
@@ -66,7 +66,7 @@ installer. The Windows MSI installs to `C:\Program Files\netsuke` and does not
 update `PATH`.
 
 The MSI installer supports pre-release SemVer versions such as
-`0.1.0-beta1`: the pre-release suffix cannot be represented in an MSI
+`0.1.0-beta2`: the pre-release suffix cannot be represented in an MSI
 product version, so the installer carries the numeric release triple
 (`0.1.0`) while the full version remains in the package and release names.
 Because successive pre-releases share that numeric version, installing a
@@ -75,7 +75,7 @@ series rather than installing alongside it.
 
 SHA-256 checksum files accompany standalone binaries and staged help,
 completion, and licence files. Installer packages do not have checksum sidecars
-in v0.1.0-beta1. Windows PowerShell help files are published beside each MSI as
+in v0.1.0-beta2. Windows PowerShell help files are published beside each MSI as
 sidecar artefacts rather than embedded in the installer.
 
 Each standalone release archive also contains generated shell completion
@@ -132,7 +132,7 @@ MSI:
 
 ```powershell
 $architecture = 'amd64' # Use 'arm64' for the Arm64 MSI.
-$releaseUri = 'https://api.github.com/repos/leynos/netsuke/releases/tags/v0.1.0-beta1'
+$releaseUri = 'https://api.github.com/repos/leynos/netsuke/releases/tags/v0.1.0-beta2'
 $release = Invoke-RestMethod -Uri $releaseUri
 
 $documents = [Environment]::GetFolderPath('MyDocuments')
@@ -142,7 +142,7 @@ $editionDirectory = if ($PSVersionTable.PSEdition -eq 'Desktop') {
     'PowerShell'
 }
 $moduleRoot = Join-Path $documents "$editionDirectory\Modules"
-$moduleDirectory = Join-Path $moduleRoot 'Netsuke\0.1.0-beta1'
+$moduleDirectory = Join-Path $moduleRoot 'Netsuke\0.1.0-beta2'
 $helpDirectory = Join-Path $moduleDirectory 'en-US'
 New-Item -ItemType Directory -Path $helpDirectory -Force | Out-Null
 
@@ -285,7 +285,7 @@ The top-level fields are:
 - `defaults`: target or action names used when `build` receives no explicit
   targets.
 
-`defaults` entries are literal names in v0.1.0-beta1; Jinja expressions are not
+`defaults` entries are literal names in v0.1.0-beta2; Jinja expressions are not
 rendered in this field.
 
 `vars` keys named `env` or `glob` are rejected because those names identify
@@ -371,7 +371,7 @@ Prefer a `command` list for a short, ordered sequence of distinct commands.
 Prefer `script` when the logic needs multi-line structure or shell
 constructs such as loops, conditionals, or variable assignment.
 
-The v0.1.0-beta1 `script` implementation invokes `/bin/sh -e`; it is not
+The v0.1.0-beta2 `script` implementation invokes `/bin/sh -e`; it is not
 currently a portable PowerShell abstraction. Prefer `command` or
 platform-selected actions when a manifest must work on Windows.
 
@@ -385,7 +385,7 @@ A target supports these fields:
 - `deps`: implicit dependencies. They affect freshness but do not become
   recipe arguments. Declare them on each target; reusable rules reject `deps`.
   The planned rule-level `deps_from` contract is not implemented in
-  v0.1.0-beta1.
+  v0.1.0-beta2.
 - `dependency_order`: scheduling policy for the `deps` list. `parallel` is the
   default; `serial` runs a list with more than one dependency in declaration
   order.
@@ -406,7 +406,7 @@ list of strings.
 Netsuke quotes paths inserted through `{{ ins }}` and `{{ outs }}`. Other Jinja
 values render as ordinary command text and are not automatically shell-quoted.
 The `shell_escape` filter described in older drafts is not implemented in
-v0.1.0-beta1.
+v0.1.0-beta2.
 
 Cycle detection follows `sources` and `deps`. Order-only dependencies enforce
 ordering but do not participate in cycle detection.
@@ -633,7 +633,7 @@ Both helpers accept:
 - `cwd_mode="auto"|"always"|"never"`: control bounded project-directory
   fallback searching.
 
-The `env(name)` function reads one required environment variable. v0.1.0-beta1
+The `env(name)` function reads one required environment variable. v0.1.0-beta2
 does not accept a default argument; an absent or non-Unicode value is an error.
 
 ### Inject the environment reader for tests
@@ -1172,7 +1172,7 @@ colour alone. Emoji policy values are:
 - `auto`: Unicode in standard output and ASCII in accessible output.
 
 The colour policy is separate. Colour rendering is not implemented in
-v0.1.0-beta1, so `color` currently affects mode selection but does not add
+v0.1.0-beta2, so `color` currently affects mode selection but does not add
 coloured terminal text.
 
 Verbose mode adds per-stage timing after a successful command. Failed commands
@@ -1213,7 +1213,7 @@ stderr has this shape:
   "schema_version": 1,
   "generator": {
     "name": "netsuke",
-    "version": "0.1.0-beta1"
+    "version": "0.1.0-beta2"
   },
   "diagnostics": [
     {
@@ -1253,7 +1253,7 @@ Exactly one outcome branch is present:
   - `source`, `primary_span`, and `labels`: optional source locations.
   - `related`: nested diagnostics using the same shape.
 
-**Triage:** Treat schema version `1` as pre-stable for v0.1.0-beta1 and check
+**Triage:** Treat schema version `1` as pre-stable for v0.1.0-beta2 and check
 `schema_version` before parsing other fields.
 
 ## Configure network access
@@ -1305,7 +1305,7 @@ Netsuke reduces some common quoting mistakes, but it is not a sandbox:
 - `{{ ins }}` and `{{ outs }}` are quoted as path arguments.
 - Arbitrary Jinja values in `command` and `script` are not automatically
   shell-quoted.
-- `script` uses `/bin/sh -e` in v0.1.0-beta1.
+- `script` uses `/bin/sh -e` in v0.1.0-beta2.
 - `shell`, `grep`, `fetch`, filesystem helpers, and ordinary recipes interact
   with the host.
 - `glob` restricts its filesystem metadata access to a capability handle

--- a/lading.toml
+++ b/lading.toml
@@ -1,0 +1,5 @@
+[preflight]
+unit_tests_only = true
+
+[bump.documentation]
+globs = ["README.md", "docs/users-guide.md"]

--- a/src/snapshots/help_targets/netsuke__runner__help__tests__json_catalogue.snap
+++ b/src/snapshots/help_targets/netsuke__runner__help__tests__json_catalogue.snap
@@ -1,13 +1,12 @@
 ---
 source: src/runner/help_tests.rs
-assertion_line: 103
 expression: rendered
 ---
 {
   "schema_version": 1,
   "generator": {
     "name": "netsuke",
-    "version": "0.1.0-beta1"
+    "version": "0.1.0-beta2"
   },
   "result": {
     "command": "help-targets",

--- a/test_support/Cargo.toml
+++ b/test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_support"
-version = "0.1.0"
+version = "0.1.0-beta2"
 edition = "2024"
 rust-version = "1.89.0"
 publish = false


### PR DESCRIPTION
## Summary

This branch prepares the v0.1.0-beta2 release of Netsuke by restructuring
CHANGELOG.md. The previous Unreleased section is now the dated
[0.1.0-beta2] release, and the entries that shipped in the
v0.1.0-beta1 tag move under their own [0.1.0-beta1] heading dated at that
tag. Nothing changes about the recorded content: the 15 changelog bullets
are preserved verbatim, only their grouping and ordering change.

The beta2 release is being cut today, so every previously unreleased entry
is now assigned to a concrete version.

## Review walkthrough

- Start with [CHANGELOG.md](https://github.com/leynos/netsuke/blob/prepare-v0-1-0-beta2-release/CHANGELOG.md#L3) to see the new [0.1.0-beta2] section.
- Then review [the [0.1.0-beta1] section](https://github.com/leynos/netsuke/blob/prepare-v0-1-0-beta2-release/CHANGELOG.md#L67), dated at the v0.1.0-beta1 tag (2026-08-05).
- Finish with [the version reference links](https://github.com/leynos/netsuke/blob/prepare-v0-1-0-beta2-release/CHANGELOG.md#L107).

## Validation

- make check-fmt: passed
- typos (uv tool run typos@1.48.0 --config typos.toml): passed
- make markdownlint nixie: passed (MD024 scoped to the duplicate release headings; .vtcode/** restored to the markdownlint ignore set)
- Bullet-preservation check: 15 bullets preserved (multiset match)

## References

- Lody session: https://lody.ai/leynos/sessions/c66433e7-a35e-4b4e-aff2-799b4a93f179

## Summary by Sourcery

Prepare the repository for the v0.1.0-beta2 release and organize the changelog by release.

Enhancements:
- Update the project and user-facing documentation from v0.1.0-beta1 to v0.1.0-beta2.
- Split the changelog into dated beta1 and beta2 release sections while preserving all release entries.

Build:
- Bump the main package and test-support package versions to 0.1.0-beta2.

Documentation:
- Update release references, installation links, versioned examples, and status text for v0.1.0-beta2.

Chores:
- Add release documentation bump configuration for README.md and the user guide.